### PR TITLE
Validate XOR checksum on all incoming BLE commands

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -188,13 +188,17 @@ class MyCallbacks : public BLECharacteristicCallbacks {
       Serial.print(" ");
       if (data[0] == 0x03) {
         //check if it's a decent scale message
+
+        // Validate XOR checksum on all incoming commands.
+        // Rejects corrupted packets before they can trigger unintended actions
+        // (e.g. power off, tare, calibration, system reset).
+        if (!validateChecksum(data, len)) {
+          Serial.println("Invalid checksum. Ignoring command.");
+          return;
+        }
+
         if (data[1] == 0x0F) {
           //taring
-          if (validateChecksum(data, len)) {
-            Serial.println("Valid checksum for tare operation. Taring");
-          } else {
-            Serial.println("Invalid checksum for tare operation.");
-          }
           b_tareByBle = true;
           t_tareByBle = millis();
           if (data[5] == 0x00) {


### PR DESCRIPTION
This is untested, but rather then just report a bug I thought I would propose a fix.

## Summary
- Move `validateChecksum()` call to the top of the BLE command dispatcher in `onWrite()`
- All incoming commands are now rejected if the XOR checksum doesn't match
- Remove the tare-only log-only validation (which logged but didn't actually reject bad packets)

## Problem
The existing code has `validateChecksum()` and `calculateChecksum()` methods, but they were only used for the tare command (0x0F) — and even then, the result was only logged, not enforced. The tare executed regardless of checksum validity.

All other commands — including **power off** (0x0A/0x02), **system reset** (0x1F), and **calibration** (0x1A) — were processed without any checksum verification.

## Fix
A single `validateChecksum()` check at the top of the `data[0] == 0x03` block, with early return on failure. This protects all commands with one check.

## Risk
Low. BLE already has link-layer CRC, so corrupted packets reaching the application are rare. This is defense-in-depth using the existing validation function. The only behavioral change is that corrupted packets are now silently dropped instead of executed.

## Testing
Found while writing unit tests for [Decenza](https://github.com/Kulitorum/Decenza) scale protocol parsing. Cross-referenced the openscale firmware to verify checksum behavior.