### PR TITLE
Make remote tare requests reliable

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -161,6 +161,19 @@ class MyCallbacks : public BLECharacteristicCallbacks {
     return expectedChecksum == calculatedChecksum;
   }
 
+  bool requireLength(size_t actual, size_t required, const char *commandName) {
+    if (actual >= required) {
+      return true;
+    }
+    Serial.print("Ignoring short BLE packet for ");
+    Serial.print(commandName);
+    Serial.print(": ");
+    Serial.print(actual);
+    Serial.print("/");
+    Serial.println(required);
+    return false;
+  }
+
   void onWrite(BLECharacteristic *pWriteCharacteristic) {
     //this is what the esp32 received via ble
     Serial.print("Timer");
@@ -178,6 +191,11 @@ class MyCallbacks : public BLECharacteristicCallbacks {
       size_t len = pWriteCharacteristic->getLength();              // Get the data length
       uint8_t *data = (uint8_t *)pWriteCharacteristic->getData();  // Get the data pointer
 
+      if (data == nullptr || len <= 0) {
+        Serial.println("Ignoring empty BLE write.");
+        return;
+      }
+
       // Optionally print the received HEX for verification or debugging
       Serial.print("Received HEX: ");
       for (size_t i = 0; i < len; i++) {
@@ -187,17 +205,24 @@ class MyCallbacks : public BLECharacteristicCallbacks {
         Serial.print(data[i], HEX);  // Print the byte in HEX
       }
       Serial.print(" ");
+
       if (data[0] == 0x03) {
+        if (!requireLength(len, 2, "message header")) {
+          return;
+        }
         //check if it's a decent scale message
         if (data[1] == 0x0F) {
+          if (!requireLength(len, 7, "tare")) {
+            return;
+          }
           //taring
           if (validateChecksum(data, len)) {
             Serial.println("Valid checksum for tare operation. Taring");
           } else {
             Serial.println("Invalid checksum for tare operation.");
+            return;
           }
-          b_tareByBle = true;
-          t_tareByBle = millis();
+          requestRemoteTare();
           if (data[5] == 0x00) {
             /*
             Tare the scale by sending "030F000000000C" (old version, disables heartbeat)

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -73,7 +73,9 @@ int i_tareDelay = 0;             //tare delay 0ms for finger detection
 unsigned long t_tareByButton = 0;  //tare time stamp used by button to mimic delay
 bool b_tareByButton = false;
 unsigned long t_tareByBle = 0;
+uint8_t i_remoteTareRequests = 0;
 bool b_tareByBle = false;
+portMUX_TYPE remoteTareMux = portMUX_INITIALIZER_UNLOCKED;
 unsigned long t_tareStatus = 0;  //tare done time stamp
 unsigned long t_power_off;       //关机倒计时
 bool b_powerOff = false;
@@ -83,6 +85,35 @@ unsigned long t_power_off_gyro = 0;  //侧放关机倒计时
 unsigned long t_button_pressed;  //进入萃取模式的时间点
 unsigned long t_temp;            //上次更新温度和度数时间
 float f_temp_tare = 0;
+
+void requestRemoteTare() {
+  unsigned long now = millis();
+  portENTER_CRITICAL(&remoteTareMux);
+  if (i_remoteTareRequests < 255) {
+    i_remoteTareRequests++;
+  }
+  b_tareByBle = true;
+  t_tareByBle = now;
+  portEXIT_CRITICAL(&remoteTareMux);
+}
+
+bool hasRemoteTareRequest() {
+  bool hasRequest;
+  portENTER_CRITICAL(&remoteTareMux);
+  hasRequest = i_remoteTareRequests > 0;
+  portEXIT_CRITICAL(&remoteTareMux);
+  return hasRequest;
+}
+
+uint8_t consumeRemoteTareRequests() {
+  uint8_t requests;
+  portENTER_CRITICAL(&remoteTareMux);
+  requests = i_remoteTareRequests;
+  i_remoteTareRequests = 0;
+  b_tareByBle = false;
+  portEXIT_CRITICAL(&remoteTareMux);
+  return requests;
+}
 // int i_sample = 0;       //采样数0-7
 // int i_sample_step = 0;  //设置采样数的第几步
 int i_icon = 0;  //充电指示电量数字0-6

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -81,8 +81,7 @@ public:
       } else {
         Serial.println("Invalid checksum for tare operation.");
       }
-      b_tareByBle = true;
-      t_tareByBle = millis();
+      requestRemoteTare();
       if (data[5] == 0x00) {
         /*
         Tare the scale by sending "030F000000000C" (old version, disables heartbeat)
@@ -703,8 +702,7 @@ void handleAdsReset(uint8_t mode) {
 
   // Step 4: Tare + reset compensations if mode == 0x02
   if (mode == 0x02) {
-    b_tareByBle = true;
-    t_tareByBle = millis();
+    requestRemoteTare();
     Serial.println("ADS reset: tare requested");
   }
 
@@ -723,12 +721,4 @@ void sendUsbAdsDebug() {
 }
 
 #endif
-
-
-
-
-
-
-
-
 

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -402,7 +402,7 @@ void _wifi_init(void *args) {
       Serial.print("Websocket recv: ");
       Serial.println(msg);
       if (msg == "tare") {
-        b_tareByBle = true;
+        requestRemoteTare();
       }
     }
   });
@@ -1362,11 +1362,17 @@ void loop() {
             b_tareByButton = false;  // reset status
             Serial.println("Tare by button");
           }
-        } else if (b_tareByBle) {
+        } else if (hasRemoteTareRequest()) {
           // Tare by BLE, performed instantly without delay
+          uint8_t remoteTareRequests = consumeRemoteTareRequests();
           scale.tareNoDelay();
-          b_tareByBle = false;  // reset status
-          Serial.println("Tare by BLE");
+          Serial.print("Tare by remote command");
+          if (remoteTareRequests > 1) {
+            Serial.print(" (");
+            Serial.print(remoteTareRequests);
+            Serial.print(" requests)");
+          }
+          Serial.println();
         }
         pureScale();
         updateOled();


### PR DESCRIPTION
## Summary
- Keep the existing BLE tare command unchanged, but reject short tare packets before indexing them
- Reject invalid BLE tare checksums before requesting a tare
- Replace the plain shared remote tare flag with an atomic pending-request handoff for BLE, USB, ADS reset, and WebSocket tare requests

## Context
BLE callbacks and the main loop run in different task contexts. A plain shared bool can lose an occasional request when the callback writes it while the main loop reads and clears it. This keeps the current command protocol intact while making the handoff deterministic.

## Validation
- `platformio run`
