### PR TITLE
fix: round oled weight display

### DIFF
--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1612,18 +1612,10 @@ void drawShutdownFail() {
 int i_weightInt;
 int i_weightFirstDecimal;
 void separateFloat(float number) {
-  // Extract the integer part
-  i_weightInt = (int)number;
-  if (number >= 0) {
-    b_negativeWeight = false;
-  } else {
-    b_negativeWeight = true;
-  }
-
-  // Calculate the decimal part by subtracting the integer part from the number
-  // and then multiplying by 10 to shift the first decimal digit into the integer place
-  float decimalPart = number - (float)(i_weightInt);
-  i_weightFirstDecimal = abs((int)(decimalPart * 10));
+  int roundedTenths = (int)roundf(number * 10.0f);
+  b_negativeWeight = roundedTenths < 0;
+  i_weightInt = roundedTenths / 10;
+  i_weightFirstDecimal = abs(roundedTenths % 10);
 }
 
 void drawWeight(float input) {
@@ -1674,7 +1666,7 @@ void drawWeight(float input) {
     separateFloat(input);
     char integerStr[10] = "-0";  // to save the - sign if the input is between -1 to 0
     char decimalStr[10] = "0";
-    if (input >= 0 || input <= -1) {
+    if (!b_negativeWeight || i_weightInt <= -1) {
       snprintf(integerStr, sizeof(integerStr), "%d", i_weightInt);
     }
     snprintf(decimalStr, sizeof(decimalStr), "%d", i_weightFirstDecimal);


### PR DESCRIPTION
Rounds the OLED weight display to one decimal place before splitting it into integer and decimal glyphs.

This fixes cases like 0.05g displaying as 0.0g on the OLED while the web UI shows 0.05g. The change is display-only; internal weight state and WebSocket/BLE/USB output paths are unchanged.

Tested:
- Uploaded to ESP32-S3
- Verified firmware build with `pio run -e esp32s3`