### PR TITLE
fix: harden calibration fault handling

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -381,11 +381,15 @@ class MyCallbacks : public BLECharacteristicCallbacks {
           }
           if (data[2] == 0x00) {
             Serial.println("Manual Calibration via BLE");
+            b_menu = false;
+            i_cal_weight = 0;
             i_button_cal_status = 1;
             i_calibration = 0;
             b_calibration = true;
           } else if (data[2] == 0x01) {
             Serial.println("Smart Calibration via BLE");
+            b_menu = false;
+            i_cal_weight = 0;
             i_button_cal_status = 1;
             i_calibration = 1;
             b_calibration = true;

--- a/include/calibration_validation.h
+++ b/include/calibration_validation.h
@@ -1,0 +1,155 @@
+#ifndef CALIBRATION_VALIDATION_H
+#define CALIBRATION_VALIDATION_H
+
+#include <math.h>
+#include <stdint.h>
+
+const float CALIBRATION_VALUE_DEFAULT = 1000.0f;
+const float CALIBRATION_VALUE_MIN_ABS = 1.0f;
+const float CALIBRATION_VALUE_MAX_ABS = 1000000.0f;
+const float CALIBRATION_KNOWN_MASS_MIN_G = 1.0f;
+const float CALIBRATION_VERIFY_MIN_TOLERANCE_G = 0.5f;
+const float CALIBRATION_VERIFY_TOLERANCE_RATIO = 0.03f;
+const float CALIBRATION_STABILITY_MAX_G = 0.5f;
+const uint8_t CALIBRATION_MIN_VALID_SAMPLES = 16;
+
+#ifndef CALIBRATION_ALLOW_NEGATIVE_FACTOR
+#define CALIBRATION_ALLOW_NEGATIVE_FACTOR 0
+#endif
+
+enum CalibrationRejectReason {
+  CAL_REJECT_NONE = 0,
+  CAL_REJECT_ADC_TIMEOUT,
+  CAL_REJECT_INSUFFICIENT_SAMPLES,
+  CAL_REJECT_ADC_RANGE,
+  CAL_REJECT_UNSTABLE_ZERO,
+  CAL_REJECT_UNSTABLE_LOAD,
+  CAL_REJECT_UNKNOWN_MASS,
+  CAL_REJECT_RAW_DELTA_TOO_SMALL,
+  CAL_REJECT_FACTOR_NEAR_ZERO,
+  CAL_REJECT_FACTOR_TOO_LARGE,
+  CAL_REJECT_FACTOR_SIGN,
+  CAL_REJECT_VERIFY_INVERTED,
+  CAL_REJECT_VERIFY_TOLERANCE,
+  CAL_REJECT_SMART_CAL_DISABLED,
+  CAL_REJECT_UNPLUG_USB
+};
+
+inline const char *calibrationRejectReasonText(CalibrationRejectReason reason) {
+  switch (reason) {
+    case CAL_REJECT_NONE: return "ok";
+    case CAL_REJECT_ADC_TIMEOUT: return "adc_timeout";
+    case CAL_REJECT_INSUFFICIENT_SAMPLES: return "insufficient_samples";
+    case CAL_REJECT_ADC_RANGE: return "adc_out_of_range";
+    case CAL_REJECT_UNSTABLE_ZERO: return "unstable_zero";
+    case CAL_REJECT_UNSTABLE_LOAD: return "unstable_load";
+    case CAL_REJECT_UNKNOWN_MASS: return "unknown_mass";
+    case CAL_REJECT_RAW_DELTA_TOO_SMALL: return "raw_delta_too_small";
+    case CAL_REJECT_FACTOR_NEAR_ZERO: return "factor_near_zero";
+    case CAL_REJECT_FACTOR_TOO_LARGE: return "factor_too_large";
+    case CAL_REJECT_FACTOR_SIGN: return "factor_sign";
+    case CAL_REJECT_VERIFY_INVERTED: return "verify_inverted";
+    case CAL_REJECT_VERIFY_TOLERANCE: return "verify_tolerance";
+    case CAL_REJECT_SMART_CAL_DISABLED: return "smart_cal_disabled";
+    case CAL_REJECT_UNPLUG_USB: return "unplug_usb";
+    default: return "unknown";
+  }
+}
+
+inline const char *calibrationRejectReasonDisplayText(CalibrationRejectReason reason) {
+  switch (reason) {
+    case CAL_REJECT_NONE: return "OK";
+    case CAL_REJECT_ADC_TIMEOUT: return "ADC timeout";
+    case CAL_REJECT_INSUFFICIENT_SAMPLES: return "Not enough samples";
+    case CAL_REJECT_ADC_RANGE: return "ADC out of range";
+    case CAL_REJECT_UNSTABLE_ZERO: return "Unstable zero";
+    case CAL_REJECT_UNSTABLE_LOAD: return "Unstable load";
+    case CAL_REJECT_UNKNOWN_MASS: return "Unknown mass";
+    case CAL_REJECT_RAW_DELTA_TOO_SMALL: return "No weight change";
+    case CAL_REJECT_FACTOR_NEAR_ZERO: return "Factor near zero";
+    case CAL_REJECT_FACTOR_TOO_LARGE: return "Factor too large";
+    case CAL_REJECT_FACTOR_SIGN: return "Wrong sign";
+    case CAL_REJECT_VERIFY_INVERTED: return "Inverted weight";
+    case CAL_REJECT_VERIFY_TOLERANCE: return "Verify failed";
+    case CAL_REJECT_SMART_CAL_DISABLED: return "Smart cal off";
+    case CAL_REJECT_UNPLUG_USB: return "Unplug USB";
+    default: return "unknown";
+  }
+}
+
+inline bool calibrationFactorSignAllowed(float value) {
+#if CALIBRATION_ALLOW_NEGATIVE_FACTOR
+  return value != 0.0f;
+#else
+  return value > 0.0f;
+#endif
+}
+
+inline bool isValidCalibrationValue(float value) {
+  float magnitude = fabsf(value);
+  return isfinite(value) &&
+         calibrationFactorSignAllowed(value) &&
+         magnitude >= CALIBRATION_VALUE_MIN_ABS &&
+         magnitude <= CALIBRATION_VALUE_MAX_ABS;
+}
+
+inline float calibrationVerifyTolerance(float knownMass) {
+  float ratioTolerance = fabsf(knownMass) * CALIBRATION_VERIFY_TOLERANCE_RATIO;
+  return ratioTolerance > CALIBRATION_VERIFY_MIN_TOLERANCE_G
+           ? ratioTolerance
+           : CALIBRATION_VERIFY_MIN_TOLERANCE_G;
+}
+
+inline float calibrationStabilityRawLimit(float currentFactor) {
+  float magnitude = fabsf(currentFactor);
+  if (!isfinite(magnitude) || magnitude < CALIBRATION_VALUE_MIN_ABS) {
+    magnitude = CALIBRATION_VALUE_DEFAULT;
+  }
+  float limit = magnitude * CALIBRATION_STABILITY_MAX_G;
+  return limit > 50.0f ? limit : 50.0f;
+}
+
+inline CalibrationRejectReason validateCalibrationCandidateBasics(float knownMass,
+                                                                  long rawDelta,
+                                                                  float candidateFactor) {
+  if (!isfinite(knownMass) || knownMass < CALIBRATION_KNOWN_MASS_MIN_G) {
+    return CAL_REJECT_UNKNOWN_MASS;
+  }
+  if (fabsf((float)rawDelta) < knownMass * CALIBRATION_VALUE_MIN_ABS) {
+    return CAL_REJECT_RAW_DELTA_TOO_SMALL;
+  }
+  if (!isfinite(candidateFactor)) {
+    return CAL_REJECT_FACTOR_NEAR_ZERO;
+  }
+  float magnitude = fabsf(candidateFactor);
+  if (magnitude < CALIBRATION_VALUE_MIN_ABS) {
+    return CAL_REJECT_FACTOR_NEAR_ZERO;
+  }
+  if (magnitude > CALIBRATION_VALUE_MAX_ABS) {
+    return CAL_REJECT_FACTOR_TOO_LARGE;
+  }
+#if CALIBRATION_ALLOW_NEGATIVE_FACTOR
+  if ((candidateFactor > 0.0f && rawDelta <= 0) ||
+      (candidateFactor < 0.0f && rawDelta >= 0)) {
+    return CAL_REJECT_FACTOR_SIGN;
+  }
+#else
+  if (candidateFactor <= 0.0f || rawDelta <= 0) {
+    return CAL_REJECT_FACTOR_SIGN;
+  }
+#endif
+  return CAL_REJECT_NONE;
+}
+
+inline CalibrationRejectReason validateCalibrationVerification(float knownMass,
+                                                               float verifiedWeight) {
+  if (!isfinite(verifiedWeight) || verifiedWeight <= 0.0f) {
+    return CAL_REJECT_VERIFY_INVERTED;
+  }
+  if (fabsf(verifiedWeight - knownMass) > calibrationVerifyTolerance(knownMass)) {
+    return CAL_REJECT_VERIFY_TOLERANCE;
+  }
+  return CAL_REJECT_NONE;
+}
+
+#endif

--- a/include/menu.h
+++ b/include/menu.h
@@ -553,29 +553,247 @@ void calibrate() {
   // calibration
 }
 
-void calibrationRefreshFailed() {
-  Serial.println("Calibration failed: ADC dataset refresh timeout");
+struct CalibrationRawCapture {
+  long raw = 0;
+  long firstRaw = 0;
+  long secondRaw = 0;
+  long spread = 0;
+  uint8_t validSamples = 0;
+  bool signalTimeout = false;
+  bool dataOutOfRange = false;
+};
+
+static bool b_calibrationSampleWindowActive = false;
+static bool b_calibrationZeroCaptured = false;
+static CalibrationRawCapture calibrationZeroCapture;
+
+void calibrationSetStatus(CalibrationRejectReason reason) {
+  snprintf(c_calibrationStatus, sizeof(c_calibrationStatus), "%s",
+           calibrationRejectReasonText(reason));
+  b_calibrationInvalid = reason != CAL_REJECT_NONE;
+}
+
+void calibrationResetLastDiagnostics() {
+  f_lastCalibrationCandidate = 0.0f;
+  f_lastCalibrationVerifiedWeight = 0.0f;
+  i_lastCalibrationZeroRaw = 0;
+  i_lastCalibrationLoadRaw = 0;
+  i_lastCalibrationRawDelta = 0;
+  i_lastCalibrationSpread = 0;
+}
+
+void calibrationEnsureSampleWindow() {
+  if (!b_calibrationSampleWindowActive) {
+    scale.setSamplesInUse(16);
+    b_calibrationSampleWindowActive = true;
+  }
+}
+
+void calibrationRestoreSampleWindow() {
+  if (b_calibrationSampleWindowActive) {
+    scale.setSamplesInUse(1);
+    b_calibrationSampleWindowActive = false;
+  }
+}
+
+void calibrationFinish(bool returnToMenu) {
+  i_button_cal_status = 0;
+  b_calibration = false;
+  b_calibrationZeroCaptured = false;
+  calibrationRestoreSampleWindow();
+  if (returnToMenu) {
+    b_menu = true;
+  }
+}
+
+void calibrationPrintDiagnostics(CalibrationRejectReason reason,
+                                 float previousFactor,
+                                 float candidateFactor,
+                                 const CalibrationRawCapture *zeroCapture,
+                                 const CalibrationRawCapture *loadCapture,
+                                 float verifiedWeight) {
+  long zeroRaw = zeroCapture != nullptr ? zeroCapture->raw : 0;
+  long loadRaw = loadCapture != nullptr ? loadCapture->raw : 0;
+  long rawDelta = loadRaw - zeroRaw;
+  Serial.print(F("Calibration "));
+  Serial.print(reason == CAL_REJECT_NONE ? F("accepted") : F("failed"));
+  Serial.print(F(": reason="));
+  Serial.print(calibrationRejectReasonText(reason));
+  Serial.print(F(" prev="));
+  Serial.print(previousFactor, 6);
+  Serial.print(F(" candidate="));
+  Serial.print(candidateFactor, 6);
+  Serial.print(F(" verified_g="));
+  Serial.print(verifiedWeight, 4);
+  Serial.print(F(" zero_raw="));
+  Serial.print(zeroRaw);
+  Serial.print(F(" load_raw="));
+  Serial.print(loadRaw);
+  Serial.print(F(" delta="));
+  Serial.print(rawDelta);
+  Serial.print(F(" zero_spread="));
+  Serial.print(zeroCapture != nullptr ? zeroCapture->spread : 0);
+  Serial.print(F(" load_spread="));
+  Serial.println(loadCapture != nullptr ? loadCapture->spread : 0);
+}
+
+void calibrationRecordDiagnostics(CalibrationRejectReason reason,
+                                  float candidateFactor,
+                                  const CalibrationRawCapture *zeroCapture,
+                                  const CalibrationRawCapture *loadCapture,
+                                  float verifiedWeight) {
+  calibrationSetStatus(reason);
+  f_lastCalibrationCandidate = candidateFactor;
+  f_lastCalibrationVerifiedWeight = verifiedWeight;
+  i_lastCalibrationZeroRaw = zeroCapture != nullptr ? zeroCapture->raw : 0;
+  i_lastCalibrationLoadRaw = loadCapture != nullptr ? loadCapture->raw : 0;
+  i_lastCalibrationRawDelta = i_lastCalibrationLoadRaw - i_lastCalibrationZeroRaw;
+  long zeroSpread = zeroCapture != nullptr ? zeroCapture->spread : 0;
+  long loadSpread = loadCapture != nullptr ? loadCapture->spread : 0;
+  i_lastCalibrationSpread = zeroSpread > loadSpread ? zeroSpread : loadSpread;
+}
+
+void calibrationShowFailure(CalibrationRejectReason reason) {
+  const char *reasonText = calibrationRejectReasonText(reason);
+  const char *displayText = calibrationRejectReasonDisplayText(reason);
+  Serial.print(F("Calibration failed: "));
+  Serial.println(reasonText);
   u8g2.firstPage();
   u8g2.setFont(FONT_S);
   do {
-    u8g2.drawUTF8(AC((char *)"Calibration failed"), AM(), (char *)"Calibration failed");
+    u8g2.drawUTF8(AC((char *)"Calibration failed"),
+                  u8g2.getMaxCharHeight() + i_margin_top,
+                  (char *)"Calibration failed");
+    u8g2.drawUTF8(AC((char *)displayText), LCDHeight - i_margin_bottom,
+                  (char *)displayText);
   } while (u8g2.nextPage());
 #ifdef BUZZER
   buzzer.off();
 #endif
   delay(1000);
-  i_button_cal_status = 0;
-  b_calibration = false;
-  scale.setSamplesInUse(1);
+}
+
+bool calibrationWaitForSample(ADS1232DebugInfo &info,
+                              int previousReadIndex,
+                              CalibrationRejectReason &failureReason) {
+  unsigned long start = millis();
+  unsigned long lastUpdate = start;
+  while (millis() - start < 4000) {
+    if (scale.update()) {
+      lastUpdate = millis();
+      info = scale.getDebugInfo();
+      if (info.signalTimeout) {
+        failureReason = CAL_REJECT_ADC_TIMEOUT;
+        return false;
+      }
+      if (info.dataOutOfRange) {
+        failureReason = CAL_REJECT_ADC_RANGE;
+        return false;
+      }
+      if (info.validSamples >= CALIBRATION_MIN_VALID_SAMPLES &&
+          (previousReadIndex < 0 || info.readIndex != previousReadIndex)) {
+        failureReason = CAL_REJECT_NONE;
+        return true;
+      }
+    } else if (millis() - lastUpdate > 1500 || scale.getSignalTimeoutFlag()) {
+      failureReason = CAL_REJECT_ADC_TIMEOUT;
+      return false;
+    }
+    delay(2);
+    yield();
+  }
+  info = scale.getDebugInfo();
+  failureReason = info.validSamples < CALIBRATION_MIN_VALID_SAMPLES
+                    ? CAL_REJECT_INSUFFICIENT_SAMPLES
+                    : CAL_REJECT_ADC_TIMEOUT;
+  return false;
+}
+
+bool calibrationCaptureRaw(CalibrationRawCapture &capture,
+                           CalibrationRejectReason unstableReason,
+                           CalibrationRejectReason &failureReason) {
+  calibrationEnsureSampleWindow();
+  ADS1232DebugInfo firstInfo;
+  ADS1232DebugInfo secondInfo;
+  if (!calibrationWaitForSample(firstInfo, -1, failureReason)) {
+    return false;
+  }
+  if (!calibrationWaitForSample(secondInfo, firstInfo.readIndex, failureReason)) {
+    return false;
+  }
+
+  capture.firstRaw = firstInfo.smoothedValue;
+  capture.secondRaw = secondInfo.smoothedValue;
+  long spread = capture.secondRaw - capture.firstRaw;
+  if (spread < 0) {
+    spread = -spread;
+  }
+  capture.spread = spread;
+  capture.raw = (capture.firstRaw + capture.secondRaw) / 2;
+  capture.validSamples = firstInfo.validSamples < secondInfo.validSamples
+                           ? firstInfo.validSamples
+                           : secondInfo.validSamples;
+  capture.signalTimeout = firstInfo.signalTimeout || secondInfo.signalTimeout;
+  capture.dataOutOfRange = firstInfo.dataOutOfRange || secondInfo.dataOutOfRange;
+
+  if ((float)capture.spread > calibrationStabilityRawLimit(f_calibration_value)) {
+    failureReason = unstableReason;
+    return false;
+  }
+
+  failureReason = CAL_REJECT_NONE;
+  return true;
+}
+
+void calibrationFail(CalibrationRejectReason reason,
+                     float previousFactor,
+                     float candidateFactor,
+                     const CalibrationRawCapture *zeroCapture,
+                     const CalibrationRawCapture *loadCapture,
+                     float verifiedWeight) {
+  f_calibration_value = previousFactor;
+  scale.setCalFactor(f_calibration_value);
+  calibrationRecordDiagnostics(reason, candidateFactor, zeroCapture, loadCapture,
+                               verifiedWeight);
+  calibrationPrintDiagnostics(reason, previousFactor, candidateFactor,
+                              zeroCapture, loadCapture, verifiedWeight);
+  calibrationShowFailure(reason);
+  calibrationFinish(false);
+}
+
+void calibrationSave(float previousCalibrationValue,
+                     float newCalibrationValue,
+                     const CalibrationRawCapture &zeroCapture,
+                     const CalibrationRawCapture &loadCapture,
+                     float verifiedWeight) {
+  f_calibration_value = newCalibrationValue;
+  scale.setCalFactor(f_calibration_value);
+  EEPROM.put(i_addr_calibration_value, f_calibration_value);
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040)
+  EEPROM.commit();
+#endif
+  calibrationRecordDiagnostics(CAL_REJECT_NONE, f_calibration_value,
+                               &zeroCapture, &loadCapture, verifiedWeight);
+  calibrationPrintDiagnostics(CAL_REJECT_NONE, previousCalibrationValue,
+                              f_calibration_value, &zeroCapture, &loadCapture,
+                              verifiedWeight);
 }
 
 void calibration(int input) {
   if (b_calibration == true) {
-    bool newDataReady = false;
     char c_calval[25];
+    if (input == 1) {
+      calibrationFail(CAL_REJECT_SMART_CAL_DISABLED, f_calibration_value, 0.0f,
+                      nullptr, nullptr, 0.0f);
+      return;
+    }
     if (i_button_cal_status == 1) {
       if (input == 0) {
-        scale.setSamplesInUse(16);
+        if (!b_calibrationSampleWindowActive) {
+          calibrationResetLastDiagnostics();
+          b_calibrationZeroCaptured = false;
+        }
+        calibrationEnsureSampleWindow();
         u8g2.firstPage();
         do {
           if (b_screenFlipped)
@@ -636,7 +854,7 @@ void calibration(int input) {
         } while (u8g2.nextPage());
       }
       if (input == 1) {
-        scale.setSamplesInUse(16);
+        calibrationEnsureSampleWindow();
         u8g2.firstPage();
         u8g2.setFont(FONT_S);
         do {
@@ -654,11 +872,14 @@ void calibration(int input) {
     if (i_button_cal_status == 2) {
       Serial.println("Before if check, i_cal_weight = " + String(i_cal_weight));
 
-      if (i_cal_weight == 0 || b_is_charging) {
+      if (i_cal_weight == 0) {
         // exit was selected, exit the calibration.
-        i_button_cal_status = 0;
-        b_calibration = false;
-        b_menu = true;
+        calibrationFinish(true);
+        return;
+      }
+      if (b_is_charging) {
+        calibrationFail(CAL_REJECT_UNPLUG_USB, f_calibration_value, 0.0f,
+                        nullptr, nullptr, 0.0f);
         return;
       }
       // scale.update();
@@ -725,7 +946,27 @@ void calibration(int input) {
                       (char *)"Calibrating 0g");
       } while (u8g2.nextPage());
 
+      float previousCalibrationValue = f_calibration_value;
+      CalibrationRejectReason zeroFailureReason = CAL_REJECT_NONE;
+      if (!calibrationCaptureRaw(calibrationZeroCapture,
+                                 CAL_REJECT_UNSTABLE_ZERO,
+                                 zeroFailureReason)) {
+        calibrationFail(zeroFailureReason, previousCalibrationValue, 0.0f,
+                        &calibrationZeroCapture, nullptr, 0.0f);
+        return;
+      }
       scale.tare();
+      b_calibrationZeroCaptured = true;
+      i_lastCalibrationZeroRaw = calibrationZeroCapture.raw;
+      i_lastCalibrationLoadRaw = 0;
+      i_lastCalibrationRawDelta = 0;
+      i_lastCalibrationSpread = calibrationZeroCapture.spread;
+      Serial.print(F("0g raw captured: "));
+      Serial.print(calibrationZeroCapture.raw);
+      Serial.print(F(" spread="));
+      Serial.print(calibrationZeroCapture.spread);
+      Serial.print(F(" valid="));
+      Serial.println(calibrationZeroCapture.validSamples);
       Serial.println(F("0g calibration done"));
       u8g2.firstPage();
       u8g2.setFont(FONT_S);
@@ -802,44 +1043,49 @@ void calibration(int input) {
         buzzer.off();
 #endif
         delay(1000);
-        double d_weight;
-        for (int i = 0; i < DATA_SET; i++) {
-          if (scale.update())
-            newDataReady = true;
-          if (newDataReady) {
-            d_weight = scale.getData();
-            Serial.println(d_weight);
-            newDataReady = false;
-            delay(100);
-          }
-        }
-        Serial.print("weight is ");
-        Serial.println(d_weight);
-        if (!scale.refreshDataSet()) {  // refresh the dataset to be sure that the known
-          calibrationRefreshFailed();   // mass is measured correct
+        float previousCalibrationValue = f_calibration_value;
+        if (!b_calibrationZeroCaptured) {
+          calibrationFail(CAL_REJECT_UNSTABLE_ZERO, previousCalibrationValue,
+                          0.0f, nullptr, nullptr, 0.0f);
           return;
         }
 
-        float previousCalibrationValue = f_calibration_value;
-        f_calibration_value = scale.getNewCalibration(
-          known_mass);  // get the new calibration value
-        if (!isValidCalibrationValue(f_calibration_value)) {
-          Serial.println("Calibration failed: invalid calibration value");
-          f_calibration_value = previousCalibrationValue;
-          scale.setCalFactor(f_calibration_value);
-          calibrationRefreshFailed();
+        CalibrationRawCapture loadCapture;
+        CalibrationRejectReason loadFailureReason = CAL_REJECT_NONE;
+        if (!calibrationCaptureRaw(loadCapture, CAL_REJECT_UNSTABLE_LOAD,
+                                   loadFailureReason)) {
+          calibrationFail(loadFailureReason, previousCalibrationValue, 0.0f,
+                          &calibrationZeroCapture, &loadCapture, 0.0f);
           return;
         }
+
+        long rawDelta = loadCapture.raw - calibrationZeroCapture.raw;
+        float candidateCalibrationValue = (float)rawDelta / known_mass;
+        CalibrationRejectReason validationReason =
+          validateCalibrationCandidateBasics(known_mass, rawDelta,
+                                             candidateCalibrationValue);
+        if (validationReason != CAL_REJECT_NONE) {
+          calibrationFail(validationReason, previousCalibrationValue,
+                          candidateCalibrationValue, &calibrationZeroCapture,
+                          &loadCapture, 0.0f);
+          return;
+        }
+
+        scale.setCalFactor(candidateCalibrationValue);
+        float verifiedWeight = scale.getData();
+        validationReason = validateCalibrationVerification(known_mass,
+                                                           verifiedWeight);
+        if (validationReason != CAL_REJECT_NONE) {
+          calibrationFail(validationReason, previousCalibrationValue,
+                          candidateCalibrationValue, &calibrationZeroCapture,
+                          &loadCapture, verifiedWeight);
+          return;
+        }
+
+        calibrationSave(previousCalibrationValue, candidateCalibrationValue,
+                        calibrationZeroCapture, loadCapture, verifiedWeight);
         Serial.print(F("New calibration value f: "));
         Serial.println(f_calibration_value);
-        // #if defined(ESP8266) || defined(ESP32) ||
-        // defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040)
-        //     EEPROM.begin(512);
-        // #endif
-        EEPROM.put(i_addr_calibration_value, f_calibration_value);
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040)
-        EEPROM.commit();
-#endif
         formatFloatSafe(c_calval, sizeof(c_calval), f_calibration_value, 2);
         Serial.print(F("New calibration value c: "));
         Serial.println(trim(c_calval));
@@ -861,206 +1107,10 @@ void calibration(int input) {
         buzzer.off();
 #endif
         delay(1000);
-        b_calibration = false;
-      }
-      if (input == 1) {
-        scale.update();
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)"Place any weight"),
-                        u8g2.getMaxCharHeight() + i_margin_top,
-                        (char *)"Place any weight");
-          u8g2.drawUTF8(AC((char *)"Wait: 3s"), LCDHeight - i_margin_bottom,
-                        (char *)"Wait: 3s");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)"Place any weight"),
-                        u8g2.getMaxCharHeight() + i_margin_top,
-                        (char *)"Place any weight");
-          u8g2.drawUTF8(AC((char *)"Wait: 2s"), LCDHeight - i_margin_bottom,
-                        (char *)"Wait: 2s");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)"Place any weight"),
-                        u8g2.getMaxCharHeight() + i_margin_top,
-                        (char *)"Place any weight");
-          u8g2.drawUTF8(AC((char *)"Wait: 1s"), LCDHeight - i_margin_bottom,
-                        (char *)"Wait: 1s");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-        scale.update();
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)"Reading weight"), AM(),
-                        (char *)"Reading weight");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-        i_button_cal_status++;
+        calibrationFinish(false);
+        return;
       }
     }
