### PR TITLE
Add active settings status display

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -394,7 +394,7 @@ void flipScreenOn() {
   actionMessage = "Flip On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_screenFlipped, b_screenFlipped);
+  EEPROM.put(i_addr_screenFlipped, (bool)b_screenFlipped);
   EEPROM.commit();
   u8g2.setDisplayRotation(U8G2_R0);
   Serial.println("Screen flipped...On");
@@ -405,7 +405,7 @@ void flipScreenOff() {
   actionMessage = "Flip Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_screenFlipped, b_screenFlipped);
+  EEPROM.put(i_addr_screenFlipped, (bool)b_screenFlipped);
   EEPROM.commit();
   u8g2.setDisplayRotation(U8G2_R2);
   Serial.println("Screen flipped...Off");
@@ -416,7 +416,7 @@ void timeOnTopOn() {
   actionMessage = "Time On Top";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_timeOnTop, b_timeOnTop);
+  EEPROM.put(i_addr_timeOnTop, (bool)b_timeOnTop);
   EEPROM.commit();
   Serial.println("Time On Top");
 }
@@ -426,7 +426,7 @@ void timeOnTopOff() {
   actionMessage = "Weight On Top";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_timeOnTop, b_timeOnTop);
+  EEPROM.put(i_addr_timeOnTop, (bool)b_timeOnTop);
   EEPROM.commit();
   Serial.println("Weight On Top");
 }
@@ -476,7 +476,7 @@ void quickBootOn() {
   actionMessage = "Quick Boot On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_quickBoot, b_quickBoot);
+  EEPROM.put(i_addr_quickBoot, (bool)b_quickBoot);
   EEPROM.commit();
   Serial.println("Quick boot on stored in EEPROM.");
 }
@@ -486,7 +486,7 @@ void quickBootOff() {
   actionMessage = "Quick Boot Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_quickBoot, b_quickBoot);
+  EEPROM.put(i_addr_quickBoot, (bool)b_quickBoot);
   EEPROM.commit();
   Serial.println("Quick boot off stored in EEPROM.");
 }

--- a/include/menu.h
+++ b/include/menu.h
@@ -329,20 +329,23 @@ void showStatus() {
   }
 
   char wifiLine[32];
-  char bleLine[24];
-  char heartbeatLine[24];
-  char sleepLine[24];
+  char bleLine[32];
+  char sleepLine[32];
+  char driftLine[32];
   snprintf(wifiLine, sizeof(wifiLine), "WiFi:%s %s %s",
            b_wifiOnBoot ? "On" : "Off",
            wifiCredentialsSaved() ? "Saved" : "NoCred",
            wifiRunState);
