### PR TITLE
fix: refresh ADS after soft sleep wake

### DIFF
--- a/include/parameter.h
+++ b/include/parameter.h
@@ -267,6 +267,7 @@ bool refreshScaleDatasetAfterDiscontinuity(const char *context);
 void resetScaleOutputAfterAdcDiscontinuity();
 bool tareScaleWhenAdcReady(const char *context);
 bool setScaleSamplesInUseWhenReady(uint8_t samplesInUse, const char *context);
+bool wakeScaleFromSoftSleep(const char *context);
 void consumeScaleTareStatus();
 void clearPendingAutomaticTareState();
 unsigned long t_extraction_begin = 0;       //开始萃取打点

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -71,10 +71,7 @@ struct UsbDecentCommandSink {
   }
 
   void softSleepOff() {
-    digitalWrite(PWR_CTRL, HIGH);
-    digitalWrite(ACC_PWR_CTRL, HIGH);
-    u8g2.setPowerSave(0);
-    b_softSleep = false;
+    wakeScaleFromSoftSleep("USB soft wake");
   }
 
   void timerStart() {

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -176,9 +176,7 @@ void processWsPendingCmds() {
   if (mask & WSP_LOWPWR_ON)   { u8g2.setContrast(0); }
   if (mask & WSP_LOWPWR_OFF)  { u8g2.setContrast(255); }
   if (mask & WSP_SLEEP_OFF) {
-    digitalWrite(PWR_CTRL, HIGH);
-    digitalWrite(ACC_PWR_CTRL, HIGH);
-    u8g2.setPowerSave(0);
+    wakeScaleFromSoftSleep("remote soft wake");
   }
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
   if ((mask & WSP_BLE_GYRO) && !(mask & WSP_SLEEP_ON) && !b_softSleep) {

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -74,12 +74,7 @@ void aceButtonHandleEvent(AceButton *button, uint8_t eventType, uint8_t buttonSt
   }
   if (b_softSleep) {
     Serial.println("Exit Soft Sleep.");
-    digitalWrite(PWR_CTRL, HIGH);
-    //#if defined(ACC_MPU6050) || defined(ACC_BMA400)
-    digitalWrite(ACC_PWR_CTRL, HIGH);
-    //#endif
-    u8g2.setPowerSave(0);
-    b_softSleep = false;
+    wakeScaleFromSoftSleep("button soft wake");
   }
   u8g2.setContrast(255);  //set oled brightness to max when button is pressed
   b_websocketLowPowerEnabled = false;  // button forced full contrast; keep WS low_power status truthful
@@ -1205,6 +1200,21 @@ void resetStableOutput() {
   if (b_weight_in_serial) {
     Serial.println("Stable output reset");
   }
+}
+
+bool wakeScaleFromSoftSleep(const char *context) {
+  digitalWrite(PWR_CTRL, HIGH);
+  digitalWrite(ACC_PWR_CTRL, HIGH);
+  delay(5);
+  scale.powerUp();
+  u8g2.setPowerSave(0);
+  b_softSleep = false;
+  b_u8g2Sleep = false;
+  if (refreshScaleDatasetAfterDiscontinuity(context)) {
+    resetScaleOutputAfterAdcDiscontinuity();
+    return true;
+  }
+  return false;
 }
 
 bool refreshScaleDatasetAfterDiscontinuity(const char *context) {

--- a/tools/test_soft_sleep_ads_wake.py
+++ b/tools/test_soft_sleep_ads_wake.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HDS_SOURCE = ROOT / "src" / "hds.ino"
+PARAMETER_HEADER = ROOT / "include" / "parameter.h"
+USBCOMM_HEADER = ROOT / "include" / "usbcomm.h"
+WEBSOCKET_HEADER = ROOT / "include" / "websocket.h"
+
+
+def read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def method_body(path, name):
+    text = read(path)
+    match = re.search(rf"\b\w+\s+{re.escape(name)}\(", text)
+    if match is None:
+        raise AssertionError(f"method not found: {name}")
+    opening = text.index("{", match.start())
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"method body not found: {name}")
+
+
+def assert_contains(path, text):
+    if text not in read(path):
+        raise AssertionError(f"{path} missing {text!r}")
+
+
+def assert_ordered(body, snippets):
+    cursor = 0
+    for snippet in snippets:
+        index = body.find(snippet, cursor)
+        if index < 0:
+            raise AssertionError(f"missing ordered snippet: {snippet}")
+        cursor = index + len(snippet)
+
+
+def main():
+    assert_contains(PARAMETER_HEADER, "bool wakeScaleFromSoftSleep")
+
+    helper = method_body(HDS_SOURCE, "wakeScaleFromSoftSleep")
+    assert_ordered(
+        helper,
+        [
+            "digitalWrite(PWR_CTRL, HIGH);",
+            "digitalWrite(ACC_PWR_CTRL, HIGH);",
+            "scale.powerUp();",
+            "refreshScaleDatasetAfterDiscontinuity(context)",
+            "resetScaleOutputAfterAdcDiscontinuity();",
+        ],
+    )
+    if "tareScaleWhenAdcReady" in helper or "tareNoDelay" in helper:
+        raise AssertionError("soft wake must not tare automatically")
+
+    button_handler = method_body(HDS_SOURCE, "aceButtonHandleEvent")
+    assert_contains(HDS_SOURCE, 'wakeScaleFromSoftSleep("button soft wake")')
+    if "digitalWrite(PWR_CTRL, HIGH);" in button_handler:
+        raise AssertionError("button soft wake must use wakeScaleFromSoftSleep")
+
+    usb_soft_off = method_body(USBCOMM_HEADER, "softSleepOff")
+    assert_ordered(usb_soft_off, ['wakeScaleFromSoftSleep("USB soft wake")'])
+    if "digitalWrite(PWR_CTRL, HIGH);" in usb_soft_off:
+        raise AssertionError("USB soft wake must use wakeScaleFromSoftSleep")
+
+    ws_pending = method_body(WEBSOCKET_HEADER, "processWsPendingCmds")
+    assert_ordered(ws_pending, ['wakeScaleFromSoftSleep("remote soft wake")'])
+    sleep_off_index = ws_pending.index("if (mask & WSP_SLEEP_OFF)")
+    sleep_on_index = ws_pending.index("if (mask & WSP_SLEEP_ON)")
+    sleep_off_body = ws_pending[sleep_off_index:sleep_on_index]
+    if "digitalWrite(PWR_CTRL, HIGH);" in sleep_off_body:
+        raise AssertionError("remote soft wake must use wakeScaleFromSoftSleep")
+
+    print("soft sleep ADS wake tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Title:
Fix ADS recovery after soft sleep wake for preview release

Body:
## Summary
- Refresh the ADS1232 path after HDS exits soft sleep.
- Route button, USB, BLE/WebSocket soft-wake paths through one wake helper.
- Keep wake behavior non-taring: the scale refills ADC data and resets display/tracking output, but does not zero automatically.

## Why
Soft sleep powers down the HDS board rails through `PWR_CTRL` / `ACC_PWR_CTRL`. On wake, the firmware previously only restored the rails and OLED state. The ADS1232 driver object kept its old buffer/timing state even though the ADC hardware had experienced a power discontinuity.

That could leave the scale relying on stale ADC state until the normal timeout recovery path ran.