### PR TITLE
fix: make remote soft wake idempotent

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -201,9 +201,14 @@ struct BleDecentCommandSink {
   }
 
   void softSleepOff() {
+    bool wasSoftSleep = b_softSleep;
     b_softSleep = false;
     b_u8g2Sleep = false;
-    remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
+    if (wasSoftSleep) {
+      remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
+    } else {
+      remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
+    }
   }
 
   void timerStart() {

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -71,7 +71,12 @@ struct UsbDecentCommandSink {
   }
 
   void softSleepOff() {
-    wakeScaleFromSoftSleep("USB soft wake");
+    if (b_softSleep) {
+      wakeScaleFromSoftSleep("USB soft wake");
+    } else {
+      u8g2.setPowerSave(0);
+      b_u8g2Sleep = false;
+    }
   }
 
   void timerStart() {

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -522,9 +522,14 @@ bool handleWebsocketControlCommand(AsyncWebSocketClient *client, String command,
     }
     if (action == "off" || action == "wake") {
       Serial.println("Websocket soft sleep off detected.");
+      bool wasSoftSleep = b_softSleep;
       b_softSleep = false;
       b_u8g2Sleep = false;
-      wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
+      if (wasSoftSleep) {
+        wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
+      } else {
+        wsReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
+      }
       sendWebsocketStatus(client, "ok");
       return true;
     }

--- a/tools/test_soft_sleep_ads_wake.py
+++ b/tools/test_soft_sleep_ads_wake.py
@@ -5,6 +5,7 @@ import re
 ROOT = Path(__file__).resolve().parents[1]
 HDS_SOURCE = ROOT / "src" / "hds.ino"
 PARAMETER_HEADER = ROOT / "include" / "parameter.h"
+BLE_HEADER = ROOT / "include" / "ble.h"
 USBCOMM_HEADER = ROOT / "include" / "usbcomm.h"
 WEBSOCKET_HEADER = ROOT / "include" / "websocket.h"
 
@@ -68,9 +69,41 @@ def main():
         raise AssertionError("button soft wake must use wakeScaleFromSoftSleep")
 
     usb_soft_off = method_body(USBCOMM_HEADER, "softSleepOff")
-    assert_ordered(usb_soft_off, ['wakeScaleFromSoftSleep("USB soft wake")'])
+    assert_ordered(
+        usb_soft_off,
+        [
+            "if (b_softSleep)",
+            'wakeScaleFromSoftSleep("USB soft wake")',
+            "u8g2.setPowerSave(0);",
+            "b_u8g2Sleep = false;",
+        ],
+    )
     if "digitalWrite(PWR_CTRL, HIGH);" in usb_soft_off:
         raise AssertionError("USB soft wake must use wakeScaleFromSoftSleep")
+
+    ble_soft_off = method_body(BLE_HEADER, "softSleepOff")
+    assert_ordered(
+        ble_soft_off,
+        [
+            "bool wasSoftSleep = b_softSleep;",
+            "b_softSleep = false;",
+            "if (wasSoftSleep)",
+            "remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
+            "remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
+        ],
+    )
+
+    ws_handler = read(WEBSOCKET_HEADER)
+    assert_ordered(
+        ws_handler,
+        [
+            'if (action == "off" || action == "wake")',
+            "bool wasSoftSleep = b_softSleep;",
+            "if (wasSoftSleep)",
+            "wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
+            "wsReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
+        ],
+    )
 
     ws_pending = method_body(WEBSOCKET_HEADER, "processWsPendingCmds")
     assert_ordered(ws_pending, ['wakeScaleFromSoftSleep("remote soft wake")'])


### PR DESCRIPTION
## Summary

Fixes the brief `0.0g` weight blip seen after `v3.1.12` when a BLE or WiFi client repeatedly sends a wake / soft-sleep-off command while the scale is already awake.

## Why It Happens

`v3.1.12` added ADS1232 recovery on real soft-sleep wake so the scale does not stay stale or stuck after the ADC power rail comes back. That was correct for an actual transition from sleep to awake.

The Decent BLE command `030A04 00` is also sent by clients as a keep-awake style command. In `v3.1.11`, duplicate wake commands only turned the display / power rails on, so they did not affect the current weight. In `v3.1.12`, the same duplicate command went through `wakeScaleFromSoftSleep()`, which calls `scale.powerUp()`, refreshes the ADS dataset, and resets the public displayed weight. That left a short window where BLE / WiFi could report `0.0g` before the next ADC sample restored the real weight.

## What This Fixes

Wake commands are now idempotent:

- If `b_softSleep` is true, this is a real wake and the ADS wake / refresh path still runs.
- If `b_softSleep` is false, the scale is already awake, so duplicate wake commands only restore the display state and do not refresh/reset the ADS output.

The fix covers BLE, `/snapshot` WebSocket, and USB command paths so the same protocol behavior stays consistent across transports.

## Validation

- `python tools\test_soft_sleep_ads_wake.py`
- `rtk proxy pio run -e esp32s3`
- Flashed the patched firmware to COM6.
- WiFi `/snapshot` smoke: real `soft_sleep on` / `soft_sleep off` still works.
- Duplicate WiFi `soft_sleep off` no longer logs `remote soft wake dataset refreshed`, confirming the ADS refresh path is skipped while already awake.
- BLE manual reconnect smoke 