-  snprintf(bleLine, sizeof(bleLine), "BLE:%s Btn:%s",
+  snprintf(bleLine, sizeof(bleLine), "BLE:%s Btn:%s HB:%s",
            b_ble_enabled ? "On" : "Off",
-           b_btnFuncWhileConnected ? "On" : "Off");
-  snprintf(heartbeatLine, sizeof(heartbeatLine), "Heartbeat:%s",
+           b_btnFuncWhileConnected ? "On" : "Off",
            b_requireHeartBeat ? "On" : "Off");
-  snprintf(sleepLine, sizeof(sleepLine), "AutoSleep:%s 15m",
-           b_autoSleep ? "On" : "Off");
+  snprintf(sleepLine, sizeof(sleepLine), "Sleep:%s Quick:%s",
+           b_autoSleep ? "On" : "Off",
+           b_quickBoot ? "On" : "Off");
+  snprintf(driftLine, sizeof(driftLine), "T:%s Drift:%.3fg",
+           b_timeOnTop ? "Top" : "Bot",
+           f_maxDriftCompensation);
 
   u8g2.firstPage();
   do {
@@ -350,8 +353,8 @@ void showStatus() {
     u8g2.drawStr(0, 10, "Status");
     u8g2.drawStr(0, 22, wifiLine);
     u8g2.drawStr(0, 34, bleLine);
-    u8g2.drawStr(0, 46, heartbeatLine);
-    u8g2.drawStr(0, 58, sleepLine);
+    u8g2.drawStr(0, 46, sleepLine);
+    u8g2.drawStr(0, 58, driftLine);
   } while (u8g2.nextPage());
   delay(1000);
   while (b_showStatusData) {

--- a/include/menu.h
+++ b/include/menu.h
@@ -10,6 +10,7 @@ bool b_showAbout = false;
 bool b_showLogo = false;
 bool b_showNumber = false;
 bool b_showWifiData = false;
+bool b_showStatusData = false;
 String actionMessage = "Default";
 String actionMessage2 = "Default";
 unsigned long t_actionMessage = 0;
@@ -41,6 +42,7 @@ void heartbeatOff();
 void calibrate();
 void drawButton();
 void wifiUpdate();
+void showStatus();
 void showAbout();
 void showMenu();
 void showLogo();
@@ -73,6 +75,7 @@ Menu menuBuzzer = { "Buzzer", NULL, NULL, NULL };
 #endif
 Menu menuCalibration = { "Calibration", NULL, NULL, NULL };
 Menu menuWifi = { "WiFi Settings", NULL, NULL, NULL };
+Menu menuStatus = { "Status", showStatus, NULL, NULL };
 // Menu menuWiFiUpdate = {"WiFi Update", NULL, NULL, NULL};
 Menu menuAbout = { "About", showAbout, NULL, NULL };
 Menu menuLogo = { "Show Logo", showLogo, NULL, NULL };
@@ -180,7 +183,7 @@ Menu *mainMenu[] = {
 #ifdef BUZZER
   &menuBuzzer,
 #endif
-  &menuCalibration, &menuWifi,
+  &menuCalibration, &menuWifi, &menuStatus,
   // &menuWiFiUpdate,
   &menuAbout, &menuLogo, &menuHeartbeat, &menuFlipScreen, &menuTimeOnTop,
   &menuBtnFuncWhileConnected, &menuAutoSleep, &menuQuickBoot, &menuDriftComp,
@@ -259,6 +262,7 @@ void buzzerOff() {
 #endif
 
 void toggleWifiOn() {
+  b_wifiOnBoot = true;
   actionMessage = "WiFi Enabled";
   actionMessage2 = "Restart scale";
   t_actionMessage = millis();
@@ -269,7 +273,7 @@ void toggleWifiOn() {
 }
 
 void toggleWifiOff() {
-  bool wifiEnabled = false;
+  b_wifiOnBoot = false;
   actionMessage = "WiFi Disabled";
   actionMessage2 = "Restart scale";
   t_actionMessage = millis();
@@ -310,6 +314,53 @@ void showWifiStatus() {
   }
 }
 
+void showStatus() {
+  b_showStatusData = true;
+
+  const char *wifiRunState = "Idle";
+  if (b_wifiEnabled) {
+    if (WiFi.getMode() == WIFI_AP) {
+      wifiRunState = "AP";
+    } else if (WiFi.status() == WL_CONNECTED) {
+      wifiRunState = "Conn";
+    } else {
+      wifiRunState = "Wait";
+    }
+  }
+
+  char wifiLine[32];
+  char bleLine[24];
+  char heartbeatLine[24];
+  char sleepLine[24];
+  snprintf(wifiLine, sizeof(wifiLine), "WiFi:%s %s %s",
+           b_wifiOnBoot ? "On" : "Off",
+           wifiCredentialsSaved() ? "Saved" : "NoCred",
+           wifiRunState);
+  snprintf(bleLine, sizeof(bleLine), "BLE:%s Btn:%s",
+           b_ble_enabled ? "On" : "Off",
+           b_btnFuncWhileConnected ? "On" : "Off");
+  snprintf(heartbeatLine, sizeof(heartbeatLine), "Heartbeat:%s",
+           b_requireHeartBeat ? "On" : "Off");
+  snprintf(sleepLine, sizeof(sleepLine), "AutoSleep:%s 15m",
+           b_autoSleep ? "On" : "Off");
+
+  u8g2.firstPage();
+  do {
+    u8g2.setFont(u8g2_font_6x12_tr);
+    u8g2.drawStr(0, 10, "Status");
+    u8g2.drawStr(0, 22, wifiLine);
+    u8g2.drawStr(0, 34, bleLine);
+    u8g2.drawStr(0, 46, heartbeatLine);
+    u8g2.drawStr(0, 58, sleepLine);
+  } while (u8g2.nextPage());
+  delay(1000);
+  while (b_showStatusData) {
+    if (digitalRead(BUTTON_SQUARE) == LOW) {
+      b_showStatusData = false;
+    }
+  }
+}
+
 void resetWifi() {
   saveCredentials("", "");
   actionMessage = "WiFi Reset";
@@ -323,7 +374,7 @@ void heartbeatOn() {
   actionMessage = "Heartbeat On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_requireHeartBeat, b_requireHeartBeat);
+  EEPROM.put(i_addr_requireHeartBeat, (bool)b_requireHeartBeat);
   EEPROM.commit();
   Serial.println("Heartbeat detection...On");
 }
@@ -333,7 +384,7 @@ void heartbeatOff() {
   actionMessage = "Heartbeat Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_requireHeartBeat, b_requireHeartBeat);
+  EEPROM.put(i_addr_requireHeartBeat, (bool)b_requireHeartBeat);
   EEPROM.commit();
   Serial.println("Heartbeat detection...Off");
 }
@@ -385,7 +436,7 @@ void btnFuncWhileConnectedOn() {
   actionMessage = "BLE Btns On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_btnFuncWhileConnected, b_btnFuncWhileConnected);
+  EEPROM.put(i_addr_btnFuncWhileConnected, (bool)b_btnFuncWhileConnected);
   EEPROM.commit();
   Serial.println("BLE Btns On");
 }
@@ -395,7 +446,7 @@ void btnFuncWhileConnectedOff() {
   actionMessage = "BLE Btns Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_btnFuncWhileConnected, b_btnFuncWhileConnected);
+  EEPROM.put(i_addr_btnFuncWhileConnected, (bool)b_btnFuncWhileConnected);
   EEPROM.commit();
   Serial.println("BLE Btns Off");
 }
@@ -405,7 +456,7 @@ void autoSleepOn() {
   actionMessage = "Autosleep On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_autoSleep, b_autoSleep);
+  EEPROM.put(i_addr_autoSleep, (bool)b_autoSleep);
   EEPROM.commit();
   Serial.println("Autosleep on stored in EEPROM.");
 }
@@ -415,7 +466,7 @@ void autoSleepOff() {
   actionMessage = "Autosleep Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_autoSleep, b_autoSleep);
+  EEPROM.put(i_addr_autoSleep, (bool)b_autoSleep);
   EEPROM.commit();
   Serial.println("Autosleep off stored in EEPROM.");
 }

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -58,8 +58,8 @@ unsigned long t_firstConnect = 0;
 // volatile: read by the AsyncTCP task in the WS status frame, written by the
 // main-loop menu/EEPROM restore paths.
 volatile bool b_requireHeartBeat = true;
-bool b_screenFlipped = false;
-bool b_timeOnTop = false;
+volatile bool b_screenFlipped = false;
+volatile bool b_timeOnTop = false;
 volatile bool b_btnFuncWhileConnected = false;
 
 //
@@ -170,7 +170,7 @@ bool b_ads1115InitFail = true;  //ads1115 not detected flag
 // volatile: surfaced from AsyncTCP status while menu/setup code updates them.
 volatile bool b_wifiOnBoot = false;
 volatile bool b_autoSleep = true;
-bool b_quickBoot = false;
+volatile bool b_quickBoot = false;
 unsigned int i_buttonBootDelay = 500;
 bool b_showChargingUI = false;
 

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -3,7 +3,9 @@
 //declaration
 
 //ble
-bool b_ble_enabled = false;
+// volatile: read by the AsyncTCP task in the WS status frame, written by the
+// main loop during boot/charging-mode transitions.
+volatile bool b_ble_enabled = false;
 bool b_usbweight_enabled = false;
 unsigned long weightBleNotifyInterval = 100;  // BLE notify interval (ms). Fixed at 100ms (10Hz); not runtime-configurable over BLE.
 unsigned long weightUsbNotifyInterval = 100;  // USB binary notify interval (ms)
@@ -53,10 +55,12 @@ volatile uint32_t wsPendingMask = 0;
 int i_onWrite_counter = 0;
 unsigned long t_heartBeat = 0;
 unsigned long t_firstConnect = 0;
-bool b_requireHeartBeat = true;
+// volatile: read by the AsyncTCP task in the WS status frame, written by the
+// main-loop menu/EEPROM restore paths.
+volatile bool b_requireHeartBeat = true;
 bool b_screenFlipped = false;
 bool b_timeOnTop = false;
-bool b_btnFuncWhileConnected = false;
+volatile bool b_btnFuncWhileConnected = false;
 
 //
 int windowLength = 5;  // default window length
@@ -163,8 +167,9 @@ int i_icon = 0;  //充电指示电量数字0-6
 int i_setContainerWeight = 0;
 float f_filtered_temperature = 0;
 bool b_ads1115InitFail = true;  //ads1115 not detected flag
-bool b_wifiOnBoot = false;
-bool b_autoSleep = true;
+// volatile: surfaced from AsyncTCP status while menu/setup code updates them.
+volatile bool b_wifiOnBoot = false;
+volatile bool b_autoSleep = true;
 bool b_quickBoot = false;
 unsigned int i_buttonBootDelay = 500;
 bool b_showChargingUI = false;

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -235,12 +235,8 @@ const char *websocketWifiModeName() {
   return "off";
 }
 
-const char *websocketScaleModeName() {
-  return b_mode == 1 ? "espresso" : "pourover";
-}
-
 void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
-  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15,\"quick_boot_enabled\":%s,\"button_boot_delay_ms\":%u,\"screen_flipped\":%s,\"time_on_top\":%s,\"drift_compensation_max_grams\":%.3f,\"buzzer_enabled\":%s,\"mode\":%d,\"mode_name\":\"%s\",\"pourover_target_grams\":%.2f,\"espresso_target_grams\":%.2f,\"calibration_factor\":%.3f,\"battery_calibration_factor\":%.3f}",
+  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15,\"quick_boot_enabled\":%s,\"time_on_top\":%s,\"drift_compensation_max_grams\":%.3f}",
                  status,
                  FIRMWARE_VER,
                  f_displayedValue,
@@ -267,17 +263,8 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
                  b_requireHeartBeat ? "true" : "false",
                  b_autoSleep ? "true" : "false",
                  b_quickBoot ? "true" : "false",
-                 i_buttonBootDelay,
-                 b_screenFlipped ? "true" : "false",
                  b_timeOnTop ? "true" : "false",
-                 f_maxDriftCompensation,
-                 b_beep ? "true" : "false",
-                 b_mode,
-                 websocketScaleModeName(),
-                 INPUTCOFFEEPOUROVER,
-                 INPUTCOFFEEESPRESSO,
-                 f_calibration_value,
-                 f_batteryCalibrationFactor);
+                 f_maxDriftCompensation);
 }
 
 // Broadcast via printfAll(): it holds the library's client-list mutex and

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -235,8 +235,12 @@ const char *websocketWifiModeName() {
   return "off";
 }
 
+const char *websocketScaleModeName() {
+  return b_mode == 1 ? "espresso" : "pourover";
+}
+
 void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
-  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15}",
+  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15,\"quick_boot_enabled\":%s,\"button_boot_delay_ms\":%u,\"screen_flipped\":%s,\"time_on_top\":%s,\"drift_compensation_max_grams\":%.3f,\"buzzer_enabled\":%s,\"mode\":%d,\"mode_name\":\"%s\",\"pourover_target_grams\":%.2f,\"espresso_target_grams\":%.2f,\"calibration_factor\":%.3f,\"battery_calibration_factor\":%.3f}",
                  status,
                  FIRMWARE_VER,
                  f_displayedValue,
@@ -261,7 +265,19 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
                  deviceConnected ? "true" : "false",
                  b_btnFuncWhileConnected ? "true" : "false",
                  b_requireHeartBeat ? "true" : "false",
-                 b_autoSleep ? "true" : "false");
+                 b_autoSleep ? "true" : "false",
+                 b_quickBoot ? "true" : "false",
+                 i_buttonBootDelay,
+                 b_screenFlipped ? "true" : "false",
+                 b_timeOnTop ? "true" : "false",
+                 f_maxDriftCompensation,
+                 b_beep ? "true" : "false",
+                 b_mode,
+                 websocketScaleModeName(),
+                 INPUTCOFFEEPOUROVER,
+                 INPUTCOFFEEESPRESSO,
+                 f_calibration_value,
+                 f_batteryCalibrationFactor);
 }
 
 // Broadcast via printfAll(): it holds the library's client-list mutex and

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -221,8 +221,22 @@ void sendWebsocketRateInfo(AsyncWebSocketClient *client, const char *status) {
                  hz);
 }
 
