### PR TITLE
chore: pin pioarduino platform to 3.3.9 (BLE fix) + warn when behind stable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,10 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
+          # Key on platformio.ini so a platform/lib pin change busts the cache.
+          # A static key froze CI on a stale cached `stable` platform zip (3.3.8)
+          # even after the pin should have resolved a newer framework.
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
       - uses: actions/setup-node@v4.1.0
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,10 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
+          # Key on platformio.ini so a platform/lib pin change busts the cache.
+          # A static key froze CI on a stale cached `stable` platform zip (3.3.8)
+          # even after the pin should have resolved a newer framework.
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
 
       - uses: actions/setup-python@v4
         with:

--- a/check_platform_freshness.py
+++ b/check_platform_freshness.py
@@ -1,0 +1,80 @@
+"""Pre-build advisory: warn when the pinned pioarduino platform is behind stable.
+
+We pin `platform =` in platformio.ini to an explicit pioarduino version (not the
+rolling `stable` tag) so builds are reproducible. The trade-off is that we have
+to remember to bump it to pick up framework fixes. This hook compares the pinned
+version against the latest pioarduino release and prints a warning -- plus a
+GitHub Actions annotation in CI -- when a newer one exists.
+
+It is advisory only: it never fails the build, and it stays silent when offline,
+rate-limited, or when the platform isn't pinned to an explicit version. Set
+HDS_SKIP_PLATFORM_CHECK=1 to skip it entirely (e.g. fast offline builds).
+"""
+import json
+import os
+import re
+import urllib.request
+
+# PlatformIO exec's extra_scripts without a module __file__; it runs from the
+# project root, so resolve platformio.ini relative to the working directory.
+PLATFORMIO_INI = os.path.join(os.getcwd(), "platformio.ini")
+LATEST_API = "https://api.github.com/repos/pioarduino/platform-espressif32/releases/latest"
+# Matches an explicitly versioned pioarduino platform pin; the rolling `stable`
+# tag deliberately does NOT match, so this stays quiet until we pin a version.
+PIN_RE = re.compile(
+    r"pioarduino/platform-espressif32/releases/download/"
+    r"([0-9]+\.[0-9]+\.[0-9]+[^/]*)/platform-espressif32\.zip"
+)
+
+
+def _warn(msg):
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print("::warning title=Platform behind stable::" + msg)
+    print("\033[33m[platform-check] " + msg + "\033[0m")
+
+
+def _version_tuple(v):
+    return tuple(int(x) for x in re.findall(r"\d+", v))
+
+
+def main():
+    if os.environ.get("HDS_SKIP_PLATFORM_CHECK"):
+        return
+    try:
+        with open(PLATFORMIO_INI, "r") as f:
+            ini = f.read()
+    except OSError:
+        return
+
+    match = PIN_RE.search(ini)
+    if not match:
+        return  # not pinned to an explicit version -> nothing to compare
+    pinned = match.group(1)
+
+    try:
+        req = urllib.request.Request(
+            LATEST_API, headers={"User-Agent": "hds-platform-check"}
+        )
+        token = os.environ.get("GITHUB_TOKEN")
+        if token:
+            req.add_header("Authorization", "Bearer " + token)
+        with urllib.request.urlopen(req, timeout=4) as resp:
+            latest = json.load(resp).get("tag_name", "")
+    except Exception:
+        return  # offline / rate-limited / API change -> never block the build
+
+    if latest and _version_tuple(latest) > _version_tuple(pinned):
+        _warn(
+            "pinned pioarduino platform {p} is behind latest stable {l}. "
+            "Consider bumping `platform =` in platformio.ini "
+            "(https://github.com/pioarduino/platform-espressif32/releases/tag/{l}).".format(
+                p=pinned, l=latest
+            )
+        )
+
+
+try:
+    main()
+except Exception:
+    # Advisory only -- never let a bug in this check fail the build.
+    pass

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,9 +16,19 @@ data_dir = web_apps
 
 [env:esp32s3]
 ;-- esp32
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; Pin the pioarduino platform to an explicit version (= arduino-esp32 3.3.9)
+; instead of the rolling `stable` tag. `stable` is a mutable asset: it silently
+; moved to 3.3.9 on 2026-06-04, but cached builds (local + CI) stayed on 3.3.8,
+; so the framework version was unknowable from this file and not reproducible.
+; 3.3.9 also carries the upstream BLE map-lock fix for the nimble_host crash
+; (issue #59). Bump this URL deliberately to adopt a newer framework.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 framework = arduino
+# Advisory pre-build check: warns (build log + CI annotation) when the pinned
+# platform above is behind the latest pioarduino stable release, so a deliberate
+# pin doesn't silently rot. Never fails the build; skip with HDS_SKIP_PLATFORM_CHECK=1.
+extra_scripts = pre:check_platform_freshness.py
 #board_build.partitions = <min_spiffs.csv>
 board_build.filesystem = littlefs
 monitor_speed = 115200


### PR DESCRIPTION
## Problem

`platformio.ini` pinned the platform to the **rolling `stable` tag**, whose release asset mutates in place. It silently advanced to arduino-esp32 **3.3.9** on 2026-06-04 — but neither local nor CI builds picked it up:

- The **v3.0.10 release build** resolved `framework-arduinoespressif32 @ 3.3.8` (verified in the [Release CI log](https://github.com/decentespresso/openscale/actions/runs/27934988943) — `PLATFORM: Espressif 32 (55.3.38)`).
- Root cause: `actions/cache@v3` used a **static key** (`${{ runner.os }}-pio`) that restored a months-old cached `stable` platform zip from `~/.platformio/.cache`. PlatformIO served the stale zip (which references the 3.3.8 core) instead of re-downloading the refreshed `stable` asset.

Net effect: the framework version was **neither knowable from `platformio.ini` nor reproducible**, and every shipped release (incl. v3.0.10) carried the 3.3.8 BLE library — which lacks the upstream map-lock fix for the `nimble_host` `LoadProhibited` crash tracked in #59.

## Changes

1. **Pin the platform to the explicit `55.03.39` URL** (= arduino-esp32 3.3.9). This both lands the BLE fix and makes the framework version reproducible. Verified the resolved framework now carries the fix (`BLEServer` guards `m_connectedServersMap` with `m_semaphoreMapAccess`).
2. **Fix the CI cache key** in `release.yml` + `nightly.yml`: key on `hashFiles('platformio.ini')` so a platform/lib pin change busts the stale download cache. The static key is exactly what froze CI on the old zip.
3. **Add `check_platform_freshness.py`** as a pre-build hook (`extra_scripts = pre:`): since we now pin (and must remember to bump), it warns — in the build log and as a GitHub Actions annotation — when the pinned platform is behind the latest pioarduino stable release. **Advisory only**: never fails the build, stays silent offline / rate-limited, and is skippable via `HDS_SKIP_PLATFORM_CHECK=1`.

This is the "pin for reproducibility, but don't let the pin silently rot" approach: deliberate adoption of framework bumps, with a nudge when one is available.

## Verification

```
PLATFORM: Espressif 32 (55.3.39) > Espressif ESP32-S3-DevKitC-1-N8
 - framework-arduinoespressif32 @ 3.3.9
[SUCCESS]
```
- `grep -c m_semaphoreMapAccess …/BLE/src/BLEServer.cpp` → `10` (fix present; was `0` on 3.3.8).
- Freshness hook ran clean with no warning (pinned == latest stable).

## Notes

- The 3.3.9 toolchain (newer GCC) surfaces pre-existing `-Wvolatile` deprecation warnings in `src/wifi_setup.cpp` (volatile `++`). Harmless, not introduced here — flagging in case we want a follow-up to quiet them.
- This addresses the framework-adoption half of #59. Whether to **close** #59 is a judgment call: the fix is now in the build, but the crash is hard to reproduce on demand, so you may prefer to verify under soak first — hence `Refs #59` rather than `Fixes`.

Refs #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)