### PR TITLE
fix: compute BLE heartbeat checksum via calculateXOR

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -579,7 +579,7 @@ void buildHeartBeatPacket(byte data[7]) {
   data[3] = 0xFF;
   data[4] = 0xFF;
   data[5] = 0x00;
-  data[6] = 0x0A;  // Checksum (can also use calculateXOR)
+  data[6] = calculateXOR(data, 6);
 }
 
 // Send heartbeat via BLE


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `0x0A` checksum byte in `buildHeartBeatPacket` with `calculateXOR(data, 6)` so the byte stays valid if the preceding payload bytes ever change.

Opened as a draft checkpoint while investigating an unrelated issue where the on-device HTTP server stalls mid-body on `GET /` (WebSocket on `/snapshot` is unaffected).

## Test plan
- [ ] Pair scale over BLE and confirm heartbeat keeps the connection alive (no premature disconnect)
- [ ] Confirm heartbeat byte 6 matches XOR of bytes 0-5 on the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)