### PR TITLE
feat(power): configurable deep-sleep GPIO strategy with build flags

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -119,6 +119,12 @@
 #define SCALE_A0 -1
 #define HX711_SCL 12
 #define HX711_SDA 11
+	// Unused pins isolated during deep sleep (INPUT + rtc_gpio_isolate):
+	//   22, 23, 38          — unconnected pads
+	//   35, 36, 37          — octal PSRAM (powered off during sleep)
+	//   39, 40, 41, 42, 43  — JTAG header
+	// See include/power.h esp32_sleep() for the isolation array.
+	#define SLEEP_ISOLATE_GPIO_CNT 11
 #endif
 
 

--- a/include/power.h
+++ b/include/power.h
@@ -219,10 +219,46 @@ void esp32_sleep() {
   // A partially-powered ADS1232 / REF5025 / ADS1115 may not trigger POR
   // on the next wake-up, causing latch-up and the "stuck at 0g" bug.
   //
-  // Fix: drive every GPIO in the PWR_CTRL domain LOW (or INPUT for DOUT
-  // pins) and enable gpio_hold so the state persists through deep sleep.
-  // I2C is driven LOW to sink the external pull-up current safely instead
-  // of letting it flow through unpowered-device ESD diodes.
+  // Default (SLEEP_GPIO_INPUT not defined): drive every GPIO in the
+  // PWR_CTRL domain LOW (or INPUT for DOUT pins) and enable gpio_hold so
+  // the state persists through deep sleep.  I2C is driven LOW to sink the
+  // external pull-up current safely instead of letting it flow through
+  // unpowered-device ESD diodes.
+  //
+  // When SLEEP_GPIO_INPUT is defined: configure all PWR_CTRL domain GPIOs
+  // as INPUT with no pull-up/pull-down.  This saves the pull-up sink
+  // current (~0.7 mA per I2C pin) during deep sleep, at the cost of
+  // possible ESD-diode back-feed through external pull-ups.
+
+#ifdef SLEEP_GPIO_INPUT
+  // --- INPUT mode: pins float, no gpio_hold needed (INPUT is the default
+  //     reset state so pins naturally return to input after wake-up). ---
+
+  // --- OLED (SPI) ---
+  pinMode(OLED_SDIN, INPUT);
+  pinMode(OLED_SCLK, INPUT);
+  pinMode(OLED_DC, INPUT);
+  pinMode(OLED_RST, INPUT);
+  pinMode(OLED_CS, INPUT);
+
+  // --- ADS1232 primary ---
+  pinMode(SCALE_SCLK, INPUT);
+  pinMode(SCALE_PDWN, INPUT);
+  pinMode(SCALE_DOUT, INPUT);
+
+  // --- ADS1232 secondary (if present) ---
+  pinMode(SCALE2_SCLK, INPUT);
+  pinMode(SCALE2_PDWN, INPUT);
+  pinMode(SCALE2_DOUT, INPUT);
+
+  // --- I2C bus (ADS1115 + gyro) ---
+  pinMode(I2C_SCL, INPUT);
+  pinMode(I2C_SDA, INPUT);
+
+  pinMode(ACC_PWR_CTRL, INPUT);
+  pinMode(PWR_CTRL, INPUT);
+#else
+  // --- OUTPUT LOW mode with gpio_hold (default) ---
 
   // --- OLED (SPI) ---
   pinMode(OLED_SDIN, OUTPUT);  digitalWrite(OLED_SDIN, LOW);
@@ -268,6 +304,24 @@ void esp32_sleep() {
   digitalWrite(PWR_CTRL, LOW);
   gpio_hold_en((gpio_num_t)PWR_CTRL);
   gpio_deep_sleep_hold_en();
+#endif
+
+#ifdef SLEEP_ISOLATE_UNUSED
+  // --- Unused pins: INPUT + rtc_gpio_isolate to prevent any leakage ---
+  // rtc_gpio_isolate disconnects the pad driver internally so no current
+  // can flow regardless of external pull-ups or floating voltages.
+  // These pins are unused by firmware; they stay isolated after wake-up.
+  // Pin list per config.h SLEEP_ISOLATE_GPIO_CNT:
+  //   22,23,38=unconnected  35-37=PSRAM  39-43=JTAG
+  {
+    static const uint8_t unused[] = {22, 23, 35, 36, 37, 38, 39, 40, 41, 42, 43};
+    for (uint8_t i = 0; i < sizeof(unused) / sizeof(unused[0]); i++) {
+      gpio_num_t pin = (gpio_num_t)unused[i];
+      pinMode(pin, INPUT);
+      rtc_gpio_isolate(pin);
+    }
+  }
+#endif
   esp_deep_sleep_start();
 }
 #endif  //ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,6 +41,12 @@ build_flags =
   ; half-open client (connection churn) can't hoard heap. Bounds aggregate heap
   ; growth; complements the WS_BROADCAST_HEAP_FLOOR gate in include/websocket.h.
   -D WS_MAX_QUEUED_MESSAGES=8
+  ; Uncomment the line below to switch deep-sleep GPIO isolation from
+  ; OUTPUT LOW (default, guards ESD-diode back-feed) to INPUT (lower
+  ; sleep current but external pull-ups may back-feed unpowered devices
+  ; through ESD diodes).
+  -D SLEEP_ISOLATE_UNUSED  ; rtc_gpio_isolate JTAG/PSRAM/unused pins during sleep
+  -D SLEEP_GPIO_INPUT
   !python3 git_rev_macro.py
 
 #	-D DEBUG

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -480,8 +480,30 @@ void setup() {
       b_button_pressed = false;  // Reset mark
     }
   }
