### PR TITLE
feat: migrate HDS settings to NVS Preferences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,10 @@ if (info->final && info->index == 0 && info->len == len && info->opcode == WS_TE
 }
 ```
 
+## Persistent settings
+
+Scale settings use the HDS-specific `hds` NVS namespace and SensorBasket-style named keys from `include/storage.h`. WiFi and OTA keep separate namespaces. The legacy EEPROM blob is read only while schema migration is incomplete and is retained for firmware rollback.
+
 ## Style conventions
 
 | Prefix | Meaning |

--- a/include/ble.h
+++ b/include/ble.h
@@ -71,7 +71,7 @@ class MyServerCallbacks : public BLEServerCallbacks {
     deviceConnected = false;
     bleState = DISCONNECTED;
 #ifdef BUZZER
-    EEPROM.get(i_addr_beep, b_beep);  //read buzzer state after disconnect
+    b_beep = storageGetInt(KEY_BEEP, 1);
 #endif
     b_u8g2Sleep = false;
     remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
@@ -102,7 +102,7 @@ class MyServerCallbacks : public BLEServerCallbacks {
     deviceConnected = false;
     bleState = DISCONNECTED;
 #ifdef BUZZER
-    EEPROM.get(i_addr_beep, b_beep);
+    b_beep = storageGetInt(KEY_BEEP, 1);
 #endif
     b_u8g2Sleep = false;
     remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);

--- a/include/menu.h
+++ b/include/menu.h
@@ -245,9 +245,8 @@ void buzzerOn() {
   actionMessage = "Buzzer on";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_beep, b_beep);
-  EEPROM.commit();
-  Serial.println("Buzzer On stored in EEPROM.");
+  storagePutInt(KEY_BEEP, b_beep);
+  Serial.println("Buzzer On stored in NVS.");
 }
 
 void buzzerOff() {
@@ -255,9 +254,8 @@ void buzzerOff() {
   actionMessage = "Buzzer off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_beep, b_beep);
-  EEPROM.commit();
-  Serial.println("Buzzer off stored in EEPROM.");
+  storagePutInt(KEY_BEEP, b_beep);
+  Serial.println("Buzzer off stored in NVS.");
 }
 #endif
 
@@ -267,8 +265,7 @@ void toggleWifiOn() {
   actionMessage2 = "Restart scale";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_enableWifiOnBoot, true);
-  EEPROM.commit();
+  storagePutBool(KEY_WIFI_BOOT, true);
   Serial.printf("%s\n", actionMessage);
 }
 
@@ -278,8 +275,7 @@ void toggleWifiOff() {
   actionMessage2 = "Restart scale";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_enableWifiOnBoot, false);
-  EEPROM.commit();
+  storagePutBool(KEY_WIFI_BOOT, false);
   Serial.printf("%s\n", actionMessage);
 }
 
@@ -377,8 +373,7 @@ void heartbeatOn() {
   actionMessage = "Heartbeat On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_requireHeartBeat, (bool)b_requireHeartBeat);
-  EEPROM.commit();
+  storagePutBool(KEY_HEARTBEAT, b_requireHeartBeat);
   Serial.println("Heartbeat detection...On");
 }
 
@@ -387,8 +382,7 @@ void heartbeatOff() {
   actionMessage = "Heartbeat Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_requireHeartBeat, (bool)b_requireHeartBeat);
-  EEPROM.commit();
+  storagePutBool(KEY_HEARTBEAT, b_requireHeartBeat);
   Serial.println("Heartbeat detection...Off");
 }
 
@@ -397,8 +391,7 @@ void flipScreenOn() {
   actionMessage = "Flip On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_screenFlipped, (bool)b_screenFlipped);
-  EEPROM.commit();
+  storagePutBool(KEY_SCREEN_FLIP, b_screenFlipped);
   u8g2.setDisplayRotation(U8G2_R0);
   Serial.println("Screen flipped...On");
 }
@@ -408,8 +401,7 @@ void flipScreenOff() {
   actionMessage = "Flip Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_screenFlipped, (bool)b_screenFlipped);
-  EEPROM.commit();
+  storagePutBool(KEY_SCREEN_FLIP, b_screenFlipped);
   u8g2.setDisplayRotation(U8G2_R2);
   Serial.println("Screen flipped...Off");
 }
@@ -419,8 +411,7 @@ void timeOnTopOn() {
   actionMessage = "Time On Top";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_timeOnTop, (bool)b_timeOnTop);
-  EEPROM.commit();
+  storagePutBool(KEY_TIME_ON_TOP, b_timeOnTop);
   Serial.println("Time On Top");
 }
 
@@ -429,8 +420,7 @@ void timeOnTopOff() {
   actionMessage = "Weight On Top";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_timeOnTop, (bool)b_timeOnTop);
-  EEPROM.commit();
+  storagePutBool(KEY_TIME_ON_TOP, b_timeOnTop);
   Serial.println("Weight On Top");
 }
 
@@ -439,8 +429,7 @@ void btnFuncWhileConnectedOn() {
   actionMessage = "BLE Btns On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_btnFuncWhileConnected, (bool)b_btnFuncWhileConnected);
-  EEPROM.commit();
+  storagePutBool(KEY_BTN_CONN, b_btnFuncWhileConnected);
   Serial.println("BLE Btns On");
 }
 
@@ -449,8 +438,7 @@ void btnFuncWhileConnectedOff() {
   actionMessage = "BLE Btns Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_btnFuncWhileConnected, (bool)b_btnFuncWhileConnected);
-  EEPROM.commit();
+  storagePutBool(KEY_BTN_CONN, b_btnFuncWhileConnected);
   Serial.println("BLE Btns Off");
 }
 
@@ -459,9 +447,8 @@ void autoSleepOn() {
   actionMessage = "Autosleep On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_autoSleep, (bool)b_autoSleep);
-  EEPROM.commit();
-  Serial.println("Autosleep on stored in EEPROM.");
+  storagePutBool(KEY_AUTO_SLEEP, b_autoSleep);
+  Serial.println("Autosleep on stored in NVS.");
 }
 
 void autoSleepOff() {
@@ -469,9 +456,8 @@ void autoSleepOff() {
   actionMessage = "Autosleep Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_autoSleep, (bool)b_autoSleep);
-  EEPROM.commit();
-  Serial.println("Autosleep off stored in EEPROM.");
+  storagePutBool(KEY_AUTO_SLEEP, b_autoSleep);
+  Serial.println("Autosleep off stored in NVS.");
 }
 
 void quickBootOn() {
@@ -479,9 +465,8 @@ void quickBootOn() {
   actionMessage = "Quick Boot On";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_quickBoot, (bool)b_quickBoot);
-  EEPROM.commit();
-  Serial.println("Quick boot on stored in EEPROM.");
+  storagePutBool(KEY_QUICK_BOOT, b_quickBoot);
+  Serial.println("Quick boot on stored in NVS.");
 }
 
 void quickBootOff() {
@@ -489,9 +474,8 @@ void quickBootOff() {
   actionMessage = "Quick Boot Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_quickBoot, (bool)b_quickBoot);
-  EEPROM.commit();
-  Serial.println("Quick boot off stored in EEPROM.");
+  storagePutBool(KEY_QUICK_BOOT, b_quickBoot);
+  Serial.println("Quick boot off stored in NVS.");
 }
 
 void driftCompOff() {
@@ -499,9 +483,8 @@ void driftCompOff() {
   actionMessage = "Drift Comp Off";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_driftCompensation, f_maxDriftCompensation);
-  EEPROM.commit();
-  Serial.println("Drift Comp Off stored in EEPROM.");
+  storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
+  Serial.println("Drift Comp Off stored in NVS.");
 }
 
 void driftComp0050() {
@@ -509,9 +492,8 @@ void driftComp0050() {
   actionMessage = "Drift Comp 0.05g";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_driftCompensation, f_maxDriftCompensation);
-  EEPROM.commit();
-  Serial.println("Drift Comp 0.05g stored in EEPROM.");
+  storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
+  Serial.println("Drift Comp 0.05g stored in NVS.");
 }
 
 void driftComp0075() {
@@ -519,9 +501,8 @@ void driftComp0075() {
   actionMessage = "Drift Comp 0.075g";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_driftCompensation, f_maxDriftCompensation);
-  EEPROM.commit();
-  Serial.println("Drift Comp 0.075g stored in EEPROM.");
+  storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
+  Serial.println("Drift Comp 0.075g stored in NVS.");
 }
 
 void driftComp0100() {
@@ -529,9 +510,8 @@ void driftComp0100() {
   actionMessage = "Drift Comp 0.1g";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_driftCompensation, f_maxDriftCompensation);
-  EEPROM.commit();
-  Serial.println("Drift Comp 0.1g stored in EEPROM.");
+  storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
+  Serial.println("Drift Comp 0.1g stored in NVS.");
 }
 
 void driftComp0200() {
@@ -539,9 +519,8 @@ void driftComp0200() {
   actionMessage = "Drift Comp 0.2g";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  EEPROM.put(i_addr_driftCompensation, f_maxDriftCompensation);
-  EEPROM.commit();
-  Serial.println("Drift Comp 0.2g stored in EEPROM.");
+  storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
+  Serial.println("Drift Comp 0.2g stored in NVS.");
 }
 
 void calibrate() {
@@ -820,10 +799,7 @@ void calibrationSave(float previousCalibrationValue,
                      float verifiedWeight) {
   f_calibration_value = newCalibrationValue;
   scale.setCalFactor(f_calibration_value);
-  EEPROM.put(i_addr_calibration_value, f_calibration_value);
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040)
-  EEPROM.commit();
-#endif
+  storagePutFloat(KEY_CAL1, f_calibration_value);
   calibrationRecordDiagnostics(CAL_REJECT_NONE, f_calibration_value,
                                &zeroCapture, &loadCapture, verifiedWeight);
   calibrationPrintDiagnostics(CAL_REJECT_NONE, previousCalibrationValue,
@@ -1284,29 +1260,6 @@ void enableDebug() {
   // Optionally reset or perform an exit action
 }
 
-// void calibrateVoltage() {
-//   actionMessage = "Calibrate 4.2v";
-//   t_actionMessage = millis();
-//   int adcValue = analogRead(BATTERY_PIN); // Read the ADC value from the
-//   battery pin float voltageAtPin = (adcValue / adcResolution) *
-//   referenceVoltage;       // Calculate the voltage at the ADC pin float
-//   batteryVoltage = voltageAtPin * dividerRatio;                       //
-//   Calculate the actual battery voltage using the voltage divider ratio
-//   f_batteryCalibrationFactor = 4.2 / batteryVoltage; // Calculate the
-//   calibration factor from user input
-//   EEPROM.put(i_addr_batteryCalibrationFactor, f_batteryCalibrationFactor); //
-//   Store the calibration factor in EEPROM
-
-// #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040) ||
-// defined(ARDUINO_ARCH_MBED_RP2040)
-//   EEPROM.commit();  // Commit changes to EEPROM to save the calibration
-//   factor
-// #endif
-//   Serial.print("Battery Voltage Factor set to: ");  // Output the new
-//   calibration factor to the Serial Monitor
-//   Serial.println(f_batteryCalibrationFactor);
-// }
-
 void calibrateVoltage() {
   actionMessage = "Calibrate 4.2v";
   t_actionMessage = millis();
@@ -1330,12 +1283,7 @@ void calibrateVoltage() {
   // Calculate the calibration factor
   f_batteryCalibrationFactor = 4.2 / batteryVoltage;
 
-  // Store the calibration factor in EEPROM
-  EEPROM.put(i_addr_batteryCalibrationFactor, f_batteryCalibrationFactor);
-
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040)
-  EEPROM.commit();  // Commit changes to EEPROM
-#endif
+  storagePutFloat(KEY_BAT_CAL, f_batteryCalibrationFactor);
 
   // Output the new calibration factor to the Serial Monitor
   Serial.print("Battery Voltage Factor set to: ");

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -2,9 +2,11 @@
 #define PARAMETER_H
 //declaration
 #include <Arduino.h>
-#include <EEPROM.h>
+#include <Preferences.h>
 #include <math.h>
 #include "calibration_validation.h"
+
+Preferences settingsPreferences;
 
 //ble
 // volatile: read by the AsyncTCP task in the WS status frame, written by the
@@ -81,7 +83,7 @@ int i_onWrite_counter = 0;
 volatile unsigned long t_heartBeat = 0;
 volatile unsigned long t_firstConnect = 0;
 // volatile: read by the AsyncTCP task in the WS status frame, written by the
-// main-loop menu/EEPROM restore paths.
+// main-loop menu/NVS restore paths.
 volatile bool b_requireHeartBeat = true;
 volatile bool b_screenFlipped = false;
 volatile bool b_timeOnTop = false;
@@ -99,7 +101,7 @@ int bufferIndex = 0;
 const int i_margin_top = 8;
 const int i_margin_bottom = 8;
 
-int b_beep = 1;  //although it should be bool, change it from int to bool will affect eeprom address, because sizeof(b_beep) was used.
+int b_beep = 1;
 bool b_about = false;
 bool b_debug = false;
 
@@ -124,10 +126,6 @@ float INPUTCOFFEEPOUROVER = 20.0;
 float INPUTCOFFEEESPRESSO = 20.0;
 float f_batteryCalibrationFactor = 0.66;
 String str_welcome = "welcome";
-const size_t WELCOME_EEPROM_BYTES = 128;
-const size_t WELCOME_EEPROM_MAGIC_BYTES = 4;
-const size_t WELCOME_EEPROM_TEXT_BYTES = WELCOME_EEPROM_BYTES - WELCOME_EEPROM_MAGIC_BYTES;
-const char WELCOME_EEPROM_MAGIC[WELCOME_EEPROM_MAGIC_BYTES] = {'H', 'D', 'S', 'W'};
 float f_calibration_value = CALIBRATION_VALUE_DEFAULT;   //称重单元校准值
 bool b_calibrationInvalid = false;
 char c_calibrationStatus[32] = "ok";
@@ -385,96 +383,5 @@ float f_divider_factor = f_true_battery_reading / f_adc_battery_reading * 4.07 /
 #endif
 
 int i_display_rotation = 0;  //rotation 0 1 2 3 : 0 90 180 270
-
-//EEPROM Address
-int i_addr_calibration_value = 0;  //EEPROM start from 0, the calibration is shown as float calibrationValue;
-//int i_addr_sample = i_addr_calibration_value + sizeof(f_calibration_value);                              //int sample
-int i_addr_container = i_addr_calibration_value + sizeof(f_calibration_value);  //sample number float f_weight_container
-int i_addr_mode = i_addr_container + sizeof(f_weight_container);                //mode int b_mode
-int INPUTCOFFEEPOUROVER_ADDRESS = i_addr_mode + sizeof(b_mode);
-int INPUTCOFFEEESPRESSO_ADDRESS = INPUTCOFFEEPOUROVER_ADDRESS + sizeof(INPUTCOFFEEPOUROVER);
-int i_addr_beep = INPUTCOFFEEESPRESSO_ADDRESS + sizeof(INPUTCOFFEEESPRESSO);
-int i_addr_welcome = i_addr_beep + sizeof(b_beep);                                                   //str_welcome text slot
-int i_addr_batteryCalibrationFactor = i_addr_welcome + WELCOME_EEPROM_BYTES;                         //f_batteryCalibrationFactor
-int i_addr_requireHeartBeat = i_addr_batteryCalibrationFactor + sizeof(f_batteryCalibrationFactor);  //b_requireHeartBeat
-int i_addr_screenFlipped = i_addr_requireHeartBeat + sizeof(b_requireHeartBeat);                     //b_screenFlipped
-int i_addr_timeOnTop = i_addr_screenFlipped + sizeof(b_screenFlipped);                               //b_timeOnTop
-int i_addr_btnFuncWhileConnected = i_addr_timeOnTop + sizeof(b_timeOnTop);                           //b_btnFuncWhileConnected
-int i_addr_enableWifiOnBoot = i_addr_btnFuncWhileConnected + sizeof(b_btnFuncWhileConnected);        //b_wifiOnBoot
-int i_addr_autoSleep = i_addr_enableWifiOnBoot + sizeof(b_wifiOnBoot);
-int i_addr_quickBoot = i_addr_autoSleep + sizeof(b_autoSleep);//b_quickBoot
-int i_addr_driftCompensation = i_addr_quickBoot + sizeof(b_quickBoot);//f_maxDriftCompensation
-
-//int i_addr_enableWifiOnBoot = i_addr_btnFuncWhileConnected + sizeof(b_wifiOnBoot);
-
-
-//int i_addr_debug = i_addr_batteryCalibrationFactor + sizeof(f_batteryCalibrationFactor);  //str_welcome
-
-static inline const char *defaultWelcomeText() {
-#ifdef WELCOME1
-  return WELCOME1;
-#else
-  return "welcome";
-#endif
-}
-
-static inline bool isWelcomeTextByte(uint8_t value) {
-  return value >= 0x20 && value <= 0x7e;
-}
-
-static inline bool welcomeMagicMatches() {
-  for (size_t i = 0; i < WELCOME_EEPROM_MAGIC_BYTES; ++i) {
-    if (EEPROM.read(i_addr_welcome + i) != (uint8_t)WELCOME_EEPROM_MAGIC[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
-static inline void loadWelcomeFromEEPROM() {
-  char welcomeBuffer[WELCOME_EEPROM_TEXT_BYTES];
-  size_t textLen = 0;
-  bool valid = welcomeMagicMatches();
-
-  if (valid) {
-    for (size_t i = 0; i < WELCOME_EEPROM_TEXT_BYTES - 1; ++i) {
-      uint8_t value = EEPROM.read(i_addr_welcome + WELCOME_EEPROM_MAGIC_BYTES + i);
-      if (value == '\0') {
-        break;
-      }
-      if (!isWelcomeTextByte(value)) {
-        valid = false;
-        break;
-      }
-      welcomeBuffer[textLen++] = (char)value;
-    }
-  }
-
-  welcomeBuffer[textLen] = '\0';
-  if (valid && textLen > 0) {
-    str_welcome = String(welcomeBuffer);
-  } else {
-    str_welcome = defaultWelcomeText();
-  }
-  str_welcome.trim();
-}
-
-static inline void saveWelcomeToEEPROM(const String &welcome) {
-  String normalized = welcome;
-  normalized.trim();
-  const char *text = normalized.c_str();
-  size_t textLen = normalized.length();
-  if (textLen >= WELCOME_EEPROM_TEXT_BYTES) {
-    textLen = WELCOME_EEPROM_TEXT_BYTES - 1;
-  }
-
-  for (size_t i = 0; i < WELCOME_EEPROM_MAGIC_BYTES; ++i) {
-    EEPROM.write(i_addr_welcome + i, WELCOME_EEPROM_MAGIC[i]);
-  }
-  for (size_t i = 0; i < WELCOME_EEPROM_TEXT_BYTES; ++i) {
-    EEPROM.write(i_addr_welcome + WELCOME_EEPROM_MAGIC_BYTES + i, i < textLen ? text[i] : 0);
-  }
-  EEPROM.commit();
-}
 
 #endif

--- a/include/storage.h
+++ b/include/storage.h
@@ -1,0 +1,268 @@
+#ifndef STORAGE_H
+#define STORAGE_H
+
+#include <Arduino.h>
+#include <EEPROM.h>
+#include <Preferences.h>
+#include <math.h>
+#include "calibration_validation.h"
+#include "config.h"
+
+constexpr const char *STORAGE_NAMESPACE = "hds";
+constexpr const char *KEY_STORAGE_SCHEMA = "schema";
+constexpr uint16_t STORAGE_SCHEMA_VERSION = 1;
+constexpr const char *KEY_CAL1 = "cal1";
+constexpr const char *KEY_CONTAINER = "container";
+constexpr const char *KEY_MODE = "mode";
+constexpr const char *KEY_POUROVER = "pourover";
+constexpr const char *KEY_ESPRESSO = "espresso";
+constexpr const char *KEY_BEEP = "beep";
+constexpr const char *KEY_WELCOME = "welcome";
+constexpr const char *KEY_BAT_CAL = "bat_cal";
+constexpr const char *KEY_HEARTBEAT = "heartbeat";
+constexpr const char *KEY_SCREEN_FLIP = "screen_flip";
+constexpr const char *KEY_TIME_ON_TOP = "time_on_top";
+constexpr const char *KEY_BTN_CONN = "btn_conn";
+constexpr const char *KEY_WIFI_BOOT = "wifi_boot";
+constexpr const char *KEY_AUTO_SLEEP = "auto_sleep";
+constexpr const char *KEY_QUICK_BOOT = "quick_boot";
+constexpr const char *KEY_DRIFT_MAX = "drift_max";
+
+constexpr size_t LEGACY_EEPROM_BYTES = 512;
+constexpr size_t LEGACY_CAL1_ADDRESS = 0;
+constexpr size_t LEGACY_CONTAINER_ADDRESS = LEGACY_CAL1_ADDRESS + sizeof(float);
+constexpr size_t LEGACY_MODE_ADDRESS = LEGACY_CONTAINER_ADDRESS + sizeof(float);
+constexpr size_t LEGACY_POUROVER_ADDRESS = LEGACY_MODE_ADDRESS + sizeof(int);
+constexpr size_t LEGACY_ESPRESSO_ADDRESS = LEGACY_POUROVER_ADDRESS + sizeof(float);
+constexpr size_t LEGACY_BEEP_ADDRESS = LEGACY_ESPRESSO_ADDRESS + sizeof(float);
+constexpr size_t LEGACY_WELCOME_ADDRESS = LEGACY_BEEP_ADDRESS + sizeof(int);
+constexpr size_t LEGACY_WELCOME_BYTES = 128;
+constexpr size_t LEGACY_BAT_CAL_ADDRESS = LEGACY_WELCOME_ADDRESS + LEGACY_WELCOME_BYTES;
+constexpr size_t LEGACY_HEARTBEAT_ADDRESS = LEGACY_BAT_CAL_ADDRESS + sizeof(float);
+constexpr size_t LEGACY_SCREEN_FLIP_ADDRESS = LEGACY_HEARTBEAT_ADDRESS + sizeof(bool);
+constexpr size_t LEGACY_TIME_ON_TOP_ADDRESS = LEGACY_SCREEN_FLIP_ADDRESS + sizeof(bool);
+constexpr size_t LEGACY_BTN_CONN_ADDRESS = LEGACY_TIME_ON_TOP_ADDRESS + sizeof(bool);
+constexpr size_t LEGACY_WIFI_BOOT_ADDRESS = LEGACY_BTN_CONN_ADDRESS + sizeof(bool);
+constexpr size_t LEGACY_AUTO_SLEEP_ADDRESS = LEGACY_WIFI_BOOT_ADDRESS + sizeof(bool);
+constexpr size_t LEGACY_QUICK_BOOT_ADDRESS = LEGACY_AUTO_SLEEP_ADDRESS + sizeof(bool);
+constexpr size_t LEGACY_DRIFT_MAX_ADDRESS = LEGACY_QUICK_BOOT_ADDRESS + sizeof(bool);
+
+static_assert(sizeof(float) == 4);
+static_assert(sizeof(int) == 4);
+static_assert(sizeof(bool) == 1);
+
+extern Preferences settingsPreferences;
+
+inline float storageBatteryCalibrationDefault() {
+#ifdef V7_2
+  return 1.66f;
+#else
+  return 1.06f;
+#endif
+}
+
+inline bool storagePutFloat(const char *key, float value) {
+  return settingsPreferences.putFloat(key, value) == sizeof(float);
+}
+
+inline bool storagePutInt(const char *key, int value) {
+  return settingsPreferences.putInt(key, value) == sizeof(int);
+}
+
+inline bool storagePutBool(const char *key, bool value) {
+  return settingsPreferences.putBool(key, value) == sizeof(bool);
+}
+
+inline bool storagePutString(const char *key, const String &value) {
+  settingsPreferences.putString(key, value);
+  return settingsPreferences.isKey(key) &&
+         settingsPreferences.getString(key, "\x01") == value;
+}
+
+inline float storageGetFloat(const char *key, float defaultValue) {
+  return settingsPreferences.getFloat(key, defaultValue);
+}
+
+inline int storageGetInt(const char *key, int defaultValue) {
+  return settingsPreferences.getInt(key, defaultValue);
+}
+
+inline bool storageGetBool(const char *key, bool defaultValue) {
+  return settingsPreferences.getBool(key, defaultValue);
+}
+
+inline String storageGetString(const char *key, const String &defaultValue) {
+  return settingsPreferences.getString(key, defaultValue);
+}
+
+inline bool storageEnsureFloat(const char *key, float value) {
+  return settingsPreferences.isKey(key) || storagePutFloat(key, value);
+}
+
+inline bool storageEnsureInt(const char *key, int value) {
+  return settingsPreferences.isKey(key) || storagePutInt(key, value);
+}
+
+inline bool storageEnsureBool(const char *key, bool value) {
+  return settingsPreferences.isKey(key) || storagePutBool(key, value);
+}
+
+inline bool storageEnsureString(const char *key, const String &value) {
+  return settingsPreferences.isKey(key) || storagePutString(key, value);
+}
+
+inline bool storageHasAllSettings() {
+  const char *keys[] = {
+    KEY_CAL1, KEY_CONTAINER, KEY_MODE, KEY_POUROVER, KEY_ESPRESSO,
+    KEY_BEEP, KEY_WELCOME, KEY_BAT_CAL, KEY_HEARTBEAT, KEY_SCREEN_FLIP,
+    KEY_TIME_ON_TOP, KEY_BTN_CONN, KEY_WIFI_BOOT, KEY_AUTO_SLEEP,
+    KEY_QUICK_BOOT, KEY_DRIFT_MAX
+  };
+  for (const char *key : keys) {
+    if (!settingsPreferences.isKey(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline bool storageEnsureDefaults() {
+  return storageEnsureFloat(KEY_CAL1, CALIBRATION_VALUE_DEFAULT) &&
+         storageEnsureFloat(KEY_CONTAINER, 0.0f) &&
+         storageEnsureInt(KEY_MODE, 0) &&
+         storageEnsureFloat(KEY_POUROVER, 16.0f) &&
+         storageEnsureFloat(KEY_ESPRESSO, 18.0f) &&
+         storageEnsureInt(KEY_BEEP, 1) &&
+         storageEnsureString(KEY_WELCOME, String(WELCOME1)) &&
+         storageEnsureFloat(KEY_BAT_CAL, storageBatteryCalibrationDefault()) &&
+         storageEnsureBool(KEY_HEARTBEAT, true) &&
+         storageEnsureBool(KEY_SCREEN_FLIP, false) &&
+         storageEnsureBool(KEY_TIME_ON_TOP, false) &&
+         storageEnsureBool(KEY_BTN_CONN, false) &&
+         storageEnsureBool(KEY_WIFI_BOOT, false) &&
+         storageEnsureBool(KEY_AUTO_SLEEP, true) &&
+         storageEnsureBool(KEY_QUICK_BOOT, false) &&
+         storageEnsureFloat(KEY_DRIFT_MAX, 0.05f);
+}
+
+inline bool storageLegacyBool(size_t address, bool defaultValue) {
+  uint8_t value = 0xff;
+  EEPROM.get(address, value);
+  return value <= 1 ? value == 1 : defaultValue;
+}
+
+inline String storageLegacyWelcome() {
+  constexpr char magic[] = {'H', 'D', 'S', 'W'};
+  constexpr size_t magicBytes = sizeof(magic);
+  constexpr size_t textBytes = LEGACY_WELCOME_BYTES - magicBytes;
+  for (size_t index = 0; index < magicBytes; ++index) {
+    if (EEPROM.read(LEGACY_WELCOME_ADDRESS + index) != (uint8_t)magic[index]) {
+      return String(WELCOME1);
+    }
+  }
+  char text[textBytes];
+  size_t length = 0;
+  for (; length < textBytes - 1; ++length) {
+    uint8_t value = EEPROM.read(LEGACY_WELCOME_ADDRESS + magicBytes + length);
+    if (value == 0) {
+      break;
+    }
+    if (value < 0x20 || value > 0x7e) {
+      return String(WELCOME1);
+    }
+    text[length] = (char)value;
+  }
+  text[length] = 0;
+  String welcome(text);
+  welcome.trim();
+  return welcome.length() > 0 ? welcome : String(WELCOME1);
+}
+
+inline bool storageMigrateLegacyEeprom() {
+  if (!EEPROM.begin(LEGACY_EEPROM_BYTES)) {
+    return false;
+  }
+
+  float calibration = CALIBRATION_VALUE_DEFAULT;
+  float container = 0.0f;
+  int mode = 0;
+  float pourover = 16.0f;
+  float espresso = 18.0f;
+  int beep = 1;
+  float batteryCalibration = storageBatteryCalibrationDefault();
+  float driftMax = 0.05f;
+  EEPROM.get(LEGACY_CAL1_ADDRESS, calibration);
+  EEPROM.get(LEGACY_CONTAINER_ADDRESS, container);
+  EEPROM.get(LEGACY_MODE_ADDRESS, mode);
+  EEPROM.get(LEGACY_POUROVER_ADDRESS, pourover);
+  EEPROM.get(LEGACY_ESPRESSO_ADDRESS, espresso);
+  EEPROM.get(LEGACY_BEEP_ADDRESS, beep);
+  EEPROM.get(LEGACY_BAT_CAL_ADDRESS, batteryCalibration);
+  EEPROM.get(LEGACY_DRIFT_MAX_ADDRESS, driftMax);
+
+  if (!isValidCalibrationValue(calibration)) calibration = CALIBRATION_VALUE_DEFAULT;
+  if (!isfinite(container)) container = 0.0f;
+  if (mode < 0 || mode > 1) mode = 0;
+  if (!isfinite(pourover)) pourover = 16.0f;
+  if (!isfinite(espresso)) espresso = 18.0f;
+  if (beep < 0 || beep > 1) beep = 1;
+#ifdef V7_2
+  if (!isfinite(batteryCalibration) || batteryCalibration < 1.4f || batteryCalibration > 1.8f) {
+    batteryCalibration = 1.66f;
+  }
+#else
+  if (!isfinite(batteryCalibration) || batteryCalibration < 0.9f || batteryCalibration > 1.3f) {
+    batteryCalibration = 1.06f;
+  }
+#endif
+  if (!isfinite(driftMax)) driftMax = 0.05f;
+
+  bool migrated = storageEnsureFloat(KEY_CAL1, calibration) &&
+                  storageEnsureFloat(KEY_CONTAINER, container) &&
+                  storageEnsureInt(KEY_MODE, mode) &&
+                  storageEnsureFloat(KEY_POUROVER, pourover) &&
+                  storageEnsureFloat(KEY_ESPRESSO, espresso) &&
+                  storageEnsureInt(KEY_BEEP, beep) &&
+                  storageEnsureString(KEY_WELCOME, storageLegacyWelcome()) &&
+                  storageEnsureFloat(KEY_BAT_CAL, batteryCalibration) &&
+                  storageEnsureBool(KEY_HEARTBEAT, storageLegacyBool(LEGACY_HEARTBEAT_ADDRESS, true)) &&
+                  storageEnsureBool(KEY_SCREEN_FLIP, storageLegacyBool(LEGACY_SCREEN_FLIP_ADDRESS, false)) &&
+                  storageEnsureBool(KEY_TIME_ON_TOP, storageLegacyBool(LEGACY_TIME_ON_TOP_ADDRESS, false)) &&
+                  storageEnsureBool(KEY_BTN_CONN, storageLegacyBool(LEGACY_BTN_CONN_ADDRESS, false)) &&
+                  storageEnsureBool(KEY_WIFI_BOOT, storageLegacyBool(LEGACY_WIFI_BOOT_ADDRESS, false)) &&
+                  storageEnsureBool(KEY_AUTO_SLEEP, storageLegacyBool(LEGACY_AUTO_SLEEP_ADDRESS, true)) &&
+                  storageEnsureBool(KEY_QUICK_BOOT, storageLegacyBool(LEGACY_QUICK_BOOT_ADDRESS, false)) &&
+                  storageEnsureFloat(KEY_DRIFT_MAX, driftMax);
+  EEPROM.end();
+  return migrated;
+}
+
+inline bool storageInit() {
+  if (!settingsPreferences.begin(STORAGE_NAMESPACE, false)) {
+    return false;
+  }
+  if (settingsPreferences.getUShort(KEY_STORAGE_SCHEMA, 0) >= STORAGE_SCHEMA_VERSION) {
+    return storageEnsureDefaults();
+  }
+  if (!storageHasAllSettings() && !storageMigrateLegacyEeprom()) {
+    return false;
+  }
+  if (!storageHasAllSettings()) {
+    return false;
+  }
+  return settingsPreferences.putUShort(KEY_STORAGE_SCHEMA, STORAGE_SCHEMA_VERSION) == sizeof(uint16_t);
+}
+
+inline bool storagePutWelcome(const String &value) {
+  String welcome = value;
+  welcome.trim();
+  if (welcome.length() > LEGACY_WELCOME_BYTES - 5) {
+    welcome.remove(LEGACY_WELCOME_BYTES - 5);
+  }
+  if (welcome.length() == 0) {
+    welcome = String(WELCOME1);
+  }
+  return storagePutString(KEY_WELCOME, welcome);
+}
+
+#endif

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -304,7 +304,7 @@ public:
     inputString.trim(); // Remove leading/trailing whitespace
     Serial.printf("handling %s\n", inputString.c_str());
     if (inputString.startsWith("welcome ")) {
-      saveWelcomeToEEPROM(inputString.substring(8));
+      storagePutWelcome(inputString.substring(8));
     }
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
     if (inputString.startsWith("gyro")) {
@@ -316,8 +316,7 @@ public:
 
     if (inputString.startsWith("cp ")) {  //手冲粉量
       INPUTCOFFEEPOUROVER = inputString.substring(3).toFloat();
-      EEPROM.put(INPUTCOFFEEPOUROVER_ADDRESS, INPUTCOFFEEPOUROVER);
-      EEPROM.commit();
+      storagePutFloat(KEY_POUROVER, INPUTCOFFEEPOUROVER);
     }
 
     if (inputString.startsWith("v")) {  //电压
@@ -342,11 +341,7 @@ public:
       float voltageAtPin = (adcValue / adcResolution) * referenceVoltage;                // Calculate the voltage at the ADC pin
       float batteryVoltage = voltageAtPin * dividerRatio;                                // Calculate the actual battery voltage using the voltage divider ratio
       f_batteryCalibrationFactor = inputString.substring(3).toFloat() / batteryVoltage;  // Calculate the calibration factor from user input
-      EEPROM.put(i_addr_batteryCalibrationFactor, f_batteryCalibrationFactor);           // Store the calibration factor in EEPROM
-
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040)
-      EEPROM.commit();  // Commit changes to EEPROM to save the calibration factor
-#endif
+      storagePutFloat(KEY_BAT_CAL, f_batteryCalibrationFactor);
 
       Serial.print("Battery Voltage Factor set to: ");  // Output the new calibration factor to the Serial Monitor
       Serial.println(f_batteryCalibrationFactor);
@@ -357,8 +352,7 @@ public:
       if (isValidCalibrationValue(newCalibrationValue)) {
         f_calibration_value = newCalibrationValue;
         scale.setCalFactor(f_calibration_value);
-        EEPROM.put(i_addr_calibration_value, f_calibration_value);
-        EEPROM.commit();
+        storagePutFloat(KEY_CAL1, f_calibration_value);
         b_calibrationInvalid = false;
         snprintf(c_calibrationStatus, sizeof(c_calibrationStatus), "%s",
                  calibrationRejectReasonText(CAL_REJECT_NONE));
@@ -453,8 +447,6 @@ public:
         Serial.print("On ");
       else
         Serial.print("Off ");
-      //EEPROM.put(i_addr_debug, b_debug);
-      //EEPROM.commit();
     }
     
     if (inputString.startsWith("adsd ")) {
@@ -498,8 +490,7 @@ public:
 #ifdef BUZZER
     if (inputString.startsWith("beep")) {  //蜂鸣器
       b_beep = !b_beep;
-      EEPROM.put(i_addr_beep, b_beep);
-      EEPROM.commit();
+      storagePutInt(KEY_BEEP, b_beep);
     }
     // Send the updated values via USB serial
     Serial.print("\tBuzzer:");

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1,8 +1,8 @@
 #include <Arduino.h>
-#include <EEPROM.h>
 #include "config.h"
 
 #include "parameter.h"
+#include "storage.h"
 #include "power.h"
 #include "gyro.h"
 #include "display.h"
@@ -46,23 +46,6 @@ void adsDebugCallback(const ADS1232DebugInfo& info) {
     lastDebugPrint = now;
   }
 }
-
-// Reads a boolean value from EEPROM with validation.
-// If the stored value is not 0 or 1 (i.e., invalid or uninitialized data),
-// it will be replaced with the provided default value.
-bool readBoolEEPROMWithValidation(int addr, bool defaultVal) {
-  uint8_t val;
-  EEPROM.get(addr, val);  // Read raw byte from EEPROM
-  if (val == 0 || val == 1) {
-    // Valid boolean value found
-    return val;
-  }
-  // Invalid value, overwrite with default
-  EEPROM.put(addr, (uint8_t)defaultVal);
-  EEPROM.commit();
-  return defaultVal;
-}
-
 
 //buttons
 
@@ -233,7 +216,7 @@ void buttonSquare_Pressed() {
 void setButtonPressConfig(int button, float min_peak, float max_net, 
                          float min_recovery, unsigned long max_press_time,
                          unsigned long min_total_time) {
-  // Can add code here to save configurations via EEPROM or other methods
+  // Can add code here to save configurations via NVS or other methods
   // Currently using predefined macros, can be changed to variables later
   Serial.print("Button config updated for ");
   Serial.print(button == BUTTON_CIRCLE ? "Circle" : "Square");
@@ -410,17 +393,17 @@ void setup() {
     g_resetReasonCode = (uint8_t)r;
     Serial.printf("[boot] reset_reason=%s (%u)\n", resetReasonStr(r), (unsigned)g_resetReasonCode);
   }
-  if (!EEPROM.begin(512)) {
-    Serial.println("EEPROM init failed!");
+  if (!storageInit()) {
+    Serial.println("NVS settings init failed!");
     while (1) {
       delay(1000);
     }
   }
 
-  b_quickBoot = readBoolEEPROMWithValidation(i_addr_quickBoot, false);
+  b_quickBoot = storageGetBool(KEY_QUICK_BOOT, false);
   i_buttonBootDelay = b_quickBoot ? 0 : 500;
 
-  Serial.println("EEPROM init success");
+  Serial.println("NVS settings init success");
   
   // Initialize USB callback function pointers
   usbCallbacks.setStableOutputThreshold = setStableOutputThreshold;
@@ -573,7 +556,7 @@ void setup() {
   analogReadResolution(ADC_BIT);
 #ifdef BUZZER
   pinMode(BUZZER, OUTPUT);
-  EEPROM.get(i_addr_beep, b_beep);
+  b_beep = storageGetInt(KEY_BEEP, 1);
 
   if (GPIO_power_on_with != BATTERY_CHARGING) {
     buzzer.beep(1, BUZZER_DURATION);
@@ -585,9 +568,10 @@ void setup() {
   u8g2.setFont(FONT_M);
   power_off(15);
 #ifdef WELCOME
-  loadWelcomeFromEEPROM();
+  str_welcome = storageGetString(KEY_WELCOME, String(WELCOME1));
+  str_welcome.trim();
 #endif
-  b_screenFlipped = readBoolEEPROMWithValidation(i_addr_screenFlipped, false);
+  b_screenFlipped = storageGetBool(KEY_SCREEN_FLIP, false);
   if (b_screenFlipped)
     u8g2.setDisplayRotation(U8G2_R0);
   else
@@ -622,75 +606,59 @@ void setup() {
   stopWatch.setResolution(StopWatch::SECONDS);
   stopWatch.start();
   stopWatch.reset();
-  EEPROM.get(INPUTCOFFEEPOUROVER_ADDRESS, INPUTCOFFEEPOUROVER);
-  EEPROM.get(INPUTCOFFEEESPRESSO_ADDRESS, INPUTCOFFEEESPRESSO);
-  EEPROM.get(i_addr_batteryCalibrationFactor, f_batteryCalibrationFactor);
-  EEPROM.get(i_addr_mode, b_mode);
-  EEPROM.get(i_addr_driftCompensation, f_maxDriftCompensation);
-
-
-  //EEPROM.get(i_addr_debug, b_debug);
+  INPUTCOFFEEPOUROVER = storageGetFloat(KEY_POUROVER, 16.0f);
+  INPUTCOFFEEESPRESSO = storageGetFloat(KEY_ESPRESSO, 18.0f);
+  f_batteryCalibrationFactor = storageGetFloat(KEY_BAT_CAL, storageBatteryCalibrationDefault());
+  b_mode = storageGetInt(KEY_MODE, 0);
+  f_maxDriftCompensation = storageGetFloat(KEY_DRIFT_MAX, 0.05f);
 
   if (isnan(INPUTCOFFEEPOUROVER)) {
     INPUTCOFFEEPOUROVER = 16.0;
-    EEPROM.put(INPUTCOFFEEPOUROVER_ADDRESS, INPUTCOFFEEPOUROVER);
-    EEPROM.commit();
+    storagePutFloat(KEY_POUROVER, INPUTCOFFEEPOUROVER);
   }
   if (isnan(INPUTCOFFEEESPRESSO)) {
     INPUTCOFFEEESPRESSO = 18.0;
-    EEPROM.put(INPUTCOFFEEESPRESSO_ADDRESS, INPUTCOFFEEESPRESSO);
-    EEPROM.commit();
+    storagePutFloat(KEY_ESPRESSO, INPUTCOFFEEESPRESSO);
   }
   if (isnan(f_maxDriftCompensation)) {
     f_maxDriftCompensation = 0.05;
-    EEPROM.put(i_addr_driftCompensation, f_maxDriftCompensation);
-    EEPROM.commit();
+    storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
   }
 #ifdef V7_2
   if (isnan(f_batteryCalibrationFactor) || f_batteryCalibrationFactor < 1.4 || f_batteryCalibrationFactor > 1.8) {
     f_batteryCalibrationFactor = 1.66;
     //33k and 100k divider resistor
-    EEPROM.put(i_addr_batteryCalibrationFactor, f_batteryCalibrationFactor);
-    EEPROM.commit();
+    storagePutFloat(KEY_BAT_CAL, f_batteryCalibrationFactor);
   }
 #else
   if (isnan(f_batteryCalibrationFactor) || f_batteryCalibrationFactor < 0.9 || f_batteryCalibrationFactor > 1.3) {
     f_batteryCalibrationFactor = 1.06;
     //33k and 100k divider resistor
-    EEPROM.put(i_addr_batteryCalibrationFactor, f_batteryCalibrationFactor);
-    EEPROM.commit();
+    storagePutFloat(KEY_BAT_CAL, f_batteryCalibrationFactor);
   }
 #endif
 #ifdef BUZZER
   if (b_beep != 0 && b_beep != 1) {
     b_beep = 1;
-    EEPROM.put(i_addr_beep, b_beep);
-    EEPROM.commit();
+    storagePutInt(KEY_BEEP, b_beep);
   }
 #endif
 
-  b_requireHeartBeat = readBoolEEPROMWithValidation(i_addr_requireHeartBeat, true);
-  b_timeOnTop = readBoolEEPROMWithValidation(i_addr_timeOnTop, false);
-  b_btnFuncWhileConnected = readBoolEEPROMWithValidation(i_addr_btnFuncWhileConnected, false);
-  b_autoSleep = readBoolEEPROMWithValidation(i_addr_autoSleep, true);
-  // if (b_debug != 0 && b_debug != 1) {
-  //   b_debug = false;
-  //   EEPROM.put(i_addr_debug, b_debug);
-  //   EEPROM.commit();
-  // }
+  b_requireHeartBeat = storageGetBool(KEY_HEARTBEAT, true);
+  b_timeOnTop = storageGetBool(KEY_TIME_ON_TOP, false);
+  b_btnFuncWhileConnected = storageGetBool(KEY_BTN_CONN, false);
+  b_autoSleep = storageGetBool(KEY_AUTO_SLEEP, true);
   if (b_mode > 1) {
     b_mode = 0;
-    EEPROM.put(i_addr_mode, b_mode);
-    EEPROM.commit();
+    storagePutInt(KEY_MODE, b_mode);
   }
   if (b_mode < 0) {
     b_mode = 0;
-    EEPROM.put(i_addr_mode, b_mode);
-    EEPROM.commit();
+    storagePutInt(KEY_MODE, b_mode);
   }
 
   //loadcell calibration value check
-  EEPROM.get(i_addr_calibration_value, f_calibration_value);
+  f_calibration_value = storageGetFloat(KEY_CAL1, CALIBRATION_VALUE_DEFAULT);
   if (!isValidCalibrationValue(f_calibration_value)) {
     float storedCalibrationValue = f_calibration_value;
     CalibrationRejectReason bootCalibrationReason = CAL_REJECT_FACTOR_SIGN;
@@ -708,7 +676,7 @@ void setup() {
     Serial.print(F(" reason="));
     Serial.println(c_calibrationStatus);
     f_calibration_value = CALIBRATION_VALUE_DEFAULT;
-    Serial.println(F("Using temporary default calibration; EEPROM not overwritten."));
+    Serial.println(F("Using temporary default calibration; NVS not overwritten."));
   } else {
     b_calibrationInvalid = false;
     snprintf(c_calibrationStatus, sizeof(c_calibrationStatus), "%s",
@@ -734,7 +702,7 @@ void setup() {
     //calibration value is not valid, go to calibration procedure.
   }
 #endif
-  b_wifiOnBoot = readBoolEEPROMWithValidation(i_addr_enableWifiOnBoot, false);
+  b_wifiOnBoot = storageGetBool(KEY_WIFI_BOOT, false);
   if (b_wifiOnBoot && GPIO_power_on_with != BATTERY_CHARGING) {
     wifi_init();
   }

--- a/tools/test_storage_migration_contract.py
+++ b/tools/test_storage_migration_contract.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STORAGE = (ROOT / "include" / "storage.h").read_text(encoding="utf-8")
+
+
+def require(text, source=STORAGE):
+    assert text in source, f"missing storage contract: {text}"
+
+
+require('STORAGE_NAMESPACE = "hds"')
+assert '"cal2"' not in STORAGE
+assert '"ntc_cal"' not in STORAGE
+require('KEY_STORAGE_SCHEMA = "schema"')
+require("STORAGE_SCHEMA_VERSION = 1")
+
+for key, value in {
+    "KEY_CAL1": "cal1",
+    "KEY_CONTAINER": "container",
+    "KEY_MODE": "mode",
+    "KEY_POUROVER": "pourover",
+    "KEY_ESPRESSO": "espresso",
+    "KEY_BEEP": "beep",
+    "KEY_WELCOME": "welcome",
+    "KEY_BAT_CAL": "bat_cal",
+    "KEY_HEARTBEAT": "heartbeat",
+    "KEY_SCREEN_FLIP": "screen_flip",
+    "KEY_TIME_ON_TOP": "time_on_top",
+    "KEY_BTN_CONN": "btn_conn",
+    "KEY_WIFI_BOOT": "wifi_boot",
+    "KEY_AUTO_SLEEP": "auto_sleep",
+    "KEY_QUICK_BOOT": "quick_boot",
+    "KEY_DRIFT_MAX": "drift_max",
+}.items():
+    require(f'{key} = "{value}"')
+
+for address, value in {
+    "LEGACY_CAL1_ADDRESS": "0",
+    "LEGACY_WELCOME_ADDRESS": "LEGACY_BEEP_ADDRESS + sizeof(int)",
+    "LEGACY_WELCOME_BYTES": "128",
+    "LEGACY_DRIFT_MAX_ADDRESS": "LEGACY_QUICK_BOOT_ADDRESS + sizeof(bool)",
+}.items():
+    require(f"{address} = {value}")
+
+assert STORAGE.index("EEPROM.end();") < STORAGE.rindex(
+    "putUShort(KEY_STORAGE_SCHEMA, STORAGE_SCHEMA_VERSION)"
+)
+require("settingsPreferences.isKey(key) || storagePutFloat(key, value)")
+require("settingsPreferences.isKey(key) || storagePutBool(key, value)")
+
+for relative_path in (
+    "src/hds.ino",
+    "include/parameter.h",
+    "include/menu.h",
+    "include/usbcomm.h",
+    "include/ble.h",
+):
+    source = (ROOT / relative_path).read_text(encoding="utf-8")
+    assert "EEPROM" not in source, f"runtime EEPROM access in {relative_path}"
+
+print("storage migration contract: ok")


### PR DESCRIPTION
## Summary
- move HDS settings from EEPROM offsets to typed Preferences keys in the HDS-only `hds` namespace
- migrate legacy EEPROM values once without erasing the rollback-compatible blob
- keep WiFi and OTA namespaces unchanged; 

## Validation
- `python tools/test_storage_migration_contract.py`
- `python tools/test_calibration_validation.py`
- `python tools/test_soft_sleep_ads_wake.py`
- `python -m unittest test_ads_debug_protocol.py test_decode_ads_debug.py` from `tools/`
- `pio run -e esp32s3`
- live COM5 migration, reboot persistence, reversible NVS write, firmware rollback, and migration-firmware restore

## Open PR compatibility
- PRs #82 and #87 are not included because they are still open; after #88 merges, both should be rebased onto `main`.
- PR #82 must replace its remaining HDS WiFi EEPROM writes with `storagePutBool(KEY_WIFI_BOOT, ...)`; grinder settings remain in the separate `grinder` namespace.
- PR #87 keeps OTA state in the separate `ota_fs` and `ota_verify` namespaces and requires no HDS schema changes.

## Notes
- blank-device NVS erase was not performed on the connected scale