+const char *websocketWifiModeName() {
+  wifi_mode_t mode = WiFi.getMode();
+  if (mode == WIFI_STA) {
+    return "sta";
+  }
+  if (mode == WIFI_AP) {
+    return "ap";
+  }
+  if (mode == WIFI_AP_STA) {
+    return "sta_ap";
+  }
+  return "off";
+}
+
 void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
-  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu}",
+  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15}",
                  status,
                  FIRMWARE_VER,
                  f_displayedValue,
@@ -237,7 +251,17 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
                  b_softSleep ? "true" : "false",
                  b_websocketEventsEnabled ? "true" : "false",
                  websocketRateForInterval(weightWebsocketNotifyInterval),
-                 weightWebsocketNotifyInterval);
+                 weightWebsocketNotifyInterval,
+                 b_wifiOnBoot ? "true" : "false",
+                 b_wifiEnabled ? "true" : "false",
+                 WiFi.status() == WL_CONNECTED ? "true" : "false",
+                 websocketWifiModeName(),
+                 wifiCredentialsSaved() ? "true" : "false",
+                 b_ble_enabled ? "true" : "false",
+                 deviceConnected ? "true" : "false",
+                 b_btnFuncWhileConnected ? "true" : "false",
+                 b_requireHeartBeat ? "true" : "false",
+                 b_autoSleep ? "true" : "false");
 }
 
 // Broadcast via printfAll(): it holds the library's client-list mutex and

