### PR TITLE
deepsleep hold

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -9,6 +9,10 @@
 #endif
 #include "espnow.h"
 
+#ifdef ESP32
+#include "driver/rtc_io.h"
+#endif
+
 #ifdef ADS1115ADC
 #include <Adafruit_ADS1X15.h>
 Adafruit_ADS1115 ads;  // Create an ADS1115 object
@@ -89,6 +93,25 @@ void ADS_init() {
 #ifdef ESP32
 
 int i_wakeupPin;
+void configureWakePinForDeepSleep(gpio_num_t pin) {
+  rtc_gpio_init(pin);
+  rtc_gpio_set_direction(pin, RTC_GPIO_MODE_INPUT_ONLY);
+  rtc_gpio_pullup_en(pin);
+  rtc_gpio_pulldown_dis(pin);
+}
+
+void configureWakePinsForDeepSleep() {
+  configureWakePinForDeepSleep((gpio_num_t)BUTTON_CIRCLE);
+  configureWakePinForDeepSleep((gpio_num_t)BUTTON_SQUARE);
+  configureWakePinForDeepSleep((gpio_num_t)BATTERY_CHARGING);
+}
+
+void releaseWakePinsFromRtcMode() {
+  rtc_gpio_deinit((gpio_num_t)BUTTON_CIRCLE);
+  rtc_gpio_deinit((gpio_num_t)BUTTON_SQUARE);
+  rtc_gpio_deinit((gpio_num_t)BATTERY_CHARGING);
+}
+
 void print_wakeup_reason() {
   esp_sleep_wakeup_cause_t wakeup_reason;
 
@@ -184,6 +207,7 @@ void esp32_sleep() {
   // attachInterrupt(GPIO_NUM_BUTTON_POWER, esp32_wakeup, FALLING);
   // esp_sleep_enable_ext0_wakeup(GPIO_NUM_BUTTON_POWER, LOW);
   //new bitmap sleep wakeup pin
+  configureWakePinsForDeepSleep();
   esp_sleep_enable_ext1_wakeup_io(PIN_BITMASK, ESP_EXT1_WAKEUP_ANY_LOW);
 #endif
 

--- a/include/power.h
+++ b/include/power.h
@@ -243,6 +243,7 @@ void esp32_sleep() {
   //#endif
   digitalWrite(PWR_CTRL, LOW);
   gpio_hold_en((gpio_num_t)PWR_CTRL);
+  gpio_deep_sleep_hold_en();
   esp_deep_sleep_start();
 }
 #endif  //ESP32

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -484,7 +484,32 @@ void setup() {
   }
   // Release GPIO holds set by esp32_sleep() — all PWR_CTRL-domain pins were
   // latched LOW (or INPUT) to prevent back-feed through ESD diodes.
-  gpio_hold_dis((gpio_num_t)PWR_CTRL);
+  pinMode(PWR_CTRL, OUTPUT);
+  digitalWrite(PWR_CTRL, HIGH);
+  pinMode(ACC_PWR_CTRL, OUTPUT);
+  digitalWrite(ACC_PWR_CTRL, HIGH);
+  pinMode(OLED_SDIN, OUTPUT);
+  digitalWrite(OLED_SDIN, LOW);
+  pinMode(OLED_SCLK, OUTPUT);
+  digitalWrite(OLED_SCLK, LOW);
+  pinMode(OLED_DC, OUTPUT);
+  digitalWrite(OLED_DC, LOW);
+  pinMode(OLED_RST, OUTPUT);
+  digitalWrite(OLED_RST, HIGH);
+  pinMode(OLED_CS, OUTPUT);
+  digitalWrite(OLED_CS, HIGH);
+  pinMode(SCALE_SCLK, OUTPUT);
+  digitalWrite(SCALE_SCLK, LOW);
+  pinMode(SCALE_PDWN, OUTPUT);
+  digitalWrite(SCALE_PDWN, HIGH);
+  pinMode(SCALE_DOUT, INPUT);
+  pinMode(SCALE2_SCLK, OUTPUT);
+  digitalWrite(SCALE2_SCLK, LOW);
+  pinMode(SCALE2_PDWN, OUTPUT);
+  digitalWrite(SCALE2_PDWN, HIGH);
+  pinMode(SCALE2_DOUT, INPUT);
+  pinMode(I2C_SCL, INPUT_PULLUP);
+  pinMode(I2C_SDA, INPUT_PULLUP);
   gpio_hold_dis((gpio_num_t)OLED_SDIN);
   gpio_hold_dis((gpio_num_t)OLED_SCLK);
   gpio_hold_dis((gpio_num_t)OLED_DC);
@@ -498,17 +523,15 @@ void setup() {
   gpio_hold_dis((gpio_num_t)SCALE2_DOUT);
   gpio_hold_dis((gpio_num_t)I2C_SCL);
   gpio_hold_dis((gpio_num_t)I2C_SDA);
+  gpio_hold_dis((gpio_num_t)PWR_CTRL);
 
-  pinMode(PWR_CTRL, OUTPUT);            // Set the PWR_CTRL pin as an output pin
-  digitalWrite(PWR_CTRL, HIGH);         // Set the PWR_CTRL pin to HIGH, turning on the connected device or circuit
 //#if defined(ACC_MPU6050) || defined(ACC_BMA400)
 #if defined(V7_3) || defined(V7_4) || defined(V7_5) || defined(V8_0) || defined(V8_1)
   gpio_hold_dis((gpio_num_t)ACC_PWR_CTRL);  // Disable GPIO hold mode for the specified pin, allowing it to be controlled
-  pinMode(ACC_PWR_CTRL, OUTPUT);            // Set the PWR_CTRL pin as an output pin
-  digitalWrite(ACC_PWR_CTRL, HIGH);         // Set the PWR_CTRL pin to HIGH, turning on the connected device or circuit
   Serial.println("ACC_PWR_CTRL = HIGH");
 #endif
 //#endif
+  gpio_deep_sleep_hold_dis();
 #ifdef ESP32
   Wire.begin(I2C_SDA, I2C_SCL);
 #endif

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -427,6 +427,9 @@ void setup() {
   usbCallbacks.setTrackingUpdateInterval = setTrackingUpdateInterval;
   usbCallbacks.buttonSquare_Pressed = buttonSquare_Pressed;
   usbCallbacks.buttonCircle_Pressed = buttonCircle_Pressed;
+#ifdef ESP32
+  releaseWakePinsFromRtcMode();
+#endif
   button_init();
   linkSubmenus();
   pinMode(BATTERY_CHARGING, INPUT_PULLUP);


### PR DESCRIPTION
This builds on the existing deep-sleep GPIO back-feed fix from PR #75 and makes the sleep setup safer for ESP32-S3 deep sleep.

Changes:
- Enable global GPIO deep-sleep hold before entering deep sleep.
- Restore held rail/control pins to safe active states before releasing individual holds on boot.
- Configure the existing EXT1 wake pins as RTC inputs with pull-ups before deep sleep.
- Deinit the RTC wake-pin mode before normal button handling starts.

## Why

PR #75 holds PWR_CTRL-domain pins low or input before deep sleep to reduce GPIO back-feed into the switched 3V3_PERIPH rail. On ESP32-S3, `gpio_hold_en()` alone is not enough for deep sleep persistence; `gpio_deep_sleep_hold_en()` is also required.

This PR also keeps the existing wake mask behavior intact:
- circle button
- square button
- charge detect

No new wake sources are added.

## Notes

The release order on boot is intentional: pins are first configured to safe normal states, then the hold is released. This avoids briefly exposing stale held states during boot.

The wake-pin RTC setup is limited to the existing EXT1 wake mask. It does not enable timer wake, WiFi wake, BLE wake, ULP, or capacitive touch wake.