### PR TITLE
fix: tolerate transient grinder heartbeat loss

### DIFF
--- a/include/grinder_protocol.h
+++ b/include/grinder_protocol.h
@@ -23,6 +23,15 @@
 #define GRINDER_MIN_CUTOFF_GRAMS 5.0f
 #define GRINDER_CUTOFF_ZERO_EXIT_PROTECTION_MS 1500
 #define GRINDER_MAX_GRIND_RATE_GPS 6.0f
+#define GRINDER_HEARTBEAT_INTERVAL_MS 500
+#define GRINDER_HEARTBEAT_RESPONSE_TIMEOUT_MS 500
+#define GRINDER_HEARTBEAT_MAX_MISSES 3
+#define GRINDER_HEARTBEAT_MAX_SILENCE_MS 1750
+
+static inline bool grinderHeartbeatLost(uint8_t missedResponses, uint32_t lastValidResponseAt, uint32_t now) {
+  return missedResponses >= GRINDER_HEARTBEAT_MAX_MISSES ||
+         now - lastValidResponseAt >= GRINDER_HEARTBEAT_MAX_SILENCE_MS;
+}
 
 enum GrinderTcpResponseKind {
   GRINDER_TCP_RESPONSE_INVALID,

--- a/include/grinder_runtime.h
+++ b/include/grinder_runtime.h
@@ -18,10 +18,6 @@
 #define GRINDER_RUNTIME_HOST_RESOLVE_TIMEOUT_MS 250
 #endif
 
-#ifndef GRINDER_RUNTIME_PING_TIMEOUT_MS
-#define GRINDER_RUNTIME_PING_TIMEOUT_MS 1200
-#endif
-
 enum GrinderDosingState {
   GRINDER_STATE_DISABLED,
   GRINDER_STATE_FINDING_PLUG,
@@ -111,6 +107,7 @@ struct GrinderRuntime {
   uint32_t cutoffGuardZeroExitAt = 0;
   uint32_t grindCandidateStartAt = 0;
   uint8_t grindCandidatePositiveSamples = 0;
+  uint8_t missedPingResponses = 0;
 };
 
 GrinderSettings grinderSettings;
@@ -305,6 +302,7 @@ static inline void grinderDisconnectToFinding() {
   grinderRuntime.tarePending = false;
   grinderRuntime.tareRequestArmsGrinder = false;
   grinderRuntime.tareRearmRequested = false;
+  grinderRuntime.userTareComplete = false;
   grinderAdaptiveShotReset(&grinderRuntime.adaptiveShot);
   grinderSetState(grinderSettings.enabled ? GRINDER_STATE_FINDING_PLUG : GRINDER_STATE_DISABLED);
 }
@@ -416,8 +414,7 @@ static inline bool grinderPlugConnectionStale(uint32_t now) {
   if (!grinderRuntime.client.connected()) {
     return true;
   }
-  return grinderRuntime.pendingCommand == GRINDER_COMMAND_PING &&
-         now - grinderRuntime.lastCommandAt > GRINDER_RUNTIME_PING_TIMEOUT_MS;
+  return grinderHeartbeatLost(grinderRuntime.missedPingResponses, grinderRuntime.lastRxAt, now);
 }
 
 #include "grinder_runtime_low_latency.h"
@@ -519,11 +516,12 @@ static inline void grinderHandleResponseLine(float weight) {
     grinderEnterError("bad response");
     return;
   }
-  grinderRuntime.lastRxAt = millis();
   if (!grinderResponseMatchesSelection(response)) {
     grinderEnterError("wrong mac");
     return;
   }
+  grinderRuntime.lastRxAt = millis();
+  grinderRuntime.missedPingResponses = 0;
   if (response.kind == GRINDER_TCP_RESPONSE_BUSY) {
     grinderEnterError("busy");
     return;
@@ -577,6 +575,7 @@ static inline bool grinderAttemptConnect(IPAddress ip) {
   grinderRuntime.client.setNoDelay(true);
   grinderRuntime.lastRxAt = millis();
   grinderRuntime.lastPingAt = 0;
+  grinderRuntime.missedPingResponses = 0;
   grinderResetLineReader();
   if (!grinderSendHello()) {
     Serial.println("[grinder] HELLO send failed");
@@ -636,7 +635,7 @@ static inline void grinderSendPingIfDue() {
   if (grinderRuntime.pendingCommand != GRINDER_COMMAND_NONE) {
     return;
   }
-  if (millis() - grinderRuntime.lastPingAt >= 500) {
+  if (millis() - grinderRuntime.lastPingAt >= GRINDER_HEARTBEAT_INTERVAL_MS) {
     grinderSendSimpleCommand("PING", GRINDER_COMMAND_PING);
   }
 }
@@ -647,7 +646,16 @@ static inline void grinderCheckConnectionLoss() {
       grinderRuntime.state == GRINDER_STATE_ERROR) {
     return;
   }
-  if (grinderPlugConnectionStale(millis())) {
+  const uint32_t now = millis();
+  if (grinderRuntime.pendingCommand == GRINDER_COMMAND_PING &&
+      now - grinderRuntime.lastCommandAt >= GRINDER_HEARTBEAT_RESPONSE_TIMEOUT_MS) {
+    grinderRuntime.pendingCommand = GRINDER_COMMAND_NONE;
+    if (grinderRuntime.missedPingResponses < UINT8_MAX) {
+      grinderRuntime.missedPingResponses++;
+    }
+    Serial.printf("[grinder] heartbeat miss=%u\n", grinderRuntime.missedPingResponses);
+  }
+  if (grinderPlugConnectionStale(now)) {
     if (grinderRuntime.state == GRINDER_STATE_GRINDING || grinderRuntime.state == GRINDER_STATE_STOPPING) {
       grinderEnterError("lost plug");
     } else {
@@ -757,6 +765,7 @@ static inline void grinderRuntimeReset() {
   grinderRuntime.rateSamples = 0;
   grinderRuntime.removalSeen = false;
   grinderRuntime.lastFastWeightSequence = 0;
+  grinderRuntime.missedPingResponses = 0;
   grinderResetCutoffGuard();
   grinderResetGrindConfirmation();
   grinderRuntime.tarePending = false;

--- a/include/grinder_runtime.h
+++ b/include/grinder_runtime.h
@@ -417,6 +417,8 @@ static inline bool grinderPlugConnectionStale(uint32_t now) {
   return grinderHeartbeatLost(grinderRuntime.missedPingResponses, grinderRuntime.lastRxAt, now);
 }
 
+static inline void grinderCheckConnectionLoss();
+
 #include "grinder_runtime_low_latency.h"
 
 static inline bool grinderLineRead(char value) {
@@ -657,10 +659,10 @@ static inline void grinderCheckConnectionLoss() {
   }
   if (grinderPlugConnectionStale(now)) {
     if (grinderRuntime.state == GRINDER_STATE_GRINDING || grinderRuntime.state == GRINDER_STATE_STOPPING) {
-      grinderEnterError("lost plug");
-    } else {
-      grinderDisconnectToFinding();
+      grinderSendOff();
     }
+    grinderSetStatus("lost plug");
+    grinderDisconnectToFinding();
   }
 }
 

--- a/include/grinder_runtime_low_latency.h
+++ b/include/grinder_runtime_low_latency.h
@@ -208,7 +208,7 @@ static inline void grinderRuntimeFreshWeightTick(float weight, uint32_t sampleSe
     return;
   }
   if (grinderPlugConnectionStale(millis())) {
-    grinderEnterError("lost plug");
+    grinderCheckConnectionLoss();
     return;
   }
   grinderTickGrindingCutoff(weight);

--- a/tools/test_grinder_contract.cpp
+++ b/tools/test_grinder_contract.cpp
@@ -39,6 +39,9 @@ int main() {
   assert(setupMassBlocked);
   assert(grinderCanArmAfterTare(true, true));
   assert(!grinderCanArmAfterTare(false, true));
+  assert(!grinderHeartbeatLost(2, 1000, 2500));
+  assert(grinderHeartbeatLost(3, 1000, 2500));
+  assert(grinderHeartbeatLost(0, 1000, 2750));
   GrinderAdaptiveShot shot;
   grinderAdaptiveShotReset(&shot);
   grinderAdaptiveShotTrack(&shot, 2.0f, 1.0f, 15.0f, 1);

--- a/tools/test_grinder_tcp_contract.py
+++ b/tools/test_grinder_tcp_contract.py
@@ -81,6 +81,9 @@ def test_adaptive_safety_source_contracts():
 def test_low_latency_cutoff_source_contracts():
     low_latency = source(LOW_LATENCY_HEADER)
     runtime = source(RUNTIME_HEADER)
+    connection_loss_start = runtime.index("static inline void grinderCheckConnectionLoss")
+    connection_loss_end = runtime.index("static inline void grinderTickConnected")
+    connection_loss = runtime[connection_loss_start:connection_loss_end]
     tare_requested_start = low_latency.index("static inline void grinderRuntimeNotifyTareRequested")
     tare_complete_start = low_latency.index("static inline void grinderRuntimeNotifyTareComplete")
     tare_complete_end = low_latency.index("static inline void grinderStartGrindCandidate")
@@ -118,6 +121,12 @@ def test_low_latency_cutoff_source_contracts():
     assert "grinderCutoffGrams(grinderSettings.targetGrams, grinderSettings.safetyMarginGrams)" in low_latency
     assert "now - grinderRuntime.lastCommandAt >= 150" in runtime
     assert "grinderEnterError(\"lost plug\")" in runtime
+    assert "GRINDER_HEARTBEAT_INTERVAL_MS 500" in source(PROTOCOL_HEADER)
+    assert "GRINDER_HEARTBEAT_RESPONSE_TIMEOUT_MS 500" in source(PROTOCOL_HEADER)
+    assert "GRINDER_HEARTBEAT_MAX_MISSES 3" in source(PROTOCOL_HEADER)
+    assert "GRINDER_HEARTBEAT_MAX_SILENCE_MS 1750" in source(PROTOCOL_HEADER)
+    assert "grinderRuntime.pendingCommand = GRINDER_COMMAND_NONE;" in connection_loss
+    assert "grinderRuntime.missedPingResponses++;" in connection_loss
     assert "grinderRuntime.state == GRINDER_STATE_ERROR" in tare_requested
     assert 'grinderSetStatus("armed");' in tare_complete
     assert 'grinderSetStatus("plug wait");' in tare_complete
@@ -222,7 +231,7 @@ def test_firmware_contracts():
     assert_contains(RUNTIME_HEADER, 'grinderSetStatus("tare to arm")')
     assert_contains(RUNTIME_HEADER, "bool userTareComplete = false")
     assert_contains(RUNTIME_HEADER, "grinderRuntime.userTareComplete = false")
-    assert source(RUNTIME_HEADER).count("grinderRuntime.userTareComplete = false;") == 1
+    assert source(RUNTIME_HEADER).count("grinderRuntime.userTareComplete = false;") == 2
     assert_contains(RUNTIME_HEADER, "grinderRuntime.tareRearmRequested = response.relayOn")
     assert_not_contains(RUNTIME_HEADER, "grind timeout")
     assert_contains(RUNTIME_HEADER, "bool setupMassBlocked = false")

--- a/tools/test_grinder_tcp_contract.py
+++ b/tools/test_grinder_tcp_contract.py
@@ -84,6 +84,9 @@ def test_low_latency_cutoff_source_contracts():
     connection_loss_start = runtime.index("static inline void grinderCheckConnectionLoss")
     connection_loss_end = runtime.index("static inline void grinderTickConnected")
     connection_loss = runtime[connection_loss_start:connection_loss_end]
+    disconnect_start = runtime.index("static inline void grinderDisconnectToFinding")
+    disconnect_end = runtime.index("static inline bool grinderSendOff")
+    disconnect = runtime[disconnect_start:disconnect_end]
     tare_requested_start = low_latency.index("static inline void grinderRuntimeNotifyTareRequested")
     tare_complete_start = low_latency.index("static inline void grinderRuntimeNotifyTareComplete")
     tare_complete_end = low_latency.index("static inline void grinderStartGrindCandidate")
@@ -120,7 +123,13 @@ def test_low_latency_cutoff_source_contracts():
     assert low_latency.index('grinderSetStatus("grinding");') > low_latency.index("grinderRuntime.grindConfirmed = true")
     assert "grinderCutoffGrams(grinderSettings.targetGrams, grinderSettings.safetyMarginGrams)" in low_latency
     assert "now - grinderRuntime.lastCommandAt >= 150" in runtime
-    assert "grinderEnterError(\"lost plug\")" in runtime
+    assert 'grinderSetStatus("lost plug")' in connection_loss
+    assert "grinderSendOff();" in connection_loss
+    assert "grinderDisconnectToFinding();" in connection_loss
+    assert "grinderRuntime.userTareComplete = false;" in disconnect
+    assert 'grinderEnterError("lost plug")' not in runtime
+    assert 'grinderEnterError("lost plug")' not in low_latency
+    assert "grinderCheckConnectionLoss();" in low_latency[fresh_start:]
     assert "GRINDER_HEARTBEAT_INTERVAL_MS 500" in source(PROTOCOL_HEADER)
     assert "GRINDER_HEARTBEAT_RESPONSE_TIMEOUT_MS 500" in source(PROTOCOL_HEADER)
     assert "GRINDER_HEARTBEAT_MAX_MISSES 3" in source(PROTOCOL_HEADER)


### PR DESCRIPTION
## Summary

- tolerate isolated missed grinder heartbeat replies by expiring the pending PING and retrying
- disconnect after three misses or 1750 ms without a valid response through the existing reconnect path
- send a best-effort `OFF` and reconnect after plug loss during grinding or stopping instead of remaining latched in `ERROR`
- require a fresh tare after reconnect before grinder control can arm again
- leave menu and plug discovery behavior unchanged

## Why

A single delayed or lost PING reply remained pending and caused the scale to declare the plug disconnected after 1200 ms. Over a multi-hour connection, one dropped reply was enough to trigger the reported failure. Plug loss during grinding or stopping also entered a permanent error state, so a recovered or reflashed plug could not reconnect without restarting the scale.

## Safety

Loss during grinding or stopping first attempts `OFF`, closes the stale client, and returns to plug finding. Every reconnect clears the previous tare state, so the grinder cannot arm again until the user performs a fresh tare.

## Validation

- `python tools/test_grinder_tcp_contract.py` passes; the optional native host compile is skipped because no host compiler is installed
- `pio run -e esp32s3` succeeds
- flashed to the ESP32-S3 scale on COM5 without erasing NVS
- one-minute real-plug capture stayed connected with zero heartbeat misses
- forced plug restart produced heartbeat misses 1 and 2, then recovered on valid replies without disconnecting
- hardware-tested in a combined PR #94 + PR #96 + reconnect-fix image: reflashing Tasmota caused `plug wait`, the scale reconnected automatically, and the display required `tare to arm`

A multi-hour hardware soak remains pending because that is the timescale of the original failure.