--- a/include/wifi_setup.h
+++ b/include/wifi_setup.h
@@ -7,6 +7,7 @@
 void setupWifi();
 void stopWifi();
 void saveCredentials(String ssid, String pass); // ssid, pass
+bool wifiCredentialsSaved();
 
 // Periodic health log + STA reconnect supervisor; call once per main-loop pass
 // when WiFi is enabled. Recovers from a silent STA disconnect (which the old
@@ -17,7 +18,7 @@ void saveCredentials(String ssid, String pass); // ssid, pass
 // isn't interrupted, then fires regardless once that window passes.
 void wifiSupervise();
 
-extern bool b_wifiEnabled;
+extern volatile bool b_wifiEnabled;
 
 extern const char *wifiPrefsKey;
 extern const char *wifiSSIDKey;

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -9,7 +9,7 @@
 #include <Preferences.h>
 #include <WiFi.h>
 
-bool b_wifiEnabled = false;
+volatile bool b_wifiEnabled = false;
 // Set by the GOT_IP WiFi event; the main loop (wifiSupervise) consumes it and
 // (re)advertises mDNS, keeping all mDNS work off the WiFi-event task.
 static volatile bool g_mdnsAdvertisePending = false;
@@ -27,6 +27,7 @@ private:
   String ssid = "";
   String pass = "";
   Preferences preferences;
+  bool initialized = false;
 
 public:
   String getSSID() { return ssid; }
@@ -301,11 +302,24 @@ void saveCredentials(String ssid, String pass) {
   params.saveCredentials(ssid, pass);
 }
 
+bool wifiCredentialsSaved() {
+  params.init();
+  return params.hasCredentials();
+}
+
 // ----------------------------------------------------
 // ------------------ WiFiParams ----------------------
 // ----------------------------------------------------
 
 void WiFiParams::saveCredentials(String ssid, String pass) {
+  if (!initialized) {
+    init();
+  }
+  if (!initialized) {
+    Serial.println("[prefs] could not save credentials -- NVS namespace unavailable");
+    return;
+  }
+
   if (this->ssid == ssid && this->pass == pass)
     return;
 
@@ -323,10 +337,14 @@ void WiFiParams::saveCredentials(String ssid, String pass) {
 }
 
 void WiFiParams::init() {
+  if (initialized) {
+    return;
+  }
   if (!preferences.begin(wifiPrefsKey)) {
     Serial.println("[prefs] could not open NVS namespace 'wifi' -- no stored credentials");
     return;
   }
+  initialized = true;
   if (!hasCredentials()) {
     this->ssid = preferences.getString(wifiSSIDKey, "");
     this->pass = preferences.getString(wifiPassKey, "");
@@ -336,5 +354,10 @@ void WiFiParams::init() {
 void WiFiParams::reset() {
   ssid = "";
   pass = "";
-  preferences.clear();
+  if (!initialized) {
+    init();
+  }
+  if (initialized) {
+    preferences.clear();
+  }
 }

--- a/tools/ws_feature_test.py
+++ b/tools/ws_feature_test.py
@@ -109,7 +109,12 @@ def main():
               "wifi_on_boot", "wifi_active", "wifi_connected", "wifi_mode",
               "wifi_credentials_saved", "ble_enabled", "ble_connected",
               "ble_buttons_enabled", "ble_heartbeat_required",
-              "auto_sleep_enabled", "auto_sleep_minutes")
+              "auto_sleep_enabled", "auto_sleep_minutes",
+              "quick_boot_enabled", "button_boot_delay_ms", "screen_flipped",
+              "time_on_top", "drift_compensation_max_grams",
+              "buzzer_enabled", "mode", "mode_name",
+              "pourover_target_grams", "espresso_target_grams",
+              "calibration_factor", "battery_calibration_factor")
     rec("status frame: all fields present, 'led' removed",
         all(k in st for k in fields) and "led" not in st,
         f"keys={sorted(st)}")

--- a/tools/ws_feature_test.py
+++ b/tools/ws_feature_test.py
@@ -105,7 +105,11 @@ def main():
     ws.send("status")
     st = recv_until(ws, is_type("status")) or {}
     fields = ("battery_percent", "timer_running", "timer_seconds", "display_on",
-              "low_power", "soft_sleep", "events_enabled", "rate_hz", "interval_ms")
+              "low_power", "soft_sleep", "events_enabled", "rate_hz", "interval_ms",
+              "wifi_on_boot", "wifi_active", "wifi_connected", "wifi_mode",
+              "wifi_credentials_saved", "ble_enabled", "ble_connected",
+              "ble_buttons_enabled", "ble_heartbeat_required",
+              "auto_sleep_enabled", "auto_sleep_minutes")
     rec("status frame: all fields present, 'led' removed",
         all(k in st for k in fields) and "led" not in st,
         f"keys={sorted(st)}")

--- a/tools/ws_feature_test.py
+++ b/tools/ws_feature_test.py
@@ -110,13 +110,13 @@ def main():
               "wifi_credentials_saved", "ble_enabled", "ble_connected",
               "ble_buttons_enabled", "ble_heartbeat_required",
               "auto_sleep_enabled", "auto_sleep_minutes",
-              "quick_boot_enabled", "button_boot_delay_ms", "screen_flipped",
-              "time_on_top", "drift_compensation_max_grams",
-              "buzzer_enabled", "mode", "mode_name",
-              "pourover_target_grams", "espresso_target_grams",
-              "calibration_factor", "battery_calibration_factor")
-    rec("status frame: all fields present, 'led' removed",
-        all(k in st for k in fields) and "led" not in st,
+              "quick_boot_enabled", "time_on_top", "drift_compensation_max_grams")
+    removed_fields = ("led", "button_boot_delay_ms", "screen_flipped",
+                      "buzzer_enabled", "mode", "mode_name",
+                      "pourover_target_grams", "espresso_target_grams",
+                      "calibration_factor", "battery_calibration_factor")
+    rec("status frame: current settings present, legacy fields removed",
+        all(k in st for k in fields) and not any(k in st for k in removed_fields),
         f"keys={sorted(st)}")
 
     rec("events on", (status_after(ws, "events on") or {}).get("events_enabled") is True)

