### PR TITLE
Fix charging wake radio startup

### DIFF
--- a/src/hds.ino
+++ b/src/hds.ino
@@ -160,6 +160,22 @@ void scaleTimer() {
   }
 }
 
+void wakeFromChargingUi(uint8_t buttonPin) {
+  if (GPIO_power_on_with != BATTERY_CHARGING && !b_showChargingUI) {
+    return;
+  }
+  GPIO_power_on_with = buttonPin;
+  b_showChargingUI = false;
+  b_is_charging = false;
+  if (!b_ble_enabled) {
+    b_ble_enabled = true;
+    ble_init();
+  }
+  if (!b_wifiEnabled) {
+    wifi_init();
+  }
+}
+
 void buttonCircle_Released() {
   Serial.println("O button released");
   onButtonReleased(BUTTON_CIRCLE);
@@ -167,12 +183,7 @@ void buttonCircle_Released() {
 
 void buttonCircle_Pressed() {
   if (b_showChargingUI && i_buttonBootDelay == 0) {
-    //change GPIO_power_on_with from BATTERY_CHARGING to enter scale loop
-    GPIO_power_on_with = BUTTON_CIRCLE;
-    b_showChargingUI = false;
-    b_ble_enabled = true;
-    ble_init();
-    wifi_init();
+    wakeFromChargingUi(BUTTON_CIRCLE);
   }
 
   if (b_menu) {
@@ -200,7 +211,7 @@ void buttonSquare_Released() {
 
 void buttonSquare_Pressed() {
   if (b_showChargingUI && i_buttonBootDelay == 0) {
-    GPIO_power_on_with = BUTTON_SQUARE;
+    wakeFromChargingUi(BUTTON_SQUARE);
   }
   if (b_menu) {
     selectMenu();
@@ -306,11 +317,7 @@ void buttonCircle_LongPressed() {
     buzzer.beep(1, 200);
 #endif
     if (GPIO_power_on_with == BATTERY_CHARGING) {
-      //change GPIO_power_on_with from BATTERY_CHARGING to enter scale loop
-      GPIO_power_on_with = BUTTON_CIRCLE;
-      b_ble_enabled = true;
-      ble_init();
-      wifi_init();
+      wakeFromChargingUi(BUTTON_CIRCLE);
     }     
     // sendUsbButton(1, 2);
     // if (deviceConnected) {
@@ -327,8 +334,7 @@ void buttonSquare_LongPressed() {
     buzzer.beep(1, 200);
 #endif
     if (GPIO_power_on_with == BATTERY_CHARGING) {
-      //change GPIO_power_on_with from BATTERY_CHARGING to enter scale loop
-      GPIO_power_on_with = BUTTON_SQUARE;
+      wakeFromChargingUi(BUTTON_SQUARE);
     }
     // sendUsbButton(2, 2);
     // if (deviceConnected) {

--- a/tools/test_charging_wake_contract.py
+++ b/tools/test_charging_wake_contract.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HDS_SOURCE = ROOT / "src" / "hds.ino"
+
+
+def read_source():
+    return HDS_SOURCE.read_text(encoding="utf-8")
+
+
+def function_body(text, name):
+    match = re.search(rf"\b\w+\s+{re.escape(name)}\(", text)
+    if match is None:
+        raise AssertionError(f"missing function: {name}")
+    opening = text.index("{", match.start())
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated function: {name}")
+
+
+def assert_contains(body, snippet):
+    if snippet not in body:
+        raise AssertionError(f"missing snippet: {snippet}")
+
+
+def test_charging_button_wake_enables_runtime_radios():
+    source = read_source()
+    wake = function_body(source, "wakeFromChargingUi")
+    assert_contains(wake, "GPIO_power_on_with = buttonPin;")
+    assert_contains(wake, "b_showChargingUI = false;")
+    assert_contains(wake, "b_is_charging = false;")
+    assert_contains(wake, "b_ble_enabled = true;")
+    assert_contains(wake, "ble_init();")
+    assert_contains(wake, "wifi_init();")
+
+    assert_contains(function_body(source, "buttonCircle_Pressed"), "wakeFromChargingUi(BUTTON_CIRCLE);")
+    assert_contains(function_body(source, "buttonSquare_Pressed"), "wakeFromChargingUi(BUTTON_SQUARE);")
+    assert_contains(function_body(source, "buttonCircle_LongPressed"), "wakeFromChargingUi(BUTTON_CIRCLE);")
+    assert_contains(function_body(source, "buttonSquare_LongPressed"), "wakeFromChargingUi(BUTTON_SQUARE);")
+
+
+if __name__ == "__main__":
+    test_charging_button_wake_enables_runtime_radios()
+    print("charging wake contract tests passed")


### PR DESCRIPTION
## Summary
- enable BLE/WiFi startup when a user wakes the scale from charging UI with O or square
- keep passive USB charging quiet until a button wake occurs
- add a small source contract test for the charging wake path

## Validation
- python tools/test_charging_wake_contract.py
- git diff --check
- pio run -e esp32s3
- flashed to COM, confirmed charging wake re-enables radios