### PR TITLE
fix: pick strongest BSSID across multi-AP SSIDs

### DIFF
--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -176,6 +176,24 @@ void setupWifi() {
   WiFi.onEvent(onWifiEvent);
   WiFi.setAutoReconnect(false);
 
+  // Multi-AP-aware connect policy. arduino-esp32's defaults are FAST_SCAN +
+  // persistent(true), which stop the scan at the first BSSID seen for the
+  // configured SSID and cache that BSSID in NVS. In a multi-AP setup (e.g.
+  // UniFi with the same SSID broadcast from several APs on different channels)
+  // that frequently associates to the wrong BSSID -- the one whose channel is
+  // scanned first, or the one cached from a previous association where the
+  // scale was somewhere else in the building. This makes every WiFi.begin()
+  // (initial connect + every supervisor reconnect) do a full scan of all
+  // channels and associate to the strongest matching BSSID right now, so the
+  // scale follows itself to whichever AP is currently closest and recovers
+  // from one AP going down without needing a reboot. Trade-off: ~1-2 extra
+  // seconds per begin() for the full-channel scan; well worth it. persistent
+  // off because we already own credential storage via the Preferences-backed
+  // WiFiParams, so the WiFi driver's NVS cache only hurts (stale BSSID hint).
+  WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+  WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
+  WiFi.persistent(false);
+
   if (params.hasCredentials()) {
     Serial.printf("trying to connect to wifi: %s\n", params.getSSID());
     connectToWifi();


### PR DESCRIPTION
## Summary

- Switch arduino-esp32 from FAST_SCAN to **WIFI_ALL_CHANNEL_SCAN** with **WIFI_CONNECT_AP_BY_SIGNAL** sort, and turn off `WiFi.persistent` so the WiFi driver doesn't carry a stale BSSID hint across reboots.
- Now every `WiFi.begin()` (boot-time connect AND every `wifiSupervise()` reconnect) scans every channel and associates to the **strongest matching BSSID** at that moment, instead of stopping at the first BSSID seen or using a cached BSSID from a previous location.

## Why

The Arduino default is FAST_SCAN: stop at the first channel where any BSSID matches the SSID. Plus `persistent(true)`, which caches the last successful BSSID in NVS. On a single-AP network this is fine. On a multi-AP network (UniFi, mesh, multi-room) the scale ends up sticky to whatever BSSID happened to be on the first-scanned channel — or to a cached BSSID from a previous location. Common symptom: the scale "won't connect to the right AP" or "is on the weak AP across the house when the strong one is right there."

Verified on a UniFi setup with two U7 APs both broadcasting the same IoT SSID:
- **Before:** scale repeatedly associated to the channel-6 AP at -91 dBm while ignoring the channel-11 AP at -49 dBm.
- **After:** boot scan saw both BSSIDs, sorted by signal, picked the -49 dBm one every time. When the radio environment changed (RSSI swapped to favor the other AP), the next reconnect followed automatically.

`WiFiParams` already owns credential storage via Preferences, so the WiFi driver's NVS cache only hurt here.

Trade-off: ~1-2 extra seconds per `WiFi.begin()` for the full-channel scan instead of stop-at-first. Boot-time GOT_IP measured at ~13 s vs ~10 s before. Well worth it for reliable association.

## Test plan

- [x] Build clean on `esp32s3` env.
- [x] Flash to hardware, verify boot scan finds both BSSIDs for the SSID and associates to the stronger one (-49 dBm channel-11 BSSID picked over -91 dBm channel-6 BSSID).
- [x] After environment change (Office AP weaker, Great Room AP stronger), reboot scale and verify it associates to whichever is now strongest, with no retries on the old BSSID.
- [x] Stable connection sustained, `disc=0 rec=0` for the test window.
- [ ] Live failover (disable currently-associated AP in controller, expect supervisor to find the other one on the next reconnect cycle without manual intervention) — to be run before merging if you want extra coverage.