--- a/web_apps/index.html
+++ b/web_apps/index.html
@@ -6,9 +6,12 @@
   <title>Available Apps</title>
   <style>
     body {
-      font-family: sans-serif;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       padding: 2rem;
       background: #f9f9f9;
+      color: #222;
+      max-width: 760px;
+      margin: 0 auto;
     }
     h1 {
       color: #333;
@@ -56,6 +59,13 @@
       color: green;
     }
 
+    .panel-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+      align-items: start;
+    }
+
     /* Weight display */
     .weight-display {
       margin-top: 2rem;
@@ -64,9 +74,9 @@
       border: 1px solid #ddd;
       border-radius: 0.5rem;
       box-shadow: 0 2px 5px rgba(0,0,0,0.05);
-      max-width: 300px;
+      max-width: none;
     }
-    #weight-display h2 {
+    .weight-display h2 {
       margin: 0 0 0.5rem 0;
       color: #333;
     }
@@ -88,6 +98,34 @@
     #tare-button:hover {
       background: #0056b3;
     }
+    .connection-state {
+      margin: 0.25rem 0 0.75rem;
+      color: #555;
+      font-size: 0.95rem;
+    }
+    .settings-list {
+      display: grid;
+      gap: 0.65rem;
+    }
+    .settings-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      border-bottom: 1px solid #eee;
+      padding-bottom: 0.55rem;
+    }
+    .settings-row:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+    .settings-row span {
+      color: #555;
+    }
+    .settings-row strong {
+      color: #222;
+      font-weight: 650;
+      text-align: right;
+    }
   </style>
 </head>
 <body>
@@ -108,11 +146,36 @@
       <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/programmers_guide_to_the_half_decent_scale">Documentation</a></li>
     </ul>
 
-  <!-- Weight Display and Tare Button -->
-  <div class="weight-display">
-    <h2>Weight</h2>
-    <div id="weight-value">-- g</div>
-    <button id="tare-button">Tare</button>
+  <div class="panel-grid">
+    <!-- Weight Display and Tare Button -->
+    <div class="weight-display">
+      <h2>Weight</h2>
+      <div id="weight-value">-- g</div>
+      <button id="tare-button">Tare</button>
+    </div>
+
+    <div class="weight-display">
+      <h2>Current Settings</h2>
+      <p id="connection-status" class="connection-state">Connecting</p>
+      <div class="settings-list">
+        <div class="settings-row">
+          <span>WiFi</span>
+          <strong id="setting-wifi">--</strong>
+        </div>
+        <div class="settings-row">
+          <span>BLE Buttons</span>
+          <strong id="setting-ble-buttons">--</strong>
+        </div>
+        <div class="settings-row">
+          <span>BLE Heartbeat</span>
+          <strong id="setting-ble-heartbeat">--</strong>
+        </div>
+        <div class="settings-row">
+          <span>Auto Sleep</span>
+          <strong id="setting-auto-sleep">--</strong>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- WiFi Setup Popup -->
@@ -162,13 +225,65 @@
     const ws = new WebSocket(`ws://${window.location.host}/snapshot`);
     const weightValue = document.getElementById('weight-value');
     const tareButton = document.getElementById('tare-button');