-    if (i_button_cal_status == 4) {
-      float known_mass = 0;
-      if (scale.update())
-        newDataReady = true;
-      if (newDataReady) {
-        float current_weight = scale.getData();
-        Serial.println(current_weight);
-//         bool valid_mass = false;
-//         for (int i = 1; i <= 40; i++) {
-//           // check from 50g to 2kg
-//           if (current_weight > i * 50 - 2 && current_weight < i * 50 + 2) {
-//             // check if the weight is within 2g
-//             known_mass = i * 50;
-//             valid_mass = true;
-//             break;
-//           }
-//         }
-
-//         if (!valid_mass) {
-//           char buffer[50];
-//           snprintf(buffer, sizeof(buffer), "%f.0g weight detected",
-//                    current_weight);
-//           Serial.println(F("Error: Invalid weight detected"));
-//           u8g2.firstPage();
-//           u8g2.setFont(FONT_S);
-//           do {
-//             u8g2.drawUTF8(AC((char *)"Error: Invalid"),
-//                           u8g2.getMaxCharHeight() + i_margin_top,
-//                           (char *)"Error: Invalid");
-//             u8g2.drawUTF8(AC((char *)trim(buffer)), LCDHeight - i_margin_bottom,
-//                           (char *)trim(buffer));
-//           } while (u8g2.nextPage());
-// #ifdef BUZZER
-//           buzzer.off();
-// #endif
-//           delay(1000);
-//           b_calibration = false;
-//           return;  // exit calibration
-//         }
-
-        char buffer[50];
-        snprintf(buffer, sizeof(buffer), "Place %.0fg weight", known_mass);
-
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)trim(buffer)),
-                        u8g2.getMaxCharHeight() + i_margin_top,
-                        (char *)trim(buffer));
-          u8g2.drawUTF8(AC((char *)"Wait: 3s"), LCDHeight - i_margin_bottom,
-                        (char *)"Wait: 3s");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)trim(buffer)),
-                        u8g2.getMaxCharHeight() + i_margin_top,
-                        (char *)trim(buffer));
-          u8g2.drawUTF8(AC((char *)"Wait: 2s"), LCDHeight - i_margin_bottom,
-                        (char *)"Wait: 2s");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)trim(buffer)),
-                        u8g2.getMaxCharHeight() + i_margin_top,
-                        (char *)trim(buffer));
-          u8g2.drawUTF8(AC((char *)"Wait: 1s"), LCDHeight - i_margin_bottom,
-                        (char *)"Wait: 1s");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)"Calibrating"), AM(), (char *)"Calibrating");
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-
-        scale.setSamplesInUse(16);
-        if (!scale.refreshDataSet()) {  // refresh the dataset to be sure that the known
-          calibrationRefreshFailed();   // mass is measured correct
-          return;
-        }
-        float previousCalibrationValue = f_calibration_value;
-        f_calibration_value = scale.getNewCalibration(
-          known_mass);  // get the new calibration value
-        if (!isValidCalibrationValue(f_calibration_value)) {
-          Serial.println("Calibration failed: invalid calibration value");
-          f_calibration_value = previousCalibrationValue;
-          scale.setCalFactor(f_calibration_value);
-          calibrationRefreshFailed();
-          return;
-        }
-        Serial.print(F("New calibration value f: "));
-        Serial.println(f_calibration_value);
-        EEPROM.put(i_addr_calibration_value, f_calibration_value);
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040)
-        EEPROM.commit();
-#endif
-        formatFloatSafe(c_calval, sizeof(c_calval), f_calibration_value, 2);
-        Serial.print(F("New calibration value c: "));
-        Serial.println(trim(c_calval));
-
-        u8g2.firstPage();
-        u8g2.setFont(FONT_S);
-        do {
-          u8g2.drawUTF8(AC((char *)"Recalibration done"), AM(),
-                        (char *)"Recalibration done");
-          // u8g2.drawUTF8(AC((char *)trim(c_calval)), LCDHeight -
-          // i_margin_bottom, (char *)trim(c_calval));
-        } while (u8g2.nextPage());
-#ifdef BUZZER
-        buzzer.off();
-#endif
-        delay(1000);
-#ifdef BUZZER
-        buzzer.beep(1, BUZZER_DURATION);
-        buzzer.off();
-#endif
-        delay(1000);
-        b_calibration = false;
-      }
-    }
-    scale.setSamplesInUse(1);
   }
 }
 

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <EEPROM.h>
 #include <math.h>
