### PR TITLE
fix: prevent scaleTimer trigger immediately after menu exit

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -211,6 +211,9 @@ void exitMenu() {
   delay(1000);
   b_menu = false;
   // Optionally reset or perform an exit action
+  t_menuExitTime = millis();
+  // Capture the moment when menu exit begins to establish a reference point
+  // This enables timing-based protection against unintended triggers
 }
 
 #ifdef BUZZER

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -184,6 +184,10 @@ bool b_extraction = false;  //萃取模式标识
 int b_mode = 0;             //0 = pourover; 1 = espresso;
 
 bool b_menu = false;
+unsigned long t_menuExitTime = 0;
+// Timestamp recording when the menu exit process started
+// Used to implement a protection period preventing unintended operations
+
 bool b_calibration = false;  //Calibration flag
 bool b_ota = false;          //wifi ota flag
 int i_calibration = 0;       //0 for manual cal, 1 for smart cal

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -189,8 +189,11 @@ void buttonSquare_Pressed() {
     b_powerOff = true;
   }
   if (!b_menu && !b_calibration && (!deviceConnected || b_btnFuncWhileConnected)) {
-    scaleTimer();
+    if (millis() - t_menuExitTime > 500)
+      // Check if enough time has passed since menu exit (500ms protection period)
+      scaleTimer();
   }
+
 
   Serial.println("[] button pressed");
   sendUsbButton(2, 1);


### PR DESCRIPTION
- Add t_menuExitTime variable to track menu exit time
- Implement 500ms protection period after exiting menu
- Prevent scaleTimer() from triggering during menu transition