+    const connectionStatus = document.getElementById('connection-status');
+    const settingWifi = document.getElementById('setting-wifi');
+    const settingBleButtons = document.getElementById('setting-ble-buttons');
+    const settingBleHeartbeat = document.getElementById('setting-ble-heartbeat');
+    const settingAutoSleep = document.getElementById('setting-auto-sleep');
+
+    function sendStatusRequest() {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send('status');
+      }
+    }
+
+    function formatEnabled(value) {
+      return value ? 'enabled' : 'disabled';
+    }
+
+    function renderStatus(status) {
+      const wifiParts = [formatEnabled(status.wifi_on_boot)];
+      wifiParts.push(status.wifi_credentials_saved ? 'SSID saved' : 'no SSID saved');
+      if (status.wifi_active) {
+        if (status.wifi_mode === 'ap') {
+          wifiParts.push('AP mode');
+        } else if (status.wifi_connected) {
+          wifiParts.push('connected');
+        } else {
+          wifiParts.push('connecting');
+        }
+      }
+
+      settingWifi.textContent = wifiParts.join(', ');
+      settingBleButtons.textContent = status.ble_buttons_enabled ? 'active' : 'inactive';
+      settingBleHeartbeat.textContent = formatEnabled(status.ble_heartbeat_required);
+      settingAutoSleep.textContent = status.auto_sleep_enabled
+        ? `enabled (${status.auto_sleep_minutes || 15} min)`
+        : 'disabled';
+    }
+
+    ws.addEventListener('open', () => {
+      connectionStatus.textContent = 'Connected';
+      connectionStatus.style.color = '#207044';
+      sendStatusRequest();
+    });
 
     ws.addEventListener('message', (event) => {
-      const json = JSON.parse(event.data)
+      let json;
+      try {
+        json = JSON.parse(event.data);
+      } catch (err) {
+        return;
+      }
       if (json.grams != undefined) {
         weightValue.textContent = `${json.grams} g`;
       }
+      if (json.type === 'status') {
+        renderStatus(json);
+      }
     });
+
+    setInterval(sendStatusRequest, 5000);
 
     tareButton.addEventListener('click', () => {
       if (ws.readyState === WebSocket.OPEN) {
@@ -181,11 +296,15 @@
     ws.addEventListener('error', () => {
       weightValue.textContent = 'Connection error';
       weightValue.style.color = 'red';
+      connectionStatus.textContent = 'Connection error';
+      connectionStatus.style.color = 'red';
     });
 
     ws.addEventListener('close', () => {
       weightValue.textContent = 'Disconnected';
       weightValue.style.color = 'gray';
+      connectionStatus.textContent = 'Disconnected';
+      connectionStatus.style.color = 'gray';
     });
 
     document.getElementById('reset-wifi-button').addEventListener('click', async function (e) {

--- a/web_apps/index.html
+++ b/web_apps/index.html
@@ -3,33 +3,149 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Available Apps</title>
+  <title>Half Decent Scale</title>
   <style>
+    :root {
+      color-scheme: light;
+      --bg: #f4f5f6;
+      --surface: #fff;
+      --surface-hover: #f7f8f9;
+      --ink: #1f2328;
+      --ink-soft: #3f4650;
+      --muted: #5f6875;
+      --border: #d8dde3;
+      --border-soft: #e8ebef;
+      --accent: #0b7180;
+      --accent-strong: #075f6c;
+      --success: #118544;
+      --danger: #b42318;
+      --radius-sm: 6px;
+      --radius-md: 8px;
+      --radius-lg: 12px;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--ink);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
     body {
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      padding: 2rem;
-      background: #f9f9f9;
-      color: #222;
-      max-width: 760px;
       margin: 0 auto;
+      width: min(100%, 1080px);
+      padding: 24px 14px 28px;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: inherit;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
     }
+
     h1 {
-      color: #333;
+      margin: 0 0 18px;
+      color: var(--ink);
+      font-size: 25px;
+      line-height: 1.16;
+      letter-spacing: 0;
     }
+
+    h2 {
+      margin: 24px 0 10px;
+      color: var(--ink);
+      font-size: 18px;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
     ul {
       list-style: none;
       padding-left: 0;
+      margin: 0;
     }
+
     li {
-      margin: 0.5rem 0;
+      margin: 0;
     }
+
     a {
-      text-decoration: none;
-      color: #007bff;
-      font-size: 1.2rem;
+      color: var(--accent-strong);
+      font-size: 1rem;
+      font-weight: 650;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
     }
+
     a:hover {
-      text-decoration: underline;
+      color: #064f5a;
+    }
+
+    a:focus-visible,
+    button:focus-visible,
+    input:focus-visible {
+      outline: 3px solid rgba(11, 113, 128, .32);
+      outline-offset: 2px;
+    }
+
+    .app-header {
+      display: grid;
+      gap: 4px;
+      margin-bottom: 24px;
+    }
+
+    .subtitle {
+      margin: 0;
+      color: var(--muted);
+      font-size: 15px;
+      line-height: 1.4;
+    }
+
+    .section {
+      margin-top: 32px;
+    }
+
+    .section h2 {
+      margin-top: 0;
+    }
+
+    .app-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      grid-auto-rows: 72px;
+      gap: 12px;
+      margin-bottom: 4px;
+    }
+
+    .app-list a {
+      display: flex;
+      align-items: center;
+      height: 100%;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 12px 14px;
+      background: var(--surface);
+      color: var(--ink);
+      line-height: 1.2;
+      text-decoration: none;
+      transition: background-color .16s ease, border-color .16s ease;
+    }
+
+    .app-list a:hover {
+      border-color: #c3cbd4;
+      background: var(--surface-hover);
+    }
+
+    .docs-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 16px;
+      border-top: 1px solid var(--border-soft);
+      padding-top: 14px;
+      margin-bottom: 24px;
+    }
+
+    .docs-list a {
+      font-size: 14px;
     }
 
     /* WiFi popup styling */
@@ -45,106 +161,223 @@
     /*   box-shadow: 0 -2px 10px rgba(0,0,0,0.1); */
     /* } */
     #wifi-popup input {
-      padding: 0.4rem;
+      width: 100%;
+      height: 44px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 10px 11px;
+      background: var(--surface);
+      color: var(--ink);
       font-size: 1rem;
     }
-    #wifi-popup button {
-      padding: 0.5rem 1rem;
-      margin-top: 0.5rem;
+
+    #wifi-popup input::placeholder {
+      color: var(--muted);
+    }
+
+    #wifi-popup input:focus {
+      border-color: var(--accent);
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(11, 113, 128, .08);
+    }
+
+    #wifi-popup button,
+    #tare-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 44px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 9px 14px;
+      background: var(--surface);
+      color: var(--ink);
       font-size: 1rem;
+      font-weight: 650;
       cursor: pointer;
+      transition: background-color .16s ease, border-color .16s ease, transform .12s ease;
     }