+#include "calibration_validation.h"
 
 //ble
 // volatile: read by the AsyncTCP task in the WS status frame, written by the
@@ -127,18 +128,15 @@ const size_t WELCOME_EEPROM_BYTES = 128;
 const size_t WELCOME_EEPROM_MAGIC_BYTES = 4;
 const size_t WELCOME_EEPROM_TEXT_BYTES = WELCOME_EEPROM_BYTES - WELCOME_EEPROM_MAGIC_BYTES;
 const char WELCOME_EEPROM_MAGIC[WELCOME_EEPROM_MAGIC_BYTES] = {'H', 'D', 'S', 'W'};
-const float CALIBRATION_VALUE_DEFAULT = 1000.0f;
-const float CALIBRATION_VALUE_MIN_ABS = 1.0f;
-const float CALIBRATION_VALUE_MAX_ABS = 1000000.0f;
-
-inline bool isValidCalibrationValue(float value) {
-  float magnitude = fabsf(value);
-  return isfinite(value) &&
-         magnitude >= CALIBRATION_VALUE_MIN_ABS &&
-         magnitude <= CALIBRATION_VALUE_MAX_ABS;
-}
-
 float f_calibration_value = CALIBRATION_VALUE_DEFAULT;   //称重单元校准值
+bool b_calibrationInvalid = false;
+char c_calibrationStatus[32] = "ok";
+float f_lastCalibrationCandidate = 0.0f;
+float f_lastCalibrationVerifiedWeight = 0.0f;
+long i_lastCalibrationZeroRaw = 0;
+long i_lastCalibrationLoadRaw = 0;
+long i_lastCalibrationRawDelta = 0;
+long i_lastCalibrationSpread = 0;
 float f_up_battery;          //开机时电池电压
 unsigned long t_up_battery;  //开机到现在时间
 

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -416,11 +416,15 @@ public:
       }
       if (data[2] == 0x00) {
         Serial.println("Manual Calibration via BLE");
+        b_menu = false;
+        i_cal_weight = 0;
         i_button_cal_status = 1;
         i_calibration = 0;
         b_calibration = true;
       } else if (data[2] == 0x01) {
         Serial.println("Smart Calibration via BLE");
+        b_menu = false;
+        i_cal_weight = 0;
         i_button_cal_status = 1;
         i_calibration = 1;
         b_calibration = true;
@@ -636,9 +640,18 @@ public:
         scale.setCalFactor(f_calibration_value);
         EEPROM.put(i_addr_calibration_value, f_calibration_value);
         EEPROM.commit();
+        b_calibrationInvalid = false;
+        snprintf(c_calibrationStatus, sizeof(c_calibrationStatus), "%s",
+                 calibrationRejectReasonText(CAL_REJECT_NONE));
       } else {
         Serial.print("Ignoring invalid calibration value: ");
         Serial.println(inputString.substring(3));
+        b_calibrationInvalid = true;
+        snprintf(c_calibrationStatus, sizeof(c_calibrationStatus), "%s",
+                 calibrationRejectReasonText(
+                   fabsf(newCalibrationValue) > CALIBRATION_VALUE_MAX_ABS
+                     ? CAL_REJECT_FACTOR_TOO_LARGE
+                     : CAL_REJECT_FACTOR_SIGN));
       }
     }
 
