### PR TITLE
Fix drift compensation reset state

### DIFF
--- a/src/hds.ino
+++ b/src/hds.ino
@@ -952,6 +952,8 @@ void pureScale() {
   static unsigned long t_lastScaleData = 0;
   static unsigned long t_lastScaleRecovery = 0;
   static unsigned long t_zeroDisplayMismatch = 0;
+  static int f_similar_diff_count = 0;
+  static float f_last_diff = 0.0;
 
   if (t_lastScaleData == 0) {
     t_lastScaleData = millis();
@@ -993,9 +995,6 @@ void pureScale() {
     
     // 2. If difference is small (0.01g-0.1g), accumulate to continuous compensation
     if (fabs(current_diff) > 0.01 && fabs(current_diff) < f_maxDriftCompensation) {
-      static int f_similar_diff_count = 0;
-      static float f_last_diff = current_diff;
-      
       // Check if continuous same direction change
       if ((f_last_diff * current_diff) > 0) {  // Same direction
         f_similar_diff_count++;
@@ -1029,8 +1028,8 @@ void pureScale() {
       f_last_diff = current_diff;
     } else {
       // Difference too large or too small, reset detection
-      static int f_similar_diff_count = 0;
       f_similar_diff_count = 0;
+      f_last_diff = 0.0;
     }
     
     // 3. Apply continuous temperature compensation


### PR DESCRIPTION
## Summary

Fixes the drift compensation state reset in `pureScale()`.

The invalid-diff branch previously declared a second block-local `static int f_similar_diff_count`, so it reset a different counter than the one used by the compensation path. This moves the counter and last-diff state to the `pureScale()` scope and resets the active state when the diff is outside the drift-compensation window.

## Validation

- `platformio run`
- Flashed/tested the same source change locally before opening this standalone PR

## Notes

This PR is intentionally scoped to the drift compensation reset bug and is based directly on `develop`.