### PR TITLE
fix: recover grinder after stable zero

### DIFF
--- a/include/grinder_runtime.h
+++ b/include/grinder_runtime.h
@@ -304,7 +304,6 @@ static inline void grinderDisconnectToFinding() {
   grinderResetGrindConfirmation();
   grinderRuntime.tarePending = false;
   grinderRuntime.tareRequestArmsGrinder = false;
-  grinderRuntime.userTareComplete = false;
   grinderRuntime.tareRearmRequested = false;
   grinderAdaptiveShotReset(&grinderRuntime.adaptiveShot);
   grinderSetState(grinderSettings.enabled ? GRINDER_STATE_FINDING_PLUG : GRINDER_STATE_DISABLED);
@@ -460,9 +459,8 @@ static inline void grinderHandleOkResponse(const GrinderTcpResponse &response, f
     case GRINDER_COMMAND_HELLO:
       grinderRuntime.pendingCommand = GRINDER_COMMAND_NONE;
       grinderRuntime.tareRequestArmsGrinder = false;
-      grinderRuntime.userTareComplete = false;
       grinderRuntime.tareRearmRequested = response.relayOn;
-      grinderSetStatus("tare to arm");
+      grinderSetStatus(grinderRuntime.userTareComplete ? "zero wait" : "tare to arm");
       if (response.relayOn) {
         if (!grinderSendOff()) {
           grinderEnterError("off send failed");

--- a/include/grinder_runtime_low_latency.h
+++ b/include/grinder_runtime_low_latency.h
@@ -58,7 +58,9 @@ static inline void grinderResetGrindConfirmation() {
 }
 
 static inline void grinderRuntimeNotifyTareRequested(bool userRequested) {
-  if (!grinderSettings.enabled || grinderRuntime.state == GRINDER_STATE_DISABLED) {
+  if (!grinderSettings.enabled ||
+      grinderRuntime.state == GRINDER_STATE_DISABLED ||
+      grinderRuntime.state == GRINDER_STATE_ERROR) {
     return;
   }
   grinderRuntime.tarePending = true;
@@ -96,6 +98,10 @@ static inline void grinderRuntimeNotifyTareComplete() {
     grinderSetState(GRINDER_STATE_CONNECTED);
   } else if (grinderRuntime.state == GRINDER_STATE_CONNECTED) {
     grinderSetStatus(grinderRuntime.userTareComplete ? "zero wait" : "tare to arm");
+  } else if (grinderRuntime.state == GRINDER_STATE_ARMED) {
+    grinderSetStatus("armed");
+  } else if (grinderRuntime.state == GRINDER_STATE_FINDING_PLUG) {
+    grinderSetStatus("plug wait");
   }
 }
 
@@ -143,6 +149,16 @@ static inline void grinderTickGrindingCutoff(float weight) {
   if (grinderRuntime.state != GRINDER_STATE_GRINDING) {
     return;
   }
+  if (grinderRuntime.setupMassBlocked) {
+    if (grinderZeroStable(weight)) {
+      grinderResetCutoffGuard();
+      grinderResetGrindConfirmation();
+      grinderSetStatus("ready");
+    } else {
+      grinderSetStatus("zero wait");
+    }
+    return;
+  }
   const uint32_t now = millis();
   grinderUpdateRate(weight);
   const float rate = grinderRuntime.rateSamples > 0 ? grinderRuntime.grindRateGps : 0.0f;
@@ -152,7 +168,6 @@ static inline void grinderTickGrindingCutoff(float weight) {
   } else {
     grinderTrackGrindConfirmation(weight, now);
   }
-  const bool setupMassWasBlocked = grinderRuntime.setupMassBlocked;
   if (!grinderCutoffShouldStop(weight,
                                grinderSettings.zeroMaxGrams,
                                grinderSettings.targetGrams,
@@ -163,9 +178,7 @@ static inline void grinderTickGrindingCutoff(float weight) {
                                &grinderRuntime.cutoffGuardZeroExitAt,
                                &grinderRuntime.setupMassBlocked)) {
     if (grinderRuntime.setupMassBlocked) {
-      grinderSetStatus("tare cup");
-    } else if (setupMassWasBlocked) {
-      grinderSetStatus("ready");
+      grinderSetStatus("zero wait");
     }
     return;
   }

--- a/tools/test_grinder_tcp_contract.py
+++ b/tools/test_grinder_tcp_contract.py
@@ -81,6 +81,11 @@ def test_adaptive_safety_source_contracts():
 def test_low_latency_cutoff_source_contracts():
     low_latency = source(LOW_LATENCY_HEADER)
     runtime = source(RUNTIME_HEADER)
+    tare_requested_start = low_latency.index("static inline void grinderRuntimeNotifyTareRequested")
+    tare_complete_start = low_latency.index("static inline void grinderRuntimeNotifyTareComplete")
+    tare_complete_end = low_latency.index("static inline void grinderStartGrindCandidate")
+    tare_requested = low_latency[tare_requested_start:tare_complete_start]
+    tare_complete = low_latency[tare_complete_start:tare_complete_end]
     cutoff_start = low_latency.index("static inline void grinderTickGrindingCutoff")
     fresh_start = low_latency.index("static inline void grinderRuntimeFreshWeightTick")
     assert "const uint8_t command[] = { '!', '\\n' };" in low_latency
@@ -94,7 +99,15 @@ def test_low_latency_cutoff_source_contracts():
     assert "GRINDER_CONFIRM_MIN_POSITIVE_SAMPLES 3" in low_latency
     assert "grinderRuntime.tarePending" in low_latency
     assert "grinderRuntime.setupMassBlocked" in low_latency
-    assert 'grinderSetStatus("tare cup")' in low_latency
+    cutoff = low_latency[cutoff_start:fresh_start]
+    blocked_start = cutoff.index("if (grinderRuntime.setupMassBlocked)")
+    blocked_end = cutoff.index("const uint32_t now")
+    blocked = cutoff[blocked_start:blocked_end]
+    assert 'grinderSetStatus("tare cup")' not in cutoff
+    assert "grinderZeroStable(weight)" in blocked
+    assert "grinderResetCutoffGuard()" in blocked
+    assert 'grinderSetStatus("ready")' in blocked
+    assert "grinderSendOff()" not in blocked
     assert "averageRate > GRINDER_MAX_GRIND_RATE_GPS" in low_latency
     assert "grinderRuntime.grindConfirmed = true" in low_latency
     assert "grinderWeightInPositiveDoseRange(weight)" in low_latency
@@ -105,6 +118,9 @@ def test_low_latency_cutoff_source_contracts():
     assert "grinderCutoffGrams(grinderSettings.targetGrams, grinderSettings.safetyMarginGrams)" in low_latency
     assert "now - grinderRuntime.lastCommandAt >= 150" in runtime
     assert "grinderEnterError(\"lost plug\")" in runtime
+    assert "grinderRuntime.state == GRINDER_STATE_ERROR" in tare_requested
+    assert 'grinderSetStatus("armed");' in tare_complete
+    assert 'grinderSetStatus("plug wait");' in tare_complete
 
 
 def test_pending_command_timeouts_source_contracts():
@@ -206,6 +222,7 @@ def test_firmware_contracts():
     assert_contains(RUNTIME_HEADER, 'grinderSetStatus("tare to arm")')
     assert_contains(RUNTIME_HEADER, "bool userTareComplete = false")
     assert_contains(RUNTIME_HEADER, "grinderRuntime.userTareComplete = false")
+    assert source(RUNTIME_HEADER).count("grinderRuntime.userTareComplete = false;") == 1
     assert_contains(RUNTIME_HEADER, "grinderRuntime.tareRearmRequested = response.relayOn")
     assert_not_contains(RUNTIME_HEADER, "grind timeout")
     assert_contains(RUNTIME_HEADER, "bool setupMassBlocked = false")


### PR DESCRIPTION
Follow-up to #82. Preserves the one-time user tare across transient grinder TCP reconnects, clears stale tare status, keeps the fast-rise false-cutoff suppression, and clears that block only after stable zero so the grinder returns to ready without another tare. Error states remain fail-safe. Validation: grinder, storage, calibration, soft-sleep, and charging-wake contracts; native MSVC grinder contract; ESP32-S3 build; COM5 hardware test including fast 100 g finger load and stable-zero recovery.