### PR TITLE
fix: lock partition table to default_8MB.csv

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,20 @@ jobs:
           pio run -e ${{ matrix.board }} 
           pio run -e ${{ matrix.board }} -t buildfs
 
+      - name: Assert vendored partition table matches framework
+        run: |
+          VENDORED=partitions/default_8MB.csv
+          UPSTREAM=~/.platformio/packages/framework-arduinoespressif32/tools/partitions/default_8MB.csv
+          if ! diff "$VENDORED" "$UPSTREAM" > /dev/null 2>&1; then
+            echo "::warning::Vendored $VENDORED differs from the framework-owned default_8MB.csv."
+            echo "This may be intentional (we pinned to an older layout) or the framework"
+            echo "has changed its partition table. Review the diff and decide whether to"
+            echo "update the vendored copy:"
+            diff "$VENDORED" "$UPSTREAM" || true
+          else
+            echo "Vendored partition table matches framework default_8MB.csv."
+          fi
+
       - name: "Run slugify"
         id: slugify
         uses: eltimn/slugify-action@v2.0.2

--- a/partitions/default_8MB.csv
+++ b/partitions/default_8MB.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x330000,
+app1,     app,  ota_1,   0x340000,0x330000,
+spiffs,   data, spiffs,  0x670000,0x180000,
+coredump, data, coredump,0x7F0000,0x10000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,14 +29,18 @@ framework = arduino
 # platform above is behind the latest pioarduino stable release, so a deliberate
 # pin doesn't silently rot. Never fails the build; skip with HDS_SKIP_PLATFORM_CHECK=1.
 extra_scripts = pre:check_platform_freshness.py
-# Partition table locked to the upstream arduino-esp32 default_8MB table (two
-# ~3.2 MB OTA slots, ~1.5 MB LittleFS, coredump). HDS <= 2.0 uses 16 MB flash;
-# HDS 2.0 uses 8 MB. We pin to 8 MB now so the HDS 2.0 transition (16→8 MB)
-# needs no partition table change — the firmware already fits in 8 MB.
-# Trade-off: wastes upper 8 MB on current HDS 1.x hardware.
-# Keep in sync with:
-# https://github.com/espressif/arduino-esp32/blob/master/tools/partitions/default_8MB.csv
-board_build.partitions = default_8MB.csv
+# Partition table: vendored copy of the upstream arduino-esp32 default_8MB.csv.
+# The board (esp32-s3-devkitc-1, 8 MB flash) already defaults to this layout,
+# so this line is currently a no-op. It makes the implicit default explicit so
+# a future platform upgrade cannot silently change the partition layout on us.
+#
+# HDS 1.x ships with 16 MB flash; HDS 2.0 will use 8 MB. The firmware already
+# fits in 8 MB, so pinning 8 MB now means the HDS 2.0 transition needs no
+# partition-table change (which would require a full erase + re-flash).
+# Trade-off: wastes the upper 8 MB on current HDS 1.x hardware.
+#
+# The vendored copy is kept in partitions/default_8MB.csv.
+board_build.partitions = partitions/default_8MB.csv
 board_build.filesystem = littlefs
 monitor_speed = 115200
 upload_speed = 921600

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,14 @@ framework = arduino
 # platform above is behind the latest pioarduino stable release, so a deliberate
 # pin doesn't silently rot. Never fails the build; skip with HDS_SKIP_PLATFORM_CHECK=1.
 extra_scripts = pre:check_platform_freshness.py
-#board_build.partitions = <min_spiffs.csv>
+# Partition table locked to the upstream arduino-esp32 default_8MB table (two
+# ~3.2 MB OTA slots, ~1.5 MB LittleFS, coredump). HDS <= 2.0 uses 16 MB flash;
+# HDS 2.0 uses 8 MB. We pin to 8 MB now so the HDS 2.0 transition (16→8 MB)
+# needs no partition table change — the firmware already fits in 8 MB.
+# Trade-off: wastes upper 8 MB on current HDS 1.x hardware.
+# Keep in sync with:
+# https://github.com/espressif/arduino-esp32/blob/master/tools/partitions/default_8MB.csv
+board_build.partitions = default_8MB.csv
 board_build.filesystem = littlefs
 monitor_speed = 115200
 upload_speed = 921600


### PR DESCRIPTION
## Summary

Replace the commented-out placeholder partition table with the upstream arduino-esp32 `default_8MB.csv`.

### Partition layout

| Partition | Type | Size | Purpose |
|-----------|------|------|---------|
| nvs | data/nvs | 20 KB | Non-volatile storage |
| otadata | data/ota | 8 KB | OTA slot tracking |
| app0 | app/ota_0 | 3.2 MB | First OTA app slot |
| app1 | app/ota_1 | 3.2 MB | Second OTA app slot |
| spiffs | data/spiffs | 1.5 MB | LittleFS (web assets) |
| coredump | data/coredump | 64 KB | Crash dumps |

### Rationale

HDS < 2.0 uses **16 MB flash**; HDS 2.0 will use **8 MB flash**. Pinning the partition table to 8 MB now ensures the HDS 2.0 flash-size transition needs **no partition table change** — the firmware already fits in 8 MB. A partition table change on existing deployed devices requires erasing flash + re-flashing (cannot be done via OTA alone).

**Trade-off:** wastes the upper 8 MB on current HDS 1.x hardware (16 MB flash). This is an intentional forward-compatibility decision.

Reference: https://github.com/espressif/arduino-esp32/blob/master/tools/partitions/default_8MB.csv