+
+    #wifi-popup button:hover,
+    #tare-button:hover {
+      border-color: #c3cbd4;
+      background: var(--surface-hover);
+    }
+
+    #wifi-popup button:active,
+    #tare-button:active {
+      transform: translateY(1px);
+    }
+
     #wifi-status {
-      margin-top: 0.5rem;
-      color: green;
+      min-height: 20px;
+      margin-top: 0.75rem;
+      color: var(--success);
+      font-size: 14px;
+      line-height: 1.4;
     }
 
     .panel-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1rem;
-      align-items: start;
+      grid-template-columns: minmax(0, 1.15fr) minmax(280px, .85fr);
+      gap: 16px;
+      align-items: stretch;
+    }
+
+    .panel-grid .weight-display {
+      margin-top: 0;
     }
 
     /* Weight display */
     .weight-display {
-      margin-top: 2rem;
-      padding: 1rem;
-      background: #fff;
-      border: 1px solid #ddd;
-      border-radius: 0.5rem;
-      box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+      margin-top: 24px;
+      padding: 24px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: none;
       max-width: none;
     }
+
     .weight-display h2 {
-      margin: 0 0 0.5rem 0;
-      color: #333;
+      margin: 0 0 10px;
+      color: var(--ink);
     }
+
     #weight-value {
-      font-size: 2rem;
-      font-weight: bold;
-      color: #007bff;
+      min-height: 76px;
+      display: grid;
+      align-content: center;
+      color: var(--accent-strong);
+      font-size: 64px;
+      font-weight: 750;
+      line-height: .98;
+      letter-spacing: 0;
+      overflow-wrap: anywhere;
     }
+
     #tare-button {
-      margin-top: 1rem;
-      padding: 0.5rem 1rem;
-      font-size: 1rem;
-      background: #007bff;
-      color: white;
-      border: none;
-      border-radius: 0.25rem;
-      cursor: pointer;
+      min-width: 128px;
+      margin-top: 16px;
+      border-color: var(--accent-strong);
+      background: var(--accent-strong);
+      color: #fff;
     }
+
     #tare-button:hover {
-      background: #0056b3;
+      border-color: #064f5a;
+      background: #064f5a;
     }
+
     .connection-state {
       margin: 0.25rem 0 0.75rem;
-      color: #555;
+      color: var(--muted);
       font-size: 0.95rem;
     }
+
     .settings-list {
       display: grid;
-      gap: 0.65rem;
+      gap: 0;
+      border-top: 1px solid var(--border-soft);
     }
+
     .settings-row {
-      display: flex;
-      justify-content: space-between;
-      gap: 1rem;
-      border-bottom: 1px solid #eee;
-      padding-bottom: 0.55rem;
+      display: grid;
+      grid-template-columns: minmax(96px, .62fr) minmax(0, 1fr);
+      gap: 12px;
+      align-items: start;
+      border-bottom: 1px solid var(--border-soft);
+      padding: 11px 0;
     }
+
     .settings-row:last-child {
       border-bottom: 0;
-      padding-bottom: 0;
     }
+
     .settings-row span {
-      color: #555;
+      color: var(--muted);
+      font-size: 14px;
     }
+
     .settings-row strong {
-      color: #222;
+      color: var(--ink);
+      font-size: 14px;
       font-weight: 650;
+      line-height: 1.35;
       text-align: right;
+      overflow-wrap: anywhere;
+    }
+
+    #wifi-form {
+      display: grid;
+      grid-template-columns: minmax(180px, 1fr) minmax(180px, 1fr) 128px;
+      gap: 12px;
+      align-items: center;
+      max-width: 680px;
+    }
+
+    #reset-wifi-button {
+      margin-top: 12px;
+      min-width: 220px;
+      color: var(--ink-soft);
+    }
+
+    @media (max-width: 820px) {
+      .panel-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .weight-display {
+        padding: 16px;
+      }
+
+      #weight-value {
+        font-size: 54px;
+      }
+    }
+
+    @media (max-width: 520px) {
+      body {
+        padding-left: 12px;
+        padding-right: 12px;
+      }
+
+      .app-list {
+        grid-template-columns: 1fr;
+        grid-auto-rows: 64px;
+      }
+
+      #wifi-form {
+        grid-template-columns: 1fr;
+        max-width: none;
+      }
+
+      #wifi-popup input,
+      #wifi-popup button,
+      #tare-button {
+        width: 100%;
+      }
+
+      #weight-value {
+        font-size: 44px;
+      }
+
+      .settings-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
+      }
+
+      .settings-row strong {
+        text-align: left;
+      }
     }
   </style>
 </head>
 <body>
