### PR TITLE
fix: 0g stuck

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -186,6 +186,57 @@ void esp32_sleep() {
   //new bitmap sleep wakeup pin
   esp_sleep_enable_ext1_wakeup_io(PIN_BITMASK, ESP_EXT1_WAKEUP_ANY_LOW);
 #endif
+
+  // ---- Prevent GPIO back-feed into PWR_CTRL domain during deep sleep ----
+  // TPS22860 load switch may not fully isolate its output when off.
+  // If any ESP32 GPIO connected to a powered-down device is HIGH (even
+  // through an external pull-up), current can flow through the device's
+  // internal ESD protection diode into its VDD pin, partially powering it.
+  // A partially-powered ADS1232 / REF5025 / ADS1115 may not trigger POR
+  // on the next wake-up, causing latch-up and the "stuck at 0g" bug.
+  //
+  // Fix: drive every GPIO in the PWR_CTRL domain LOW (or INPUT for DOUT
+  // pins) and enable gpio_hold so the state persists through deep sleep.
+  // I2C is driven LOW to sink the external pull-up current safely instead
+  // of letting it flow through unpowered-device ESD diodes.
+
+  // --- OLED (SPI) ---
+  pinMode(OLED_SDIN, OUTPUT);  digitalWrite(OLED_SDIN, LOW);
+  pinMode(OLED_SCLK, OUTPUT);  digitalWrite(OLED_SCLK, LOW);
+  pinMode(OLED_DC, OUTPUT);    digitalWrite(OLED_DC, LOW);
+  pinMode(OLED_RST, OUTPUT);   digitalWrite(OLED_RST, LOW);
+  pinMode(OLED_CS, OUTPUT);    digitalWrite(OLED_CS, LOW);
+  gpio_hold_en((gpio_num_t)OLED_SDIN);
+  gpio_hold_en((gpio_num_t)OLED_SCLK);
+  gpio_hold_en((gpio_num_t)OLED_DC);
+  gpio_hold_en((gpio_num_t)OLED_RST);
+  gpio_hold_en((gpio_num_t)OLED_CS);
+
+  // --- ADS1232 primary ---
+  pinMode(SCALE_SCLK, OUTPUT); digitalWrite(SCALE_SCLK, LOW);
+  pinMode(SCALE_PDWN, OUTPUT); digitalWrite(SCALE_PDWN, LOW);  // power-down
+  pinMode(SCALE_DOUT, INPUT);                                    // input from ADC
+  gpio_hold_en((gpio_num_t)SCALE_SCLK);
+  gpio_hold_en((gpio_num_t)SCALE_PDWN);
+  gpio_hold_en((gpio_num_t)SCALE_DOUT);
+
+  // --- ADS1232 secondary (if present) ---
+  pinMode(SCALE2_SCLK, OUTPUT); digitalWrite(SCALE2_SCLK, LOW);
+  pinMode(SCALE2_PDWN, OUTPUT); digitalWrite(SCALE2_PDWN, LOW);
+  pinMode(SCALE2_DOUT, INPUT);
+  gpio_hold_en((gpio_num_t)SCALE2_SCLK);
+  gpio_hold_en((gpio_num_t)SCALE2_PDWN);
+  gpio_hold_en((gpio_num_t)SCALE2_DOUT);
+
+  // --- I2C bus (ADS1115 + gyro) ---
+  // Both sides of the bus are unpowered, but external pull-ups to 3.3V
+  // remain.  Driving LOW sinks the pull-up current safely to ESP32 ground
+  // instead of letting it flow through unpowered-device ESD diodes.
+  pinMode(I2C_SCL, OUTPUT); digitalWrite(I2C_SCL, LOW);
+  pinMode(I2C_SDA, OUTPUT); digitalWrite(I2C_SDA, LOW);
+  gpio_hold_en((gpio_num_t)I2C_SCL);
+  gpio_hold_en((gpio_num_t)I2C_SDA);
+
   //#if defined(V7_3) || defined(V7_4) || defined(V7_5) || defined(V8_0) || defined(V8_1)
   digitalWrite(ACC_PWR_CTRL, LOW);
   gpio_hold_en((gpio_num_t)ACC_PWR_CTRL);

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -482,7 +482,23 @@ void setup() {
       b_button_pressed = false;  // Reset mark
     }
   }