@@ -687,11 +700,17 @@ public:
     }
 
     if (inputString.startsWith("cal0")) {  //calibrate load cell 0
+      b_menu = false;
+      i_cal_weight = 0;
+      i_button_cal_status = 1;
       b_calibration = true;
       i_calibration = 0;
     }
 
     if (inputString.startsWith("cal1")) {  ////calibrate load cell 1
+      b_menu = false;
+      i_cal_weight = 0;
+      i_button_cal_status = 1;
       b_calibration = true;
       i_calibration = 1;
     }
@@ -738,6 +757,21 @@ public:
         Serial.print("SPS: "); Serial.print(info.sps, 2);
         Serial.print(" | ConvTime: "); Serial.print(info.conversionTimeMs, 3);
         Serial.print("ms | Valid: "); Serial.println(info.validSamples);
+        Serial.print("CalFactor: "); Serial.print(f_calibration_value, 2);
+        Serial.print(" | CalStatus: "); Serial.print(c_calibrationStatus);
+        Serial.print(" | CalInvalid: "); Serial.println(b_calibrationInvalid ? "true" : "false");
+        Serial.print("LastCal zero/load/delta: ");
+        Serial.print(i_lastCalibrationZeroRaw);
+        Serial.print(" / ");
+        Serial.print(i_lastCalibrationLoadRaw);
+        Serial.print(" / ");
+        Serial.println(i_lastCalibrationRawDelta);
+        Serial.print("LastCal candidate/verified/spread: ");
+        Serial.print(f_lastCalibrationCandidate, 2);
+        Serial.print(" / ");
+        Serial.print(f_lastCalibrationVerifiedWeight, 2);
+        Serial.print(" / ");
+        Serial.println(i_lastCalibrationSpread);
         Serial.println("==============================");
       }
     }

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -308,7 +308,7 @@ const char *websocketWifiModeName() {
 
 void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
   if (!wsClientHeapOk()) return;
-  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15,\"quick_boot_enabled\":%s,\"time_on_top\":%s,\"drift_compensation_max_grams\":%.3f,\"calibration_factor\":%.2f,\"calibration_invalid\":%s,\"calibration_status\":\"%s\",\"calibration_last_candidate\":%.2f,\"calibration_last_verified_grams\":%.2f,\"calibration_last_raw_delta\":%ld}",
+  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15,\"quick_boot_enabled\":%s,\"time_on_top\":%s,\"drift_compensation_max_grams\":%.3f}",
                  status,
                  FIRMWARE_VER,
                  f_displayedValue,
@@ -336,13 +336,7 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
                  b_autoSleep ? "true" : "false",
                  b_quickBoot ? "true" : "false",
                  b_timeOnTop ? "true" : "false",
-                 f_maxDriftCompensation,
-                 f_calibration_value,
-                 b_calibrationInvalid ? "true" : "false",
-                 c_calibrationStatus,
-                 f_lastCalibrationCandidate,
-                 f_lastCalibrationVerifiedWeight,
-                 i_lastCalibrationRawDelta);
+                 f_maxDriftCompensation);
 }
 
 // Broadcast via printfAll(): it holds the library's client-list mutex and

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -308,7 +308,7 @@ const char *websocketWifiModeName() {
 
 void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
   if (!wsClientHeapOk()) return;
-  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15,\"quick_boot_enabled\":%s,\"time_on_top\":%s,\"drift_compensation_max_grams\":%.3f}",
+  client->printf("{\"type\":\"status\",\"status\":\"%s\",\"protocol_version\":1,\"firmware_version\":\"%s\",\"grams\":%.2f,\"ms\":%lu,\"battery_percent\":%d,\"battery_voltage\":%.2f,\"charging\":%s,\"timer_running\":%s,\"timer_seconds\":%lu,\"display_on\":%s,\"low_power\":%s,\"soft_sleep\":%s,\"events_enabled\":%s,\"rate_hz\":%lu,\"interval_ms\":%lu,\"wifi_on_boot\":%s,\"wifi_active\":%s,\"wifi_connected\":%s,\"wifi_mode\":\"%s\",\"wifi_credentials_saved\":%s,\"ble_enabled\":%s,\"ble_connected\":%s,\"ble_buttons_enabled\":%s,\"ble_heartbeat_required\":%s,\"auto_sleep_enabled\":%s,\"auto_sleep_minutes\":15,\"quick_boot_enabled\":%s,\"time_on_top\":%s,\"drift_compensation_max_grams\":%.3f,\"calibration_factor\":%.2f,\"calibration_invalid\":%s,\"calibration_status\":\"%s\",\"calibration_last_candidate\":%.2f,\"calibration_last_verified_grams\":%.2f,\"calibration_last_raw_delta\":%ld}",
                  status,
                  FIRMWARE_VER,
                  f_displayedValue,
@@ -336,7 +336,13 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
                  b_autoSleep ? "true" : "false",
                  b_quickBoot ? "true" : "false",
                  b_timeOnTop ? "true" : "false",
-                 f_maxDriftCompensation);
+                 f_maxDriftCompensation,
+                 f_calibration_value,
+                 b_calibrationInvalid ? "true" : "false",
+                 c_calibrationStatus,
+                 f_lastCalibrationCandidate,
+                 f_lastCalibrationVerifiedWeight,
+                 i_lastCalibrationRawDelta);
 }
 
 // Broadcast via printfAll(): it holds the library's client-list mutex and

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -652,9 +652,27 @@ void setup() {
   //loadcell calibration value check
   EEPROM.get(i_addr_calibration_value, f_calibration_value);
   if (!isValidCalibrationValue(f_calibration_value)) {
+    float storedCalibrationValue = f_calibration_value;
+    CalibrationRejectReason bootCalibrationReason = CAL_REJECT_FACTOR_SIGN;
+    if (!isfinite(storedCalibrationValue) ||
+        fabsf(storedCalibrationValue) < CALIBRATION_VALUE_MIN_ABS) {
+      bootCalibrationReason = CAL_REJECT_FACTOR_NEAR_ZERO;
+    } else if (fabsf(storedCalibrationValue) > CALIBRATION_VALUE_MAX_ABS) {
+      bootCalibrationReason = CAL_REJECT_FACTOR_TOO_LARGE;
+    }
+    b_calibrationInvalid = true;
+    snprintf(c_calibrationStatus, sizeof(c_calibrationStatus), "%s",
+             calibrationRejectReasonText(bootCalibrationReason));
+    Serial.print(F("Invalid stored calibration value: "));
+    Serial.print(storedCalibrationValue, 6);
+    Serial.print(F(" reason="));
+    Serial.println(c_calibrationStatus);
     f_calibration_value = CALIBRATION_VALUE_DEFAULT;
-    EEPROM.put(i_addr_calibration_value, f_calibration_value);  //set to default value
-    EEPROM.commit();
+    Serial.println(F("Using temporary default calibration; EEPROM not overwritten."));
+  } else {
+    b_calibrationInvalid = false;
+    snprintf(c_calibrationStatus, sizeof(c_calibrationStatus), "%s",
+             calibrationRejectReasonText(CAL_REJECT_NONE));
   }
   scale.setCalFactor(f_calibration_value);  //设定校准值
 

--- a/tools/test_calibration_validation.py
+++ b/tools/test_calibration_validation.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import math
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HEADER = ROOT / "include" / "calibration_validation.h"
+
+
+def const_float(name):
+    text = HEADER.read_text(encoding="utf-8")
+    match = re.search(rf"const float {name} = ([0-9.]+)f;", text)
+    if not match:
+        raise AssertionError(f"missing {name}")
+    return float(match.group(1))
+
+
+def const_uint8(name):
+    text = HEADER.read_text(encoding="utf-8")
+    match = re.search(rf"const uint8_t {name} = ([0-9]+);", text)
+    if not match:
+        raise AssertionError(f"missing {name}")
+    return int(match.group(1))
+
+
+MIN_ABS = const_float("CALIBRATION_VALUE_MIN_ABS")
+MAX_ABS = const_float("CALIBRATION_VALUE_MAX_ABS")
+KNOWN_MIN = const_float("CALIBRATION_KNOWN_MASS_MIN_G")
+VERIFY_MIN_TOLERANCE = const_float("CALIBRATION_VERIFY_MIN_TOLERANCE_G")
+VERIFY_RATIO = const_float("CALIBRATION_VERIFY_TOLERANCE_RATIO")
+STABILITY_MAX_G = const_float("CALIBRATION_STABILITY_MAX_G")
+MIN_VALID_SAMPLES = const_uint8("CALIBRATION_MIN_VALID_SAMPLES")
+ALLOW_NEGATIVE = False
+
+
+def sign_allowed(value):
+    return value != 0.0 if ALLOW_NEGATIVE else value > 0.0
+
+
+def valid_value(value):
+    magnitude = abs(value)
+    return (
+        math.isfinite(value)
+        and sign_allowed(value)
+        and magnitude >= MIN_ABS
+        and magnitude <= MAX_ABS
+    )
+
+
+def verify_tolerance(known_mass):
+    return max(abs(known_mass) * VERIFY_RATIO, VERIFY_MIN_TOLERANCE)
+
+
+def stability_raw_limit(current_factor):
+    magnitude = abs(current_factor)
+    if not math.isfinite(magnitude) or magnitude < MIN_ABS:
+        magnitude = 1000.0
+    return max(magnitude * STABILITY_MAX_G, 50.0)
+
+
+def validate_basics(known_mass, raw_delta, candidate):
+    if not math.isfinite(known_mass) or known_mass < KNOWN_MIN:
+        return "unknown_mass"
+    if abs(raw_delta) < known_mass * MIN_ABS:
+        return "raw_delta_too_small"
+    if not math.isfinite(candidate):
+        return "factor_near_zero"
+    magnitude = abs(candidate)
+    if magnitude < MIN_ABS:
+        return "factor_near_zero"
+    if magnitude > MAX_ABS:
+        return "factor_too_large"
+    if ALLOW_NEGATIVE:
+        if (candidate > 0 and raw_delta <= 0) or (candidate < 0 and raw_delta >= 0):
+            return "factor_sign"
+    elif candidate <= 0 or raw_delta <= 0:
+        return "factor_sign"
+    return "ok"
+
+
+def validate_verification(known_mass, verified_weight):
+    if not math.isfinite(verified_weight) or verified_weight <= 0:
+        return "verify_inverted"
+    if abs(verified_weight - known_mass) > verify_tolerance(known_mass):
+        return "verify_tolerance"
+    return "ok"
+
+
+def test(name, actual, expected):
+    if actual != expected:
+        raise AssertionError(f"{name}: expected {expected}, got {actual}")
+
+
+def main():
+    test("stored positive factor", valid_value(1000.0), True)
+    test("stored negative factor rejected by default", valid_value(-1000.0), False)
+    test("stored huge factor rejected", valid_value(1500000.0), False)
+
+    test("normal positive raw delta", validate_basics(50.0, 50000, 1000.0), "ok")
+    test("normal positive verification", validate_verification(50.0, 49.9), "ok")
+    test("negative raw delta rejected by default", validate_basics(50.0, -50000, -1000.0), "factor_sign")
+    test("stale tare inverted verification", validate_verification(50.0, -49.9), "verify_inverted")
+    test("zero raw delta", validate_basics(50.0, 0, 0.0), "raw_delta_too_small")
+    test("too small raw delta", validate_basics(50.0, 20, 1.1), "raw_delta_too_small")
+    test("huge factor rejected", validate_basics(50.0, 75000000, 1500000.0), "factor_too_large")
+    test("unknown smart mass rejected", validate_basics(0.0, 50000, 1000.0), "unknown_mass")
+
+    assert MIN_VALID_SAMPLES == 16
+    assert stability_raw_limit(1000.0) == 500.0
+    assert 600.0 > stability_raw_limit(1000.0)
+    print("calibration validation tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Summary:**
This fixes calibration so bad zero/load readings, USB-connected calibration attempts, invalid manual factors, and likely load-cell fault symptoms fail visibly without overwriting the saved calibration factor.

**Fixes Done**
Added shared calibration validation logic in include/calibration_validation.h.
Reworked calibration to use fresh zero/load raw ADC captures.
Computes calibration from raw delta instead of tare-dependent getNewCalibration().
Verifies the known weight before saving to EEPROM.
Preserves the previous factor on every calibration failure.
Rejects negative and implausibly large factors.
Changed USB/charging calibration from silent exit to unplug_usb failure.
Added user-facing OLED failure text like Unplug USB, No weight change, Unstable zero.
Added serial/HDS Doctor diagnostics via adsd info.
Added helper validation tests.
Keeps the existing `/snapshot` status schema unchanged.
Keeps HDS Doctor compatibility unchanged; the 41-byte ADS debug packet is not modified.
Calibration diagnostics are exposed through serial `adsd info` logs, not through `/snapshot`

**Why:**
Prevents the reported negative-weight-after-calibration failure from being saved as a bad factor.
Prevents faulty/unstable load-cell behavior from being “calibrated around.”
Makes failed calibration understandable to users and maintainers.
Keeps EEPROM safe: failed attempts do not poison the stored factor.

**Verified locally:**
Helper tests passed.
pio run -e esp32s3 passed.
Flashed to COM6 and tested tare/sign, failed calibration preservation, disturbed calibration rejection, invalid cv rejection, and unplug_usb diagnostics.