### PR TITLE
Harden USB commands and calibration refresh

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -499,6 +499,22 @@ void calibrate() {
   // calibration
 }
 
+void calibrationRefreshFailed() {
+  Serial.println("Calibration failed: ADC dataset refresh timeout");
+  u8g2.firstPage();
+  u8g2.setFont(FONT_S);
+  do {
+    u8g2.drawUTF8(AC((char *)"Calibration failed"), AM(), (char *)"Calibration failed");
+  } while (u8g2.nextPage());
+#ifdef BUZZER
+  buzzer.off();
+#endif
+  delay(1000);
+  i_button_cal_status = 0;
+  b_calibration = false;
+  scale.setSamplesInUse(1);
+}
+
 void calibration(int input) {
   if (b_calibration == true) {
     bool newDataReady = false;
@@ -745,8 +761,10 @@ void calibration(int input) {
         }
         Serial.print("weight is ");
         Serial.println(d_weight);
-        scale.refreshDataSet();  // refresh the dataset to be sure that the known
-                                 // mass is measured correct
+        if (!scale.refreshDataSet()) {  // refresh the dataset to be sure that the known
+          calibrationRefreshFailed();   // mass is measured correct
+          return;
+        }
 
         f_calibration_value = scale.getNewCalibration(
           known_mass);  // get the new calibration value
@@ -936,8 +954,10 @@ void calibration(int input) {
         delay(1000);
 
         scale.setSamplesInUse(16);
-        scale.refreshDataSet();  // refresh the dataset to be sure that the known
-                                 // mass is measured correct
+        if (!scale.refreshDataSet()) {  // refresh the dataset to be sure that the known
+          calibrationRefreshFailed();   // mass is measured correct
+          return;
+        }
         f_calibration_value = scale.getNewCalibration(
           known_mass);  // get the new calibration value
         Serial.print(F("New calibration value f: "));

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -44,6 +44,19 @@ public:
     return expectedChecksum == calculatedChecksum;
   }
 
+  bool requireLength(size_t actual, size_t required, const char *commandName) {
+    if (actual >= required) {
+      return true;
+    }
+    Serial.print("Ignoring short USB packet for ");
+    Serial.print(commandName);
+    Serial.print(": ");
+    Serial.print(actual);
+    Serial.print("/");
+    Serial.println(required);
+    return false;
+  }
+
   void onWrite(uint8_t *data, size_t len) {
     //this is what the esp32 received via usb
     Serial.print("Timer ");
@@ -69,17 +82,28 @@ public:
     Serial.println(" ");
 
     if (data[0] != 0x03) {
-      String input = String((char *)data);
+      String input;
+      input.reserve(len);
+      for (size_t i = 0; i < len; i++) {
+        input += (char)data[i];
+      }
       handleStringCommand(input);
+      return;
+    }
+    if (!requireLength(len, 2, "message header")) {
       return;
     }
     //check if it's a decent scale message
     if (data[1] == 0x0F) {
+      if (!requireLength(len, 7, "tare")) {
+        return;
+      }
       //taring
       if (validateChecksum(data, len)) {
         Serial.println("Valid checksum for tare operation. Taring");
       } else {
         Serial.println("Invalid checksum for tare operation.");
+        return;
       }
       b_tareByBle = true;
       t_tareByBle = millis();
@@ -104,6 +128,9 @@ public:
         Serial.println(" ***");
       }
     } else if (data[1] == 0x0A) {
+      if (!requireLength(len, 3, "LED/power")) {
+        return;
+      }
       if (data[2] == 0x00) {
         Serial.println("LED off detected. Turn off OLED.");
         u8g2.setPowerSave(1);
@@ -114,6 +141,9 @@ public:
         u8g2.setPowerSave(0);
         b_u8g2Sleep = false;
         sendUsbLedResponse();
+        if (!requireLength(len, 6, "LED on")) {
+          return;
+        }
         if (data[5] == 0x00) {
           b_requireHeartBeat = false;
           Serial.println(" *** Heartbeat detection Off ***");
@@ -130,6 +160,9 @@ public:
         Serial.println("Power off detected.");
         b_powerOff = true;
       } else if (data[2] == 0x03) {
+        if (!requireLength(len, 4, "low power")) {
+          return;
+        }
         if (data[3] == 0x01) {
           Serial.println("Start Low Power Mode.");
           u8g2.setContrast(0);
@@ -138,6 +171,9 @@ public:
           u8g2.setContrast(255);
         }
       } else if (data[2] == 0x04) {
+        if (!requireLength(len, 4, "soft sleep")) {
+          return;
+        }
         if (data[3] == 0x01) {
           Serial.println("Start Soft Sleep.");
           u8g2.setPowerSave(1);
@@ -157,6 +193,9 @@ public:
         }
       }
     } else if (data[1] == 0x0B) {
+      if (!requireLength(len, 3, "timer")) {
+        return;
+      }
       if (data[2] == 0x03) {
         Serial.println("Timer start detected.");
         stopWatch.reset();
@@ -169,6 +208,9 @@ public:
         stopWatch.reset();
       }
     } else if (data[1] == 0x1A) {
+      if (!requireLength(len, 3, "calibration")) {
+        return;
+      }
       if (data[2] == 0x00) {
         Serial.println("Manual Calibration via BLE");
         i_button_cal_status = 1;
@@ -186,6 +228,9 @@ public:
     }
 #ifdef BUZZER
     else if (data[1] == 0x1C) {  //buzzer settings
+      if (!requireLength(len, 3, "buzzer")) {
+        return;
+      }
       if (data[2] == 0x00) {
         Serial.println("Buzzer Off");
         b_beep = false;  // won't store into eeprom
@@ -199,6 +244,9 @@ public:
     }
 #endif
     else if (data[1] == 0x1D) {  //Sample settings
+      if (!requireLength(len, 3, "sample settings")) {
+        return;
+      }
       if (data[2] == 0x00) {
         scale.setSamplesInUse(1);
         Serial.print("Samples in use set to: ");
@@ -213,6 +261,9 @@ public:
         Serial.println(scale.getSamplesInUse());
       }
     } else if (data[1] == 0x1E) {
+      if (!requireLength(len, 4, "menu/about/debug")) {
+        return;
+      }
       if (data[2] == 0x00) {
         //menu control
         if (data[3] == 0x00) {
@@ -257,6 +308,9 @@ public:
     } else if (data[1] == 0x1F) {
       reset();
     } else if (data[1] == 0x20) {
+      if (!requireLength(len, 3, "USB weight")) {
+        return;
+      }
       if (data[2] == 0x00) {
         Serial.println("Weight by USB disabled");
         b_usbweight_enabled = false;
@@ -288,6 +342,9 @@ public:
       sendUsbVoltage();
     }
     else if (data[1] == 0x25) {
+      if (!requireLength(len, 3, "ADS debug")) {
+        return;
+      }
       // ADS1232 Debug commands
       if (data[2] == 0x00) {
         Serial.println("ADS debug off via hex");
@@ -301,6 +358,9 @@ public:
       }
     }
     else if (data[1] == 0x26) {
+      if (!requireLength(len, 3, "ADS reset")) {
+        return;
+      }
       // ADS1232 Reset command
       if (data[2] <= 0x02) {
         handleAdsReset(data[2]);
@@ -697,7 +757,11 @@ void handleAdsReset(uint8_t mode) {
 
   // Step 3: Refresh dataset if mode >= 0x01
   if (mode >= 0x01) {
-    scale.refreshDataSet();
+    if (!scale.refreshDataSet()) {
+      Serial.println("ADS reset FAILED: dataset refresh timeout");
+      sendUsbAdsResetResponse(mode, 0x02);
+      return;
+    }
     Serial.println("ADS reset: dataset refreshed");
   }
 
@@ -723,12 +787,6 @@ void sendUsbAdsDebug() {
 }
 
 #endif
-
-
-
-
-
-
 
 
 


### PR DESCRIPTION
## Summary
- Validate USB packet lengths before reading indexed bytes
- Build text commands from the received length instead of assuming a null-terminated buffer
- Reject invalid tare checksums before changing tare state
- Report ADS reset refresh failures and abort calibration when dataset refresh fails

## Context
This hardens command parsing against short USB frames and makes calibration/reset paths compatible with ADC refresh timeouts, so stale samples are not used after a failed refresh.

## Validation
- `platformio run`
- Also tested the combined local firmware on an attached ESP32-S3 with `platformio run -t upload --upload-port /dev/cu.wchusbserial110`; flash verification completed successfully.