-  <h1>Available Apps</h1>
-  <ul>
-    <li><a href="Quality_Control_Assistant/quality_control.html">Quality Control Assistant</a></li>
-    <li><a href="Weigh_Save/weigh_save.html">Weigh Save</a></li>
-    <li><a href="dosing_assistant/dosing_assistant.html">Dosing assistant</a></li>
-    <li><a href="https://decentespresso.com/support/scale/js/cocktail_maker/index.adp">Make cocktails with your HDS</a></li>
-    <li><a href="update">Update firmware</a></li>
-  </ul>
-
-  <h2>Other useful links</h2>
-    <ul>
-      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/firmware_for_half_decent_scale">Firmware versions</a></li>
-      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/how_to_use_usbc_to_upgrade_your_hds_firmware_v300_and_above">Upgrading with USB-C</a></li>
-      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/how_to_use_wifi_to_upgrade_your_hds_firmware_v300_and_above">Upgrading via Wi-Fi</a></li>
-      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/programmers_guide_to_the_half_decent_scale">Documentation</a></li>
-    </ul>
+  <header class="app-header">
+    <h1>OpenScale</h1>
+    <p class="subtitle">Half Decent Scale control surface</p>
+  </header>
 
   <div class="panel-grid">
     <!-- Weight Display and Tare Button -->
@@ -174,9 +407,31 @@
           <span>Auto Sleep</span>
           <strong id="setting-auto-sleep">--</strong>
         </div>
+        <div class="settings-row">
+          <span>Quick Boot</span>
+          <strong id="setting-quick-boot">--</strong>
+        </div>
+        <div class="settings-row">
+          <span>Timer Position</span>
+          <strong id="setting-time-position">--</strong>
+        </div>
+        <div class="settings-row">
+          <span>Drift Comp</span>
+          <strong id="setting-drift-comp">--</strong>
+        </div>
       </div>
     </div>
   </div>
+
+  <section class="section" aria-labelledby="apps-title">
+    <h2 id="apps-title">Available Apps</h2>
+    <ul class="app-list">
+      <li><a href="Quality_Control_Assistant/quality_control.html">Quality Control Assistant</a></li>
+      <li><a href="Weigh_Save/weigh_save.html">Weigh Save</a></li>
+      <li><a href="dosing_assistant/dosing_assistant.html">Dosing assistant</a></li>
+      <li><a href="update">Update firmware</a></li>
+    </ul>
+  </section>
 
   <!-- WiFi Setup Popup -->
   <div id="wifi-popup" class="weight-display">
@@ -189,6 +444,17 @@
           <button id="reset-wifi-button">Reset WiFi settings</button>
     <p id="wifi-status"></p>
   </div>
+
+  <section class="section" aria-labelledby="links-title">
+    <h2 id="links-title">Other useful links</h2>
+    <ul class="docs-list">
+      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/firmware_for_half_decent_scale">Firmware versions</a></li>
+      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/how_to_use_usbc_to_upgrade_your_hds_firmware_v300_and_above">Upgrading with USB-C</a></li>
+      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/how_to_use_wifi_to_upgrade_your_hds_firmware_v300_and_above">Upgrading via Wi-Fi</a></li>
+      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/docs/programmers_guide_to_the_half_decent_scale">Documentation</a></li>
+      <li><a target="_blank" rel="noopener noreferrer" href="https://decentespresso.com/support/scale/js/cocktail_maker/index.adp">Cocktail recipes</a></li>
+    </ul>
+  </section>
 
   <script>
     // WiFi form submission
@@ -230,6 +496,9 @@
     const settingBleButtons = document.getElementById('setting-ble-buttons');
     const settingBleHeartbeat = document.getElementById('setting-ble-heartbeat');
     const settingAutoSleep = document.getElementById('setting-auto-sleep');
+    const settingQuickBoot = document.getElementById('setting-quick-boot');
+    const settingTimePosition = document.getElementById('setting-time-position');
+    const settingDriftComp = document.getElementById('setting-drift-comp');
 
     function sendStatusRequest() {
       if (ws.readyState === WebSocket.OPEN) {
@@ -239,6 +508,14 @@
 
     function formatEnabled(value) {
       return value ? 'enabled' : 'disabled';
+    }
+
+    function formatDriftComp(value) {
+      const grams = Number(value);
+      if (!Number.isFinite(grams) || grams <= 0) {
+        return 'off';
+      }
+      return `${grams.toFixed(3).replace(/0+$/, '').replace(/\.$/, '')} g`;
     }
 
     function renderStatus(status) {
@@ -260,6 +537,9 @@
       settingAutoSleep.textContent = status.auto_sleep_enabled
         ? `enabled (${status.auto_sleep_minutes || 15} min)`
         : 'disabled';
+      settingQuickBoot.textContent = formatEnabled(status.quick_boot_enabled);
+      settingTimePosition.textContent = status.time_on_top ? 'timer above weight' : 'weight above timer';
+      settingDriftComp.textContent = formatDriftComp(status.drift_compensation_max_grams);
     }
 
     ws.addEventListener('open', () => {


### PR DESCRIPTION
Refs #23

Adds a current settings display to:
- OLED setup menu via a new top-level Status item
- root web UI via the existing /snapshot WebSocket status frame

Also extends the WebSocket status frame with WiFi, BLE, heartbeat, and auto sleep settings.

Tested:
- pio run -e esp32s3
- flashed firmware and LittleFS to ESP32-S3
- HDS Settings page
- Wifi web page