### PR TITLE
Show ADC recovery instead of stuck zero

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -63,7 +63,7 @@ U8G2_SSD1306_128X64_NONAME_1_SW_I2C u8g2(U8G2_R0, /* clock=*/OLED_SCL, /* data=*
 //文本对齐 AC居中 AR右对齐 AL左对齐 T为要显示的文本
 #define LCDWidth u8g2.getDisplayWidth()
 #define LCDHeight u8g2.getDisplayHeight()
-#define AC(T) ((LCDWidth - u8g2.getUTF8Width((const char *)(T))) / 2 - Margin_Left - Margin_Right)
+#define AC(T) ((LCDWidth - u8g2.getUTF8Width(T)) / 2 - Margin_Left - Margin_Right)
 #define AR(T) (LCDWidth - u8g2.getUTF8Width(T) - Margin_Right)
 #define AL(T) (u8g2.getUTF8Width(T) + Margin_Left)
 #define AM() ((LCDHeight + u8g2.getMaxCharHeight()) / 2 - Margin_Top - Margin_Bottom)

--- a/include/display.h
+++ b/include/display.h
@@ -63,7 +63,7 @@ U8G2_SSD1306_128X64_NONAME_1_SW_I2C u8g2(U8G2_R0, /* clock=*/OLED_SCL, /* data=*
 //文本对齐 AC居中 AR右对齐 AL左对齐 T为要显示的文本
 #define LCDWidth u8g2.getDisplayWidth()
 #define LCDHeight u8g2.getDisplayHeight()
-#define AC(T) ((LCDWidth - u8g2.getUTF8Width(T)) / 2 - Margin_Left - Margin_Right)
+#define AC(T) ((LCDWidth - u8g2.getUTF8Width((const char *)(T))) / 2 - Margin_Left - Margin_Right)
 #define AR(T) (LCDWidth - u8g2.getUTF8Width(T) - Margin_Right)
 #define AL(T) (u8g2.getUTF8Width(T) + Margin_Left)
 #define AM() ((LCDHeight + u8g2.getMaxCharHeight()) / 2 - Margin_Top - Margin_Bottom)

--- a/include/finger_detection.h
+++ b/include/finger_detection.h
@@ -215,6 +215,7 @@ bool isFingerPress(int button) {
         }
         if (!deviceConnected || b_btnFuncWhileConnected) {
           b_weight_quick_zero = true;
+          t_quickZeroStart = millis();
           t_tareByButton = millis();
           b_tareByButton = true;
         }

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -71,6 +71,7 @@ int i_bootTareDelay = 1000;
 //int i_tareDelay = 200;             //tare delay for button
 int i_tareDelay = 0;             //tare delay 0ms for finger detection
 unsigned long t_tareByButton = 0;  //tare time stamp used by button to mimic delay
+unsigned long t_quickZeroStart = 0;
 bool b_tareByButton = false;
 unsigned long t_tareByBle = 0;
 uint8_t i_remoteTareRequests = 0;
@@ -154,6 +155,12 @@ static float f_driftCompensation = 0.0;  // Continuous temperature drift compens
 static float f_maxDriftCompensation = 0.05;  // Maximum micro-drift range for temperature compensation (g)
 // Range: 0.01g to this value will be considered as temperature drift
 // Values above this are considered as real weight changes, not drift
+static const unsigned long QUICK_ZERO_HOLD_TIMEOUT = 3000;
+static const unsigned long ZERO_DISPLAY_MISMATCH_TIMEOUT = 1500;
+static const float ZERO_DISPLAY_MISMATCH_THRESHOLD = 0.5;
+static const uint8_t ADC_ERROR_RECOVERY_COUNT = 2;
+static bool b_adc_recovery_active = false;
+static uint8_t i_adc_recovery_count = 0;
 //bool b_tempDisablePowerOff = true;
 
 bool b_negativeWeight = false;
@@ -161,6 +168,11 @@ bool b_negativeWeight = false;
 bool b_weight_quick_zero = false;           //Tare后快速显示为0优化
 char c_weight[10];                          //咖啡重量显示
 char c_brew_ratio[10];                      //粉水比显示
+
+static inline void resetAdcRecoveryState() {
+  b_adc_recovery_active = false;
+  i_adc_recovery_count = 0;
+}
 unsigned long t_extraction_begin = 0;       //开始萃取打点
 unsigned long t_extraction_first_drop = 0;  //下液第一滴打点
 unsigned long t_extraction_last_drop = 0;   //下液结束打点

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -734,6 +734,7 @@ void handleAdsReset(uint8_t mode) {
   scale.powerDown();
   delay(500);
   scale.powerUp();
+  resetAdcRecoveryState();
 
   // Step 2: Check if ADS came back (DOUT should go low when conversion ready)
   unsigned long startTime = millis();

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -581,6 +581,7 @@ void setup() {
   scale.begin();
   scale.setSamplesInUse(1);  //设置灵敏度 (SAMPLES=4 allows runtime change via hex cmd)
   scale.start(stabilizingtime, _tare);
+  resetAdcRecoveryState();
   scale.setCalFactor(f_calibration_value);  //设置偏移量
   //set the calibration value
   //scale.setSamplesInUse(sample[i_sample]);  //设置灵敏度
@@ -950,6 +951,7 @@ void pureScale() {
   static float f_last_displayed = 0.0;  // Last displayed value
   static unsigned long t_lastScaleData = 0;
   static unsigned long t_lastScaleRecovery = 0;
+  static unsigned long t_zeroDisplayMismatch = 0;
 
   if (t_lastScaleData == 0) {
     t_lastScaleData = millis();
@@ -958,10 +960,15 @@ void pureScale() {
   if (scale.update()) {
     b_newDataReady = true;
     t_lastScaleData = millis();
+    resetAdcRecoveryState();
   } else if (scale.getSignalTimeoutFlag() &&
              millis() - t_lastScaleData > 1500 &&
              millis() - t_lastScaleRecovery > 5000) {
     Serial.println("Scale ADC timeout. Power cycling ADC.");
+    b_adc_recovery_active = true;
+    if (i_adc_recovery_count < 255) {
+      i_adc_recovery_count++;
+    }
     scale.powerDown();
     delay(5);
     scale.powerUp();
@@ -1041,6 +1048,23 @@ void pureScale() {
     }
     // Update adaptive tracking (use temperature compensated value)
     updateAdaptiveTracking(tracking_compensated);
+
+    if (!b_bootTare && !b_weight_quick_zero &&
+        fabs(f_displayedValue) <= 0.14 &&
+        fabs(raw_weight) > ZERO_DISPLAY_MISMATCH_THRESHOLD) {
+      if (t_zeroDisplayMismatch == 0) {
+        t_zeroDisplayMismatch = millis();
+      } else if (millis() - t_zeroDisplayMismatch > ZERO_DISPLAY_MISMATCH_TIMEOUT) {
+        Serial.println("Display held at zero while raw weight moved. Resetting output filters.");
+        resetTracking();
+        resetStableOutput();
+        f_driftCompensation = 0.0;
+        f_displayedValue = raw_weight;
+        t_zeroDisplayMismatch = 0;
+      }
+    } else {
+      t_zeroDisplayMismatch = 0;
+    }
     
     // Display and debugging
     dtostrf(f_displayedValue, 7, i_decimal_precision, c_weight);
@@ -1082,6 +1106,14 @@ void pureScale() {
       Serial.println("TARE: Temperature drift compensation reset");
     }
   }
+  if (b_weight_quick_zero && millis() - t_quickZeroStart > QUICK_ZERO_HOLD_TIMEOUT) {
+    Serial.println("Quick zero timeout. Releasing display zero hold.");
+    b_weight_quick_zero = false;
+    resetTracking();
+    resetStableOutput();
+    f_driftCompensation = 0.0;
+  }
+
   
   // Quick zero handling
   if (b_weight_quick_zero || b_bootTare) {
@@ -1339,6 +1371,7 @@ void loop() {
             GPIO_power_on_with = BUTTON_SQUARE;
             b_is_charging = false;
             scale.powerUp();
+            resetAdcRecoveryState();
             scale.tareNoDelay();
           } else {
             if (f_batteryVoltage > 4.1) {
@@ -1366,11 +1399,13 @@ void loop() {
         //showing charging animation when powered off
         //charging();
       } else {
-        sendUsbTextWeight();
-        if (b_ble_enabled)
-          sendBleWeight();
-        if (b_usbweight_enabled)
-          sendUsbWeight();
+        if (!b_adc_recovery_active) {
+          sendUsbTextWeight();
+          if (b_ble_enabled)
+            sendBleWeight();
+          if (b_usbweight_enabled)
+            sendUsbWeight();
+        }
         if (b_wifiEnabled) {
           websocket.cleanupClients(1);
           ElegantOTA.loop();
@@ -1378,7 +1413,9 @@ void loop() {
           unsigned long current = millis();
           if (current - lastUpdate > 500) {
             if (websocket.availableForWriteAll() > 0) {
-              websocket.printfAll("{ \"grams\": %.2f, \"ms\": %lu }", f_displayedValue, current);
+              if (!b_adc_recovery_active) {
+                websocket.printfAll("{ \"grams\": %.2f, \"ms\": %lu }", f_displayedValue, current);
+              }
             } else {
               Serial.println("Websocket write unavailable");
             }
@@ -1499,8 +1536,12 @@ void updateOled() {
       u8g2.setFontMode(1);
       u8g2.setDrawColor(1);
       if (!b_debug) {
-        drawWeight(f_displayedValue);
-        drawTime();
+        if (b_adc_recovery_active) {
+          drawAdcRecovery();
+        } else {
+          drawWeight(f_displayedValue);
+          drawTime();
+        }
       }
       u8g2.setDrawColor(2);
 
@@ -1642,6 +1683,18 @@ void drawTime() {
       y = u8g2.getMaxCharHeight() - 8;
     u8g2.drawStr(AC(sec2sec(stopWatch.elapsed())), y, sec2sec(stopWatch.elapsed()));
   }
+}
+
+void drawAdcRecovery() {
+  u8g2.setFont(FONT_S);
+  const char* line1 = getAdcRecoveryDisplayText();
+  const char* line2 = "CHECK SCALE";
+  u8g2.drawStr(AC(line1), AM() - 12, line1);
+  u8g2.drawStr(AC(line2), AM() + 12, line2);
+}
+
+const char* getAdcRecoveryDisplayText() {
+  return i_adc_recovery_count >= ADC_ERROR_RECOVERY_COUNT ? "ADC ERROR" : "ADC RECOVER";
 }
 
 //button pressed box, left and right, added xor


### PR DESCRIPTION
## Summary

This PR hardens firmware-side ADC sample-loss and display-zero recovery paths. It does not address the separate U21 cold-solder failure mode where DRDY continues clocking and raw readings are pinned at `0xFFFFFF`.

Changes:

- releases the quick-zero display hold if a nonblocking tare does not complete in time
- uses a dedicated quick-zero start timestamp instead of reusing the button tare timestamp
- detects when raw weight has moved but the filtered/displayed value remains pinned at zero, then resets the output filters and publishes the raw weight
- marks ADC sample-loss recovery on the OLED as `ADC RECOVER`, then `ADC ERROR` / `CHECK SCALE` after repeated recovery attempts
- suppresses remote weight publishes while ADC recovery is active, preserving existing BLE/USB/WebSocket payload formats instead of sending fake zero or a sentinel value
- resets ADC recovery state when the ADC stack is explicitly initialized or reset

## Why

The existing firmware could make genuine ADC sample-loss and unresolved tare/filter states look like a legitimate `0.0g` reading. This PR makes those firmware-detectable states visible locally and avoids publishing misleading zero-weight updates remotely.

Per review feedback, the field-reported stuck-zero case tied to a U21 cold solder joint is a different hardware failure mode. In that case the ADC can continue producing ready samples, so `scale.update()` may keep succeeding and this PR's sample-loss recovery path will not trigger.

## Validation

- Built successfully with `platformio run`
