### PR TITLE
Wifi connectivity improvements

### DIFF
--- a/include/wifi_setup.h
+++ b/include/wifi_setup.h
@@ -5,6 +5,7 @@
 // check if can connect
 // if not, start AP mode
 void setupWifi();
+void stopWifi();
 void saveCredentials(String ssid, String pass); // ssid, pass
 
 extern bool b_wifiEnabled;

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ monitor_speed = 115200
 upload_speed = 921600
 build_flags =
 ;  -DESP32
+  -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
   -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
 #	-D DEBUG
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ data_dir = web_apps
 
 [env:esp32s3]
 ;-- esp32
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13-1/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.21/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 framework = arduino
 #board_build.partitions = <min_spiffs.csv>

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -172,6 +172,7 @@ void buttonSquare_Pressed() {
     //return;
   }
   if (deviceConnected && millis() - t_shutdownFailBle < 3000)
+    stopWebServer();
     stopWifi();
     shut_down_now_nobeep();
   if (!b_menu && !b_calibration && (!deviceConnected || b_btnFuncWhileConnected)) {
@@ -210,6 +211,7 @@ void buttonCircle_DoubleClicked() {
   if (!deviceConnected && !b_menu && !b_calibration) {
     Serial.println("Going to sleep now.");
     sendBlePowerOff(1);
+    stopWebServer();
     stopWifi();
     shut_down_now_nobeep();
   } else {
@@ -230,6 +232,7 @@ void buttonSquare_DoubleClicked() {
   if (!deviceConnected && !b_menu && !b_calibration) {
     Serial.println("Going to sleep now.");
     sendBlePowerOff(2);
+    stopWebServer();
     stopWifi();
     shut_down_now_nobeep();
   } else {
@@ -346,6 +349,7 @@ void setup() {
         //Power on by button press
         Serial.println("Button released before 0.5 second.");
         Serial.println("Going to sleep now.");
+        stopWebServer();
         stopWifi();
         shut_down_now_nobeep();
         break;  // Exit loop to enter sleep mode
@@ -550,6 +554,7 @@ void setup() {
           AsyncWebSocket *server, AsyncWebSocketClient *client,
                AwsEventType type, void *arg, uint8_t *data, size_t len
           ){
+        client->setCloseClientOnQueueFull(false);
         if (type == WS_EVT_DATA) {
 
           AwsFrameInfo *info = (AwsFrameInfo *)arg;
@@ -937,7 +942,8 @@ void loop() {
             //charging not complete, but the serial maynot be ouput cause usb unplugged.
             Serial.println("USB Unplugged, charging not compelete.");
           }
-    stopWifi();
+          stopWebServer();
+          stopWifi();
           shut_down_now_nobeep();  //deepsleep
         }
       }
@@ -955,13 +961,17 @@ void loop() {
         if (b_usbweight_enabled)
           sendUsbWeight();
         if (b_wifiEnabled) {
-          websocket.cleanupClients();
+          websocket.cleanupClients(1);
           ElegantOTA.loop();
           static long lastUpdate = 0;
           unsigned long current = millis();
           if (current - lastUpdate > 500) {  
-            websocket.textAll(String(f_displayedValue));
-            lastUpdate = current;
+            if (websocket.availableForWriteAll() > 0) {
+              websocket.printfAll("%.2f", f_displayedValue);
+              lastUpdate = current;
+            } else {
+              Serial.println("Websocket write unavailable");
+            }
           }
         }
         if (b_bootTare) {
@@ -985,7 +995,6 @@ void loop() {
         }
         pureScale();
         updateOled();
-        delay(10);
       }
     }
   }

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -172,6 +172,7 @@ void buttonSquare_Pressed() {
     //return;
   }
   if (deviceConnected && millis() - t_shutdownFailBle < 3000)
+    stopWifi();
     shut_down_now_nobeep();
   if (!b_menu && !b_calibration && (!deviceConnected || b_btnFuncWhileConnected)) {
     scaleTimer();
@@ -209,6 +210,7 @@ void buttonCircle_DoubleClicked() {
   if (!deviceConnected && !b_menu && !b_calibration) {
     Serial.println("Going to sleep now.");
     sendBlePowerOff(1);
+    stopWifi();
     shut_down_now_nobeep();
   } else {
     if (deviceConnected) {
@@ -228,6 +230,7 @@ void buttonSquare_DoubleClicked() {
   if (!deviceConnected && !b_menu && !b_calibration) {
     Serial.println("Going to sleep now.");
     sendBlePowerOff(2);
+    stopWifi();
     shut_down_now_nobeep();
   } else {
     if (deviceConnected) {
@@ -343,6 +346,7 @@ void setup() {
         //Power on by button press
         Serial.println("Button released before 0.5 second.");
         Serial.println("Going to sleep now.");
+        stopWifi();
         shut_down_now_nobeep();
         break;  // Exit loop to enter sleep mode
       }
@@ -933,6 +937,7 @@ void loop() {
             //charging not complete, but the serial maynot be ouput cause usb unplugged.
             Serial.println("USB Unplugged, charging not compelete.");
           }
+    stopWifi();
           shut_down_now_nobeep();  //deepsleep
         }
       }
@@ -980,6 +985,7 @@ void loop() {
         }
         pureScale();
         updateOled();
+        delay(10);
       }
     }
   }

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -545,7 +545,7 @@ void setup() {
   }
 #endif
 
-  if (readBoolEEPROMWithValidation(i_addr_enableWifiOnBoot, false)) { 
+  if (b_ble_enabled && readBoolEEPROMWithValidation(i_addr_enableWifiOnBoot, false)) { 
     b_wifiEnabled = true;
     setupWifi();
     startWebServer();

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -1,4 +1,5 @@
 
+#include "NetworkEvents.h"
 #include "WiFiType.h"
 #include "esp32-hal.h"
 #include <Arduino.h>
@@ -51,7 +52,7 @@ void connectToWifi() {
     wifiCounter++;
     delay(1000);
     Serial.println(".");
-    if (wifiCounter > 10) {
+    if (wifiCounter > 20) {
       WiFi.disconnect(true);
       delay(100);
       setupAP();
@@ -63,6 +64,10 @@ void connectToWifi() {
   Serial.println(WiFi.SSID().c_str());
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP().toString().c_str());
+}
+
+void stopWifi() {
+    WiFi.disconnect(true);
 }
 
 void setupWifi() {


### PR DESCRIPTION
Limit number of websocket clients to 1
Drop messages if client can't handle them all (to prevent connection dropping)
Update platform sdk
Add stop functions, to disconnect from AP and turn off Wifi and web server when powering down
Increase wait time for connecting to Wifi from 10 to 20 seconds
Configure webserver to run on core 1 to [prevent interference with RF core](https://github.com/ESP32Async/ESPAsyncWebServer?tab=readme-ov-file#important-recommendations-for-build-options)