### PR TITLE
Add BLE debug packet support (HDS Doctor over BLE)

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -14,9 +14,22 @@ const unsigned long HEARTBEAT_TIMEOUT = 5000;  // 5 seconds
 unsigned long t_lastDisconnectAttempt = 0;
 unsigned long t_lastDisconnectAttemptNotice = 0;
 
+// ADS1232 debug streaming mode over BLE (cmd 0x25)
+enum DebugMode {
+  DEBUG_OFF = 0,
+  DEBUG_SINGLE = 1,
+  DEBUG_CONTINUOUS = 2
+};
+DebugMode bleDebugMode = DEBUG_OFF;
+unsigned long t_lastBleDebugNotify = 0;
+const unsigned long BLE_DEBUG_MIN_INTERVAL = 100;  // ~10 Hz cap for continuous mode
+
 //functions
 void sendBleVoltage();
 void sendBleLedResponse();
+void sendAdsDebugInfoBLE();
+// Defined in usbcomm.h, included after ble.h in hds.ino
+void buildAdsDebugPacket(byte data[41]);
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
 void sendBleGyro();
 #endif
@@ -439,6 +452,22 @@ class MyCallbacks : public BLECharacteristicCallbacks {
         else if (data[1] == 0x22) {
           sendBleVoltage();
         }
+        else if (data[1] == 0x25) {
+          if (!requireLength(len, 3, "ADS debug BLE")) {
+            return;
+          }
+          // 0x25 ADS1232 debug streaming over BLE
+          if (data[2] == 0x00) {
+            Serial.println("BLE ADS debug: OFF");
+            bleDebugMode = DEBUG_OFF;
+          } else if (data[2] == 0x01) {
+            Serial.println("BLE ADS debug: CONTINUOUS");
+            bleDebugMode = DEBUG_CONTINUOUS;
+          } else if (data[2] == 0x02) {
+            Serial.println("BLE ADS debug: SINGLE");
+            bleDebugMode = DEBUG_SINGLE;
+          }
+        }
       }
     }
   }
@@ -711,6 +740,22 @@ void sendBleLedResponse() {
   buildLedResponsePacket(data);
   pReadCharacteristic->setValue(data, 7);
   pReadCharacteristic->notify();
+}
+
+// Send 41-byte ADS1232 debug packet via BLE notify on fff4.
+// In SINGLE mode, auto-clears bleDebugMode to OFF after sending.
+void sendAdsDebugInfoBLE() {
+  if (!(b_ble_enabled && deviceConnected && pReadCharacteristic)) return;
+  if (bleDebugMode == DEBUG_OFF) return;
+
+  byte data[41];
+  buildAdsDebugPacket(data);
+  pReadCharacteristic->setValue(data, 41);
+  pReadCharacteristic->notify();
+
+  if (bleDebugMode == DEBUG_SINGLE) {
+    bleDebugMode = DEBUG_OFF;
+  }
 }
 
 #endif

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1405,6 +1405,14 @@ void loop() {
           if (b_usbweight_enabled)
             sendUsbWeight();
         }
