### PR TITLE
removed no weight detected

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -745,25 +745,6 @@ void calibration(int input) {
         }
         Serial.print("weight is ");
         Serial.println(d_weight);
-//         if (abs(d_weight) < 5) {
-//           u8g2.firstPage();
-//           u8g2.setFont(FONT_S);
-//           do {
-//             // 2行
-//             // FONT_M = u8g2_font_fub14_tn;
-//             u8g2.drawUTF8(AC((char *)"No weight detected"), AM(),
-//                           (char *)"No weight detected");
-//           } while (u8g2.nextPage());
-// #ifdef BUZZER
-//           buzzer.off();
-// #endif
-//           delay(1000);
-//           // reject the weight and exit
-//           i_button_cal_status = 0;
-//           b_calibration = false;
-//           b_menu = true;
-//           return;
-//         }
         scale.refreshDataSet();  // refresh the dataset to be sure that the known
                                  // mass is measured correct
 

--- a/include/menu.h
+++ b/include/menu.h
@@ -745,25 +745,25 @@ void calibration(int input) {
         }
         Serial.print("weight is ");
         Serial.println(d_weight);
-        if (abs(d_weight) < 5) {
-          u8g2.firstPage();
-          u8g2.setFont(FONT_S);
-          do {
-            // 2行
-            // FONT_M = u8g2_font_fub14_tn;
-            u8g2.drawUTF8(AC((char *)"No weight detected"), AM(),
-                          (char *)"No weight detected");
-          } while (u8g2.nextPage());
-#ifdef BUZZER
-          buzzer.off();
-#endif
-          delay(1000);
-          // reject the weight and exit
-          i_button_cal_status = 0;
-          b_calibration = false;
-          b_menu = true;
-          return;
-        }
+//         if (abs(d_weight) < 5) {
+//           u8g2.firstPage();
+//           u8g2.setFont(FONT_S);
+//           do {
+//             // 2行
+//             // FONT_M = u8g2_font_fub14_tn;
+//             u8g2.drawUTF8(AC((char *)"No weight detected"), AM(),
+//                           (char *)"No weight detected");
+//           } while (u8g2.nextPage());
+// #ifdef BUZZER
+//           buzzer.off();
+// #endif
+//           delay(1000);
+//           // reject the weight and exit
+//           i_button_cal_status = 0;
+//           b_calibration = false;
+//           b_menu = true;
+//           return;
+//         }
         scale.refreshDataSet();  // refresh the dataset to be sure that the known
                                  // mass is measured correct
 


### PR DESCRIPTION
No weight detected used to prevent user from doing a wrong calibration. But when user change another load cell, or user accidentally performed a successful wrong calibration, the cal_value will be very wrong, thus enter the "if (abs(d_weight) < 5)" and oled will show no weight detected, and block user from recalibration.