### PR TITLE
Fix ADS1232 startup and refresh handling

### DIFF
--- a/include/ADS1232_ADC.h
+++ b/include/ADS1232_ADC.h
@@ -77,7 +77,7 @@ typedef void (*DebugCallback)(const ADS1232DebugInfo& info);
 class ADS1232_ADC {
 
 public:
-  ADS1232_ADC(uint8_t dout, uint8_t sck, uint8_t pwdn, uint8_t a0);  //constructor
+  ADS1232_ADC(uint8_t dout, uint8_t sck, uint8_t pwdn, int8_t a0);  //constructor
   ADS1232_ADC(uint8_t dout, uint8_t sck, uint8_t pwdn);  //constructor
   void setGain(uint8_t gain = 128);                 //value must be 32, 64 or 128*
   void begin();                                     //set pinMode, ADS1232 gain and power up the ADS1232
@@ -134,7 +134,7 @@ protected:
   uint8_t doutPin;                            //ADS1232 dout pin
   uint8_t GAIN;                               //ADS1232 GAIN
   uint8_t pdwnPin;                            //ADS1232 PWDN for power down
-  uint8_t a0Pin;                              //ADS1232 A0 for choose channel
+  int8_t a0Pin;                               //ADS1232 A0 for choose channel
   float calFactor = 1.0;                      //calibration factor as given in function setCalFactor(float cal)
   float calFactorRecip = 1.0;                 //reciprocal calibration factor (1/calFactor), the ADS1232 raw data is multiplied by this value
   volatile long dataSampleSet[DATA_SET + 1];  // dataset, make voltile if interrupt is used
@@ -150,6 +150,7 @@ protected:
   bool startStatus = 0;
   unsigned long startMultipleTimeStamp = 0;
   unsigned long startMultipleWaitTime = 0;
+  unsigned long startMultipleTareTimeStamp = 0;
   uint8_t convRslt = 0;
   bool tareStatus = 0;
   unsigned int tareTimeOut = (SAMPLES + IGN_HIGH_SAMPLE + IGN_HIGH_SAMPLE) * 150;  // tare timeout time in ms, no of samples * 150ms (10SPS + 50% margin)

--- a/src/ADS1232_ADC.cpp
+++ b/src/ADS1232_ADC.cpp
@@ -10,7 +10,7 @@
 #include <Arduino.h>
 #include "ADS1232_ADC.h"
 
-ADS1232_ADC::ADS1232_ADC(uint8_t dout, uint8_t sck, uint8_t pdwn, uint8_t a0)  //constructor
+ADS1232_ADC::ADS1232_ADC(uint8_t dout, uint8_t sck, uint8_t pdwn, int8_t a0)  //constructor
 {
   doutPin = dout;
   sckPin = sck;
@@ -38,7 +38,7 @@ void ADS1232_ADC::begin() {
   pinMode(sckPin, OUTPUT);
   pinMode(doutPin, INPUT);
   pinMode(pdwnPin, OUTPUT);
-  if(a0Pin != -1)
+  if (a0Pin != -1)
     pinMode(a0Pin, OUTPUT); // Set A0 pin as OUTPUT
 
   setGain(128);
@@ -50,15 +50,17 @@ void ADS1232_ADC::begin(uint8_t gain) {
   pinMode(sckPin, OUTPUT);
   pinMode(doutPin, INPUT);
   pinMode(pdwnPin, OUTPUT);
-  pinMode(a0Pin, OUTPUT); // Set A0 pin as OUTPUT
+  if (a0Pin != -1)
+    pinMode(a0Pin, OUTPUT); // Set A0 pin as OUTPUT
 
   setGain(gain);
   powerUp();
 }
 void ADS1232_ADC::start(unsigned long t) {
-  t += 400;
+  unsigned long waitTime = t + 400;
+  unsigned long startTime = millis();
   lastDoutLowTime = millis();
-  while (millis() < t) {
+  while (millis() - startTime < waitTime) {
     update();
     yield();
   }
@@ -70,9 +72,10 @@ void ADS1232_ADC::start(unsigned long t) {
 *	will do conversions continuously for 't' +400 milliseconds (400ms is min. settling time at 10SPS). 
 *   Running this for 1-5s in setup() - before tare() seems to improve the tare accuracy. */
 void ADS1232_ADC::start(unsigned long t, bool dotare) {
-  t += 400;
+  unsigned long waitTime = t + 400;
+  unsigned long startTime = millis();
   lastDoutLowTime = millis();
-  while (millis() < t) {
+  while (millis() - startTime < waitTime) {
     update();
     yield();
   }
@@ -97,23 +100,28 @@ int ADS1232_ADC::startMultiple(unsigned long t) {
         startMultipleWaitTime = t;
       }
       isFirst = 0;
+      startMultipleTareTimeStamp = 0;
     }
     if ((millis() - startMultipleTimeStamp) < startMultipleWaitTime) {
       update();  //do conversions during stabilization time
       yield();
       return 0;
     } else {  //do tare after stabilization time is up
-      static unsigned long timeout = millis() + tareTimeOut;
+      if (startMultipleTareTimeStamp == 0) {
+        startMultipleTareTimeStamp = millis();
+      }
       doTare = 1;
       update();
       if (convRslt == 2) {
         doTare = 0;
         convRslt = 0;
         startStatus = 1;
+        startMultipleTareTimeStamp = 0;
       }
       if (!tareTimeoutDisable) {
-        if (millis() > timeout) {
+        if (millis() - startMultipleTareTimeStamp > tareTimeOut) {
           tareTimeoutFlag = 1;
+          startMultipleTareTimeStamp = 0;
           return 1;  // Prevent endless loop if no ADS1232 is connected
         }
       }
@@ -138,6 +146,7 @@ int ADS1232_ADC::startMultiple(unsigned long t, bool dotare) {
         startMultipleWaitTime = t;
       }
       isFirst = 0;
+      startMultipleTareTimeStamp = 0;
     }
     if ((millis() - startMultipleTimeStamp) < startMultipleWaitTime) {
       update();  //do conversions during stabilization time
@@ -145,21 +154,28 @@ int ADS1232_ADC::startMultiple(unsigned long t, bool dotare) {
       return 0;
     } else {  //do tare after stabilization time is up
       if (dotare) {
-        static unsigned long timeout = millis() + tareTimeOut;
+        if (startMultipleTareTimeStamp == 0) {
+          startMultipleTareTimeStamp = millis();
+        }
         doTare = 1;
         update();
         if (convRslt == 2) {
           doTare = 0;
           convRslt = 0;
           startStatus = 1;
+          startMultipleTareTimeStamp = 0;
         }
         if (!tareTimeoutDisable) {
-          if (millis() > timeout) {
+          if (millis() - startMultipleTareTimeStamp > tareTimeOut) {
             tareTimeoutFlag = 1;
+            startMultipleTareTimeStamp = 0;
             return 1;  // Prevent endless loop if no ADS1232 is connected
           }
         }
-      } else return 1;
+      } else {
+        startMultipleTareTimeStamp = 0;
+        return 1;
+      }
     }
   }
   return startStatus;
@@ -468,13 +484,17 @@ void ADS1232_ADC::resetSamplesIndex() {
 //Fill the whole dataset up with new conversions, i.e. after a reset/restart (this function is blocking once started)
 bool ADS1232_ADC::refreshDataSet() {
   int s = getSamplesInUse() + IGN_HIGH_SAMPLE + IGN_LOW_SAMPLE;  // get number of samples in dataset
+  unsigned long startTime = millis();
+  unsigned long timeout = (unsigned long)s * SIGNAL_TIMEOUT * 2;
   resetSamplesIndex();
   while (s > 0) {
-    update();
-    yield();
-    if (digitalRead(doutPin) == LOW) {  // ADS1232 dout pin is pulled low when a new conversion is ready
-      getData();                        // add data to the set and start next conversion
+    if (update()) {
+      getData();
       s--;
+    }
+    yield();
+    if (millis() - startTime > timeout) {
+      return false;
     }
   }
   return true;
@@ -515,6 +535,11 @@ void ADS1232_ADC::setReverseOutput() {
 }
 
 void ADS1232_ADC::setChannelInUse(int channel) {
+  if (a0Pin == -1) {
+    Serial.println("Channel selection unavailable: A0 pin not configured.");
+    return;
+  }
+
   channelInUse = channel;
   if (channel == 0) {
     digitalWrite(a0Pin, LOW); // Set A0 pin LOW for Channel B
@@ -601,5 +626,3 @@ void ADS1232_ADC::captureDebugInfo() {
     debugCallback(info);
   }
 }
-
-


### PR DESCRIPTION
## Summary
- Fix ADS1232 startup stabilization wait to use elapsed time instead of comparing against an absolute timestamp
- Add a timeout to dataset refresh and count samples consumed by `update()`
- Preserve the signed A0 sentinel so `SCALE_A0 = -1` does not become GPIO 255
- Reset `startMultiple()` timeout state for each tare/start sequence

## Context
These changes remove direct hang paths around ADC startup/reset and fix the `Invalid IO 255 selected` boot behavior caused by storing the A0 sentinel in an unsigned pin field.

## Validation
- `platformio run`
- Also tested the combined local firmware on an attached ESP32-S3 with `platformio run -t upload --upload-port /dev/cu.wchusbserial110`; flash verification completed successfully.