+        if (b_ble_enabled && deviceConnected && bleDebugMode != DEBUG_OFF) {
+          // SINGLE fires once; CONTINUOUS rate-limited to ~10 Hz
+          if (bleDebugMode == DEBUG_SINGLE ||
+              millis() - t_lastBleDebugNotify >= BLE_DEBUG_MIN_INTERVAL) {
+            t_lastBleDebugNotify = millis();
+            sendAdsDebugInfoBLE();
+          }
+        }
         if (b_wifiEnabled) {
           websocket.cleanupClients(1);
           ElegantOTA.loop();

--- a/tools/README_ADS_DEBUG.md
+++ b/tools/README_ADS_DEBUG.md
@@ -21,15 +21,16 @@ adsd off      # Disable continuous debug output
 adsd info     # Get one-time debug snapshot
 ```
 
-## Hex/Binary Commands (via USB)
+## Hex/Binary Commands (via USB or BLE)
 
-Send these hex commands for programmatic access:
+Send these hex commands for programmatic access. The exact same `0x25`
+command set works over BLE (write characteristic `36f5`, notify on `fff4`).
 
-| Command | Hex Bytes | Description |
-|---------|-----------|-------------|
-| Debug ON | `03 25 01 XX` | Enable debug mode (XX = checksum) |
-| Debug OFF | `03 25 00 XX` | Disable debug mode (XX = checksum) |
-| Get Info | `03 25 02 XX` | Request debug packet (XX = checksum) |
+| Command | Hex Bytes | USB behavior | BLE behavior |
+|---------|-----------|--------------|--------------|
+| Debug OFF       | `03 25 00 XX` | Stops continuous text output     | Stops continuous notify stream |
+| Debug ON        | `03 25 01 XX` | Enables continuous text output   | Starts CONTINUOUS notify stream (~10 Hz) |
+| Get Info / SINGLE | `03 25 02 XX` | One 41-byte packet on Serial    | One 41-byte notify on `fff4`, auto-clears to OFF |
 
 **Checksum calculation:** XOR of all bytes except the last one.
 
@@ -38,6 +39,9 @@ Example for "Get Info":
 0x03 ^ 0x25 ^ 0x02 = 0x24
 Command: 03 25 02 24
 ```
+
+> BLE transport eliminates the mechanical drag the USB cable puts on the
+> scale during diagnostics, which can otherwise show up as false drift.
 
 ## Debug Packet Format
 
@@ -69,9 +73,9 @@ All multi-byte values are **big-endian** (network byte order).
 
 ## Using the Python Tools
 
-Two Python scripts are provided:
+Three Python scripts are provided:
 
-### 1. `ads_debug_monitor.py` - Serial Communication & Commands
+### 1. `ads_debug_monitor.py` - USB Serial Communication & Commands
 
 Connects to the scale, sends commands, and displays results.
 
@@ -96,9 +100,34 @@ python tools/ads_debug_monitor.py /dev/cu.wchusbserial10 --debug-on
 python tools/ads_debug_monitor.py /dev/cu.wchusbserial10 --debug-off
 ```
 
-### 2. `decode_ads_debug.py` - Packet Decoder
+### 2. `ads_debug_monitor_ble.py` - BLE Communication & Commands
 
-Decodes raw hex packets (used by ads_debug_monitor.py or standalone).
+Same commands as the USB version, but talks to the scale over BLE. Useful
+when the USB cable would mechanically interfere with the load cell.
+
+```bash
+# Install bleak if needed
+pip install bleak
+
+# Auto-scan for "Decent Scale" and request a single packet
+python tools/ads_debug_monitor_ble.py
+
+# Specify BLE address directly (skip scan)
+python tools/ads_debug_monitor_ble.py --address AA:BB:CC:DD:EE:FF
+
+# Continuous streaming, ~once per second printed, stops on Ctrl+C
+python tools/ads_debug_monitor_ble.py --monitor
+
+# Stream for 10 seconds and exit
+python tools/ads_debug_monitor_ble.py --monitor --duration 10
+
+# Interactive mode
+python tools/ads_debug_monitor_ble.py --interactive
+```
+
+### 3. `decode_ads_debug.py` - Packet Decoder
+
+Decodes raw 41-byte packets (used by both monitors above, or standalone).
 
 ```bash
 # Decode a hex string directly

--- a/tools/ads_debug_monitor_ble.py
+++ b/tools/ads_debug_monitor_ble.py
@@ -51,6 +51,11 @@ def build_debug_command(mode):
     return payload + bytes([xor_checksum(payload)])
 
 
+# Decent Scale heartbeat: firmware disconnects after 5s without one
+HEARTBEAT_CMD = bytes([0x03, 0x0A, 0x03, 0xFF, 0xFF, 0x00, 0x0A])
+HEARTBEAT_INTERVAL = 2.0
+
+
 async def find_device(name_filter, timeout):
     print(f"Scanning for BLE devices (filter='{name_filter}', timeout={timeout}s)...")
     devices = await BleakScanner.discover(timeout=timeout)
@@ -75,6 +80,7 @@ class BleMonitor:
         self.client = None
         # Notify packets are 41 bytes and fit a single MTU; assume one notify == one packet
         self._packet_handler = None
+        self._heartbeat_task = None
 
     async def __aenter__(self):
         self.client = BleakClient(self.address)
@@ -83,15 +89,37 @@ class BleMonitor:
             raise RuntimeError(f"Failed to connect to {self.address}")
         print(f"Connected to {self.address}")
         await self.client.start_notify(NOTIFY_UUID, self._on_notify)
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
+        if self._heartbeat_task:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except (asyncio.CancelledError, Exception):
+                pass
         try:
             await self.client.stop_notify(NOTIFY_UUID)
         except Exception:
             pass
-        await self.client.disconnect()
+        try:
+            await self.client.disconnect()
+        except Exception:
+            pass
         print("Disconnected.")
+
+    async def _heartbeat_loop(self):
+        # Keeps firmware-side b_requireHeartBeat timer fed (5s window).
+        try:
+            while self.client and self.client.is_connected:
+                try:
+                    await self.client.write_gatt_char(WRITE_UUID, HEARTBEAT_CMD, response=True)
+                except Exception:
+                    return
+                await asyncio.sleep(HEARTBEAT_INTERVAL)
+        except asyncio.CancelledError:
+            return
 
     def _on_notify(self, _char, data):
         # Filter to debug packets only (header 0x03 0x25, length 41).
@@ -105,7 +133,9 @@ class BleMonitor:
         cmd = build_debug_command(mode)
         mode_names = {0: "OFF", 1: "CONTINUOUS", 2: "SINGLE"}
         print(f"Sent: {mode_names.get(mode, '?')} ({' '.join(f'{b:02X}' for b in cmd)})")
-        await self.client.write_gatt_char(WRITE_UUID, cmd, response=False)
+        # Firmware characteristic 36f5 is PROPERTY_WRITE only (with response).
+        # Using response=False here would be silently dropped by some stacks.
+        await self.client.write_gatt_char(WRITE_UUID, cmd, response=True)
 
     def set_handler(self, handler):
         self._packet_handler = handler

--- a/tools/ads_debug_monitor_ble.py
+++ b/tools/ads_debug_monitor_ble.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+ADS1232 Debug Monitor (BLE)
+Companion to ads_debug_monitor.py that talks to the scale over BLE
+instead of USB serial. Uses the same 0x25 command and 41-byte packet
+format, decoded with decode_ads_debug.py.
+
+BLE GATT layout (Decent Scale):
+  Service:   0000fff0-0000-1000-8000-00805f9b34fb
+  Write:     0000 36f5-0000-1000-8000-00805f9b34fb
+  Notify:    0000fff4-0000-1000-8000-00805f9b34fb
+
+Commands (write to 36f5):
+  03 25 00 <xor>   -> debug streaming OFF
+  03 25 01 <xor>   -> debug streaming CONTINUOUS (~10 Hz)
+  03 25 02 <xor>   -> debug streaming SINGLE (one notify, auto-clears)
+
+Requires: pip install bleak
+"""
+
+import argparse
+import asyncio
+import sys
+import time
+
+try:
+    from bleak import BleakClient, BleakScanner
+except ImportError:
+    print("Error: bleak not installed. Run: pip install bleak", file=sys.stderr)
+    sys.exit(1)
+
+from decode_ads_debug import decode_ads_debug_packet, print_debug_info
+
+SERVICE_UUID = "0000fff0-0000-1000-8000-00805f9b34fb"
+WRITE_UUID   = "000036f5-0000-1000-8000-00805f9b34fb"
+NOTIFY_UUID  = "0000fff4-0000-1000-8000-00805f9b34fb"
+
+DEFAULT_NAME = "Decent Scale"
+
+
+def xor_checksum(data):
+    c = 0
+    for b in data:
+        c ^= b
+    return c
+
+
+def build_debug_command(mode):
+    """mode: 0=OFF, 1=CONTINUOUS, 2=SINGLE"""
+    payload = bytes([0x03, 0x25, mode])
+    return payload + bytes([xor_checksum(payload)])
+
+
+async def find_device(name_filter, timeout):
+    print(f"Scanning for BLE devices (filter='{name_filter}', timeout={timeout}s)...")
+    devices = await BleakScanner.discover(timeout=timeout)
+    matches = [d for d in devices if d.name and name_filter.lower() in d.name.lower()]
+    if not matches:
+        print("No matching device found. Visible devices:")
+        for d in devices:
+            print(f"  {d.address}  {d.name}")
+        return None
+    if len(matches) > 1:
+        print(f"Multiple matches, using first:")
+        for d in matches:
+            print(f"  {d.address}  {d.name}")
+    chosen = matches[0]
+    print(f"Selected: {chosen.address}  {chosen.name}")
+    return chosen.address
+
+
+class BleMonitor:
+    def __init__(self, address):
+        self.address = address
+        self.client = None
+        # Notify packets are 41 bytes and fit a single MTU; assume one notify == one packet
+        self._packet_handler = None
+
+    async def __aenter__(self):
+        self.client = BleakClient(self.address)
+        await self.client.connect()
+        if not self.client.is_connected:
+            raise RuntimeError(f"Failed to connect to {self.address}")
+        print(f"Connected to {self.address}")
+        await self.client.start_notify(NOTIFY_UUID, self._on_notify)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            await self.client.stop_notify(NOTIFY_UUID)
+        except Exception:
+            pass
+        await self.client.disconnect()
+        print("Disconnected.")
+
+    def _on_notify(self, _char, data):
+        # Filter to debug packets only (header 0x03 0x25, length 41).
+        # Other notifications on fff4 (weight, voltage, etc.) are ignored.
+        if len(data) == 41 and data[0] == 0x03 and data[1] == 0x25:
+            info = decode_ads_debug_packet(bytes(data))
+            if info and self._packet_handler:
+                self._packet_handler(info)
+
+    async def send(self, mode):
+        cmd = build_debug_command(mode)
+        mode_names = {0: "OFF", 1: "CONTINUOUS", 2: "SINGLE"}
+        print(f"Sent: {mode_names.get(mode, '?')} ({' '.join(f'{b:02X}' for b in cmd)})")
+        await self.client.write_gatt_char(WRITE_UUID, cmd, response=False)
+
+    def set_handler(self, handler):
+        self._packet_handler = handler
+
+
+async def single_shot(address):
+    async with BleMonitor(address) as mon:
+        received = asyncio.Event()
+
+        def handler(info):
+            print_debug_info(info)
+            received.set()
+
+        mon.set_handler(handler)
+        await mon.send(2)  # SINGLE
+        try:
+            await asyncio.wait_for(received.wait(), timeout=3.0)
+            return True
+        except asyncio.TimeoutError:
+            print("Timeout waiting for debug packet")
+            return False
+
+
+async def monitor(address, duration=None):
+    async with BleMonitor(address) as mon:
+        count = 0
+        last_print = time.time()
+
+        def handler(info):
+            nonlocal count, last_print
+            count += 1
+            now = time.time()
+            # Print every 1s to avoid flooding terminal at ~10 Hz
+            if now - last_print >= 1.0:
+                print_debug_info(info)
+                print(f"({count} packets received)\n")
+                last_print = now
+
+        mon.set_handler(handler)
+        await mon.send(1)  # CONTINUOUS
+        print("Streaming. Press Ctrl+C to stop." if duration is None
+              else f"Streaming for {duration}s...")
+        try:
+            if duration is None:
+                while True:
+                    await asyncio.sleep(0.5)
+            else:
+                await asyncio.sleep(duration)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            print("\nStopping...")
+        finally:
+            try:
+                await mon.send(0)  # OFF
+            except Exception:
+                pass
+        print(f"Total packets: {count}")
+
+
+async def interactive(address):
+    async with BleMonitor(address) as mon:
+        latest = {"info": None}
+
+        def handler(info):
+            latest["info"] = info
+            print_debug_info(info)
+
+        mon.set_handler(handler)
+        print("\n=== Interactive Mode (BLE) ===")
+        print("  on       - Enable continuous streaming")
+        print("  off      - Disable streaming")
+        print("  info     - Request single packet")
+        print("  quit     - Exit\n")
+
+        loop = asyncio.get_event_loop()
+        try:
+            while True:
+                cmd = (await loop.run_in_executor(None, input, "ble> ")).strip().lower()
+                if cmd in ("quit", "exit", "q"):
+                    await mon.send(0)
+                    break
+                elif cmd == "on":
+                    await mon.send(1)
+                elif cmd == "off":
+                    await mon.send(0)
+                elif cmd == "info":
+                    await mon.send(2)
+                elif cmd == "":
+                    continue
+                else:
+                    print("Commands: on, off, info, quit")
+        except (KeyboardInterrupt, EOFError):
+            print()
+            try:
+                await mon.send(0)
+            except Exception:
+                pass
+
+
+async def run(args):
+    address = args.address
+    if address is None:
+        address = await find_device(args.name, args.scan_timeout)
+        if address is None:
+            sys.exit(1)
+
+    if args.debug_on:
+        async with BleMonitor(address) as mon:
+            await mon.send(1)
+    elif args.debug_off:
+        async with BleMonitor(address) as mon:
+            await mon.send(0)
+    elif args.interactive:
+        await interactive(address)
+    elif args.monitor:
+        await monitor(address, args.duration)
+    else:
+        ok = await single_shot(address)
+        sys.exit(0 if ok else 1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ADS1232 Debug Monitor (BLE) - HDS Doctor over BLE",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Auto-scan for "Decent Scale" and request a single packet
+  python ads_debug_monitor_ble.py
+
+  # Specify BLE address directly
+  python ads_debug_monitor_ble.py --address AA:BB:CC:DD:EE:FF
+
+  # Stream continuously, print ~once per second, OFF on Ctrl+C
+  python ads_debug_monitor_ble.py --monitor
+
+  # Stream for 10 seconds and exit
+  python ads_debug_monitor_ble.py --monitor --duration 10
+
+  # Interactive mode
+  python ads_debug_monitor_ble.py --interactive
+
+Requires: pip install bleak
+        """,
+    )
+    parser.add_argument("--address", help="BLE address (skips scan)")
+    parser.add_argument("--name", default=DEFAULT_NAME, help=f"Name filter for scan (default: '{DEFAULT_NAME}')")
+    parser.add_argument("--scan-timeout", type=float, default=5.0, help="Scan timeout in seconds (default: 5)")
+    parser.add_argument("-m", "--monitor", action="store_true", help="Continuous streaming mode")
+    parser.add_argument("--duration", type=float, help="Stop monitor after N seconds (default: until Ctrl+C)")
+    parser.add_argument("--interactive", action="store_true", help="Interactive command mode")
+    parser.add_argument("--debug-on", action="store_true", help="Start CONTINUOUS streaming and exit (stream keeps going on device)")
+    parser.add_argument("--debug-off", action="store_true", help="Stop streaming and exit")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(run(args))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Add `0x25` BLE write handler that streams the 41-byte ADS1232 debug packet over the existing notify characteristic (`fff4`). USB and BLE paths share `buildAdsDebugPacket()`.

Modes (data[2]):
- `0x00` — OFF
- `0x01` — CONTINUOUS (rate-limited to ~10 Hz)
- `0x02` — SINGLE (auto-clears to OFF after one notify)

## Why

USB-cable drag during HDS Doctor diagnostics was producing false drift failures (Basecamp [Decent Diaspora #9856380088](https://3.basecamp.com/3671212/buckets/7351439/messages/9856380088)). BLE eliminates the mechanical interference. Closes #48.

## Test plan

- [ ] Write `03 25 02 24` to `36f5` → one 41-byte notify on `fff4`
- [ ] Write `03 25 01 26` → continuous stream (~10/s)
- [ ] Write `03 25 00 26` → stream stops
- [ ] USB debug path still works
- [ ] Both paths can run concurrently