-  gpio_hold_dis((gpio_num_t)PWR_CTRL);  // Disable GPIO hold mode for the specified pin, allowing it to be controlled
+  // Release GPIO holds set by esp32_sleep() — all PWR_CTRL-domain pins were
+  // latched LOW (or INPUT) to prevent back-feed through ESD diodes.
+  gpio_hold_dis((gpio_num_t)PWR_CTRL);
+  gpio_hold_dis((gpio_num_t)OLED_SDIN);
+  gpio_hold_dis((gpio_num_t)OLED_SCLK);
+  gpio_hold_dis((gpio_num_t)OLED_DC);
+  gpio_hold_dis((gpio_num_t)OLED_RST);
+  gpio_hold_dis((gpio_num_t)OLED_CS);
+  gpio_hold_dis((gpio_num_t)SCALE_SCLK);
+  gpio_hold_dis((gpio_num_t)SCALE_PDWN);
+  gpio_hold_dis((gpio_num_t)SCALE_DOUT);
+  gpio_hold_dis((gpio_num_t)SCALE2_SCLK);
+  gpio_hold_dis((gpio_num_t)SCALE2_PDWN);
+  gpio_hold_dis((gpio_num_t)SCALE2_DOUT);
+  gpio_hold_dis((gpio_num_t)I2C_SCL);
+  gpio_hold_dis((gpio_num_t)I2C_SDA);
+
   pinMode(PWR_CTRL, OUTPUT);            // Set the PWR_CTRL pin as an output pin
   digitalWrite(PWR_CTRL, HIGH);         // Set the PWR_CTRL pin to HIGH, turning on the connected device or circuit
 //#if defined(ACC_MPU6050) || defined(ACC_BMA400)


### PR DESCRIPTION
## Root cause: GPIO back-feed through ESD diodes

The `TPS22860` load switch that gates `3V3_PERIPH` (power for OLED, ADS1232, REF5025, ADS1115) does not fully isolate when off. During deep sleep, ESP32 GPIOs connected to these devices leak current through their internal ESD protection diodes into the `3V3_PERIPH` rail, keeping it at a small residual voltage:

| Battery | 3V3_PERIPH residual |
|---------|---------------------|
| 3.5V    | 0.295V              |
| 3.6V    | 0.308V              |
| 3.7V    | 0.319V              |
| 3.8V    | 0.331V              |
| 3.9V    | 0.342V              |
| 4.0V    | 0.356V              |
| 4.1V    | 0.365V              |
| 4.2V    | 0.377V              |

On cold boot (battery physically disconnected then reconnected) the ADS1232 starts from **true 0V** and its internal power-on reset fires correctly. But after deep sleep the `3V3_PERIPH` rail only drops to the residual voltage above — **not low enough to trigger POR**. The ADC analog front-end (PGA, modulator) wakes up in a latched state and outputs frozen mid-scale values, which the firmware reads as `0g`.

Testing shows the threshold is **~0.33V**: any residual above this causes the ADC to stick at 0g on wake.

### Reproduction

1. Set bench supply to **3.5V**. Place 100g on scale → reads **100g**.
2. Raise supply to **4.0V**. Reading stays **100g** (ADC not power-cycled).
3. **Sleep → wake**. `3V3_PERIPH` starts from **0.356V** (≥ 0.33V → POR skipped). 100g now reads **0g**.
4. Lower supply to **3.5V** (while running). Still reads **0g**.
5. **Sleep → wake**. `3V3_PERIPH` starts from **0.295V** (< 0.33V → POR fires). 100g now reads **100g** correctly.

### Fix

Before deep sleep, drive every GPIO in the `PWR_CTRL` domain `LOW` (`INPUT` for DOUT pins) and enable `gpio_hold`. This forces `3V3_PERIPH` to **0V** regardless of battery voltage, guaranteeing a clean POR on the next wake-up. No library changes required.