### PR TITLE
Fix/reset wifi credentials

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -3,6 +3,7 @@
 
 #include "esp32-hal.h"
 #include "parameter.h"
+#include "wifi_setup.h"
 const char *weights[] = { "Exit", "50g", "100g", "200g", "500g", "1000g" };
 const float weight_values[] = { 0.0, 50.0, 100.0, 200.0, 500.0, 1000.0 };
 bool b_showAbout = false;
@@ -33,6 +34,7 @@ void buzzerOff();
 #endif
 void toggleWifiOff();
 void toggleWifiOn();
+void resetWifi();
 void showWifiStatus();
 void heartbeatOn();
 void heartbeatOff();
@@ -91,11 +93,14 @@ Menu menuWiFiUpdateBack = { "Back", NULL, NULL, &menuWifi };
 Menu menuWiFiOnOption = { "WiFi On", toggleWifiOn, NULL, &menuWifi };
 Menu menuWiFiOffOption = { "WiFi Off", toggleWifiOff, NULL, &menuWifi };
 Menu menuWiFiStatusOption = { "WiFi Status", showWifiStatus, NULL, &menuWifi };
+Menu menuWiFiResetOption = { "Reset WiFi", resetWifi, NULL, &menuWifi };
+
 Menu *wifiUpdateMenu[] = {
   &menuWiFiUpdateBack,
   &menuWiFiOnOption,
   &menuWiFiOffOption,
   &menuWiFiStatusOption,
+  &menuWiFiResetOption,
 };
 
 // Heartbeat detection
@@ -272,6 +277,14 @@ void showWifiStatus() {
       b_showWifiData = false;
     }
   }
+}
+
+void resetWifi() {
+  saveCredentials("", "");
+  actionMessage = "WiFi Reset";
+  actionMessage2 = "Restart scale";
+  t_actionMessage = millis();
+  t_actionMessageDelay = 1000;
 }
 
 void heartbeatOn() {

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -1,6 +1,7 @@
 #ifndef SCALE_WEBSERVER_H
 #define SCALE_WEBSERVER_H
 
+#include "esp_system.h"
 #include "wifi_setup.h"
 #include <ArduinoJson.h>
 #include <AsyncJson.h>
@@ -32,6 +33,7 @@ void startWebServer() {
         saveCredentials(ssid, pass);
         Serial.println("new ssid saved");
         request->send(200);
+        esp_restart();
       });
   server.addHandler(wifiHandler);
 

--- a/web_apps/index.html
+++ b/web_apps/index.html
@@ -30,22 +30,24 @@
     }
 
     /* WiFi popup styling */
-    #wifi-popup {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      background: #fff;
-      border-top: 1px solid #ccc;
-      padding: 1rem;
-      box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
-    }
+    /* #wifi-popup { */
+    /*   position: fixed; */
+    /*   bottom: 0; */
+    /*   left: 0; */
+    /*   width: 100%; */
+    /*   background: #fff; */
+    /*   border-top: 1px solid #ccc; */
+    /*   margin-top: 1rem; */
+    /*   padding: 1rem; */
+    /*   box-shadow: 0 -2px 10px rgba(0,0,0,0.1); */
+    /* } */
     #wifi-popup input {
       padding: 0.4rem;
       font-size: 1rem;
     }
     #wifi-popup button {
       padding: 0.5rem 1rem;
+      margin-top: 0.5rem;
       font-size: 1rem;
       cursor: pointer;
     }
@@ -55,7 +57,7 @@
     }
 
     /* Weight display */
-    #weight-display {
+    .weight-display {
       margin-top: 2rem;
       padding: 1rem;
       background: #fff;
@@ -107,20 +109,21 @@
     </ul>
 
   <!-- Weight Display and Tare Button -->
-  <div id="weight-display">
+  <div class="weight-display">
     <h2>Weight</h2>
     <div id="weight-value">-- g</div>
     <button id="tare-button">Tare</button>
   </div>
 
   <!-- WiFi Setup Popup -->
-  <div id="wifi-popup">
+  <div id="wifi-popup" class="weight-display">
     <h2>Setup WiFi</h2>
-    <form id="wifi-form">
-      <input type="text" id="ssid" placeholder="WiFi SSID" required style="margin-right: 1rem;" />
-      <input type="password" id="password" placeholder="WiFi Password" style="margin-right: 1rem;" />
-      <button type="submit">Connect</button>
-    </form>
+          <form id="wifi-form">
+            <input type="text" id="ssid" placeholder="WiFi SSID" required style="margin-right: 1rem;" />
+            <input type="password" id="password" placeholder="WiFi Password" style="margin-right: 1rem;" />
+            <button type="submit">Connect</button>
+          </form>
+          <button id="reset-wifi-button">Reset WiFi settings</button>
     <p id="wifi-status"></p>
   </div>
 
@@ -184,6 +187,30 @@
       weightValue.textContent = 'Disconnected';
       weightValue.style.color = 'gray';
     });
+
+    document.getElementById('reset-wifi-button').addEventListener('click', async function (e) {
+
+      const status = document.getElementById('wifi-status');
+      try {
+        const response = await fetch(`http://${window.location.host}/setup/wifi`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ 'ssid': '' })
+        });
+
+        if (response.ok) {
+          status.textContent = 'WiFi reset request sent successfully! Please restart the scale';
+        } else {
+          status.textContent = 'Failed to send WiFi reset request.';
+          status.style.color = 'red';
+        }
+      } catch (err) {
+        status.textContent = 'Error connecting to server.';
+        status.style.color = 'red';
+      }
+    })
   </script>
 </body>
 </html>


### PR DESCRIPTION
HDS homepage was missing a "Reset WiFi settings" button, leaving users unable to reset WiFi back to stock.

This PR adds a "Reset WiFi" button to the HDS homepage which calls the /setup/wifi endpoint with an empty ssid parameter, effectively preventing HDS to try and connect to an erroneous WiFi on setup.

I've also added the call to `esp_reset()` in the function that handles WiFi parameters application, streamlining the WiFi setup as users no longer need to reset the scale manually.