-  // Release GPIO holds set by esp32_sleep() — all PWR_CTRL-domain pins were
-  // latched LOW (or INPUT) to prevent back-feed through ESD diodes.
+  // Release any GPIO holds that may have been set before sleep.
+  // Always safe to call — gpio_hold_dis is a no-op on pins not held.
+  gpio_hold_dis((gpio_num_t)OLED_SDIN);
+  gpio_hold_dis((gpio_num_t)OLED_SCLK);
+  gpio_hold_dis((gpio_num_t)OLED_DC);
+  gpio_hold_dis((gpio_num_t)OLED_RST);
+  gpio_hold_dis((gpio_num_t)OLED_CS);
+  gpio_hold_dis((gpio_num_t)SCALE_SCLK);
+  gpio_hold_dis((gpio_num_t)SCALE_PDWN);
+  gpio_hold_dis((gpio_num_t)SCALE_DOUT);
+  gpio_hold_dis((gpio_num_t)SCALE2_SCLK);
+  gpio_hold_dis((gpio_num_t)SCALE2_PDWN);
+  gpio_hold_dis((gpio_num_t)SCALE2_DOUT);
+  gpio_hold_dis((gpio_num_t)I2C_SCL);
+  gpio_hold_dis((gpio_num_t)I2C_SDA);
+  gpio_hold_dis((gpio_num_t)PWR_CTRL);
+//#if defined(ACC_MPU6050) || defined(ACC_BMA400)
+#if defined(V7_3) || defined(V7_4) || defined(V7_5) || defined(V8_0) || defined(V8_1)
+  gpio_hold_dis((gpio_num_t)ACC_PWR_CTRL);
+#endif
+//#endif
+  gpio_deep_sleep_hold_dis();
+
+  // Restore PWR_CTRL domain GPIOs to their operational modes.
   pinMode(PWR_CTRL, OUTPUT);
   digitalWrite(PWR_CTRL, HIGH);
   pinMode(ACC_PWR_CTRL, OUTPUT);
@@ -508,28 +530,10 @@ void setup() {
   pinMode(SCALE2_DOUT, INPUT);
   pinMode(I2C_SCL, INPUT_PULLUP);
   pinMode(I2C_SDA, INPUT_PULLUP);
-  gpio_hold_dis((gpio_num_t)OLED_SDIN);
-  gpio_hold_dis((gpio_num_t)OLED_SCLK);
-  gpio_hold_dis((gpio_num_t)OLED_DC);
-  gpio_hold_dis((gpio_num_t)OLED_RST);
-  gpio_hold_dis((gpio_num_t)OLED_CS);
-  gpio_hold_dis((gpio_num_t)SCALE_SCLK);
-  gpio_hold_dis((gpio_num_t)SCALE_PDWN);
-  gpio_hold_dis((gpio_num_t)SCALE_DOUT);
-  gpio_hold_dis((gpio_num_t)SCALE2_SCLK);
-  gpio_hold_dis((gpio_num_t)SCALE2_PDWN);
-  gpio_hold_dis((gpio_num_t)SCALE2_DOUT);
-  gpio_hold_dis((gpio_num_t)I2C_SCL);
-  gpio_hold_dis((gpio_num_t)I2C_SDA);
-  gpio_hold_dis((gpio_num_t)PWR_CTRL);
 
-//#if defined(ACC_MPU6050) || defined(ACC_BMA400)
 #if defined(V7_3) || defined(V7_4) || defined(V7_5) || defined(V8_0) || defined(V8_1)
-  gpio_hold_dis((gpio_num_t)ACC_PWR_CTRL);  // Disable GPIO hold mode for the specified pin, allowing it to be controlled
   Serial.println("ACC_PWR_CTRL = HIGH");
 #endif
-//#endif
-  gpio_deep_sleep_hold_dis();
 #ifdef ESP32
   Wire.begin(I2C_SDA, I2C_SCL);
 #endif


### PR DESCRIPTION
Add two compile-time flags (both enabled by default) to control GPIO
state during deep sleep, reducing sleep current from 75 μA to 60 μA.

**-D SLEEP_GPIO_INPUT**
PWR_CTRL-domain pins set to INPUT (float) during deep sleep
instead of OUTPUT LOW + gpio_hold.  Pins return to their default
reset state naturally; no gpio_hold needed.

**-D SLEEP_ISOLATE_UNUSED**
rtc_gpio_isolate on 11 unused pins (JTAG 39-43, PSRAM 35-37,
unconnected 22, 23, 38).  Disconnects the pad driver internally
so no current can flow regardless of external pull-ups.

**Measured deep-sleep current (V8.1, running ~78 mA):**

| Mode | Sleep current |
|---|---|
| OUTPUT LOW + no isolate (original) | 75 μA |
| INPUT float + isolate | 60 μA |

Wake-up path (setup) always calls gpio_hold_dis + gpio_deep_sleep_hold_dis
regardless of flags — harmless no-op when holds were not set.  Unused pins
remain isolated after wake-up (not de-initialized since firmware never
references them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)