### PR TITLE
Fix/wifi and hds setup

### DIFF
--- a/git_rev_macro.py
+++ b/git_rev_macro.py
@@ -1,0 +1,9 @@
+import subprocess
+
+revision = (
+    subprocess.check_output(["git", "rev-parse", "HEAD"])
+    .strip()
+    .decode("utf-8")
+    
+)
+print("'-DGIT_REV=\"%s\"'" % revision[:6])

--- a/include/config.h
+++ b/include/config.h
@@ -26,9 +26,9 @@
 //#define CHECKBATTERY
 
 //SCALE CONFIG
-#define LINE1 (char*)"FW: 3.0.1"
-#define LINE2 (char*)"Built-date(YYYYMMDD): 20251009"
-#define LINE3 (char*)"S/N: HDS001"  //Serial number
+#define LINE1 (char*)"FW: 3.0.2"
+#define LINE2 (char*)"Built-date "
+#define LINE3 __DATE__ //Serial number
 #define VERSION /*version*/ LINE1, /*compile date*/ LINE2, /*sn*/ LINE3
 //About info
 #define FIRMWARE_VER LINE1

--- a/include/menu.h
+++ b/include/menu.h
@@ -908,17 +908,15 @@ void wifiUpdate() {
 
 void showAbout() {
   actionMessage = FIRMWARE_VER;
-  // actionMessage2 = PCB_VER;
+  actionMessage2 = LINE3;
   b_showAbout = true;
-  u8g2.setFont(FONT_M);
+  u8g2.setFont(FONT_S);
   u8g2.firstPage();
   do {
-    if (AC(actionMessage.c_str()) < 0)
-      u8g2.setFont(FONT_S);
-    // u8g2.drawStr(AC(actionMessage.c_str()), AM() - 12,
-    // actionMessage.c_str()); u8g2.drawStr(AC(actionMessage2.c_str()), AM() +
-    // 12, actionMessage2.c_str());
-    u8g2.drawStr(AC(actionMessage.c_str()), AM(), actionMessage.c_str());
+    u8g2.setFont(FONT_S);
+    u8g2.drawStr(AC(actionMessage.c_str()), AM() - 24, actionMessage.c_str()); 
+    u8g2.drawStr(AC(actionMessage2.c_str()), AM(), actionMessage2.c_str());
+    u8g2.drawStr(AC(GIT_REV), AM()+ 24, GIT_REV);
   } while (u8g2.nextPage());
 #ifdef BUZZER
   buzzer.off();

--- a/include/menu.h
+++ b/include/menu.h
@@ -401,7 +401,7 @@ void calibrate() {
 void calibration(int input) {
   if (b_calibration == true) {
     bool newDataReady = false;
-    char *c_calval = (char *)"";
+    char c_calval[25];
     if (i_button_cal_status == 1) {
       if (input == 0) {
         scale.setSamplesInUse(16);

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ build_flags =
 ;  -DESP32
   -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
   -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+  !python3 git_rev_macro.py
 
 #	-D DEBUG
 #

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -637,8 +637,10 @@ void setup() {
   Serial.print(LINE1);
   Serial.print("\t");
   Serial.print(LINE2);
-  // Serial.print("\t");
-  // Serial.println(LINE3);
+  Serial.print("\t");
+  Serial.print(LINE3);
+  Serial.print("\t");
+  Serial.println(GIT_REV);
   Serial.print("\tCal_Val: ");
   Serial.print(f_calibration_value);
   Serial.print("\tHB_DET: ");

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -306,7 +306,7 @@ void button_init() {
   config1.setLongPressDelay(LONGCLICK);
 }
 
-void wifi_init() {
+void _wifi_init(void *args) {
   if (!readBoolEEPROMWithValidation(i_addr_enableWifiOnBoot, false)) {
     return;
   }
@@ -342,8 +342,11 @@ void wifi_init() {
       }
     }
   });
+  vTaskDelete(NULL);
 }
-
+void wifi_init() {
+  xTaskCreate(_wifi_init, "Wifi Init Task", configMINIMAL_STACK_SIZE + 2048, NULL, 0, NULL);
+}
 
 void setup() {
   Serial.begin(115200);

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -599,7 +599,9 @@ void setup() {
     //calibration value is not valid, go to calibration procedure.
   }
 #endif
-  wifi_init();
+  if (b_ble_enabled) {
+    wifi_init();
+  }
   // //wifiota
   // #ifdef WIFI
   if (digitalRead(BUTTON_CIRCLE) == LOW && digitalRead(BUTTON_SQUARE) == LOW) {

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -43,6 +43,7 @@ void setupAP() {
   Serial.println("WiFi: DecentScale");
   Serial.print("IP: ");
   Serial.println(WiFi.softAPIP());
+  b_wifiEnabled = true;
 }
 
 void connectToWifi() {
@@ -60,9 +61,11 @@ void connectToWifi() {
     wifiCounter++;
     delay(1000);
     Serial.println(".");
+    // Toggle, to emulate blinking?
+    b_wifiEnabled = !b_wifiEnabled;
     if (wifiCounter > 20) {
       WiFi.disconnect(true);
-      delay(100);
+      delay(200);
       setupAP();
       break;
     }
@@ -72,6 +75,7 @@ void connectToWifi() {
   Serial.println(WiFi.SSID().c_str());
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP().toString().c_str());
+  b_wifiEnabled = true;
 }
 
 void stopWifi() { WiFi.disconnect(true); }


### PR DESCRIPTION
- Perform Wifi/Server setup as a separate task to avoid hangup on start when WiFi is not present or misconfigured.

- Enable Wifi only if BLE is also enabled

- Blink wifi icon until HDS is connected or Access Point is established

- Fix crash that would sometimes occur during calibration