### PR TITLE
Reduce transient String allocations

### DIFF
--- a/include/webserver.h
+++ b/include/webserver.h
@@ -123,7 +123,7 @@ void startWebServer() {
     //     bucket is clamped at HTTP_STREAMING_BURST, so accumulated idle time
     //     never pre-fills it beyond the burst depth.
     server.addMiddleware([](AsyncWebServerRequest *request, ArMiddlewareNext next) {
-      String url = request->url();
+      const String &url = request->url();
       if (url == "/snapshot") {
         next();
         return;

--- a/include/wifi_setup.h
+++ b/include/wifi_setup.h
@@ -6,8 +6,8 @@
 // if not, start AP mode
 void setupWifi();
 void stopWifi();
-void saveCredentials(String ssid, String pass); // ssid, pass
-bool saveCredentialsForRestart(String ssid, String pass);
+void saveCredentials(const String &ssid, const String &pass); // ssid, pass
+bool saveCredentialsForRestart(const String &ssid, const String &pass);
 bool wifiCredentialsSaved();
 bool wifiEnsureMdnsReadyForSta();
 

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <cstring>
 #include "config.h"
 
 #include "parameter.h"
@@ -1987,7 +1988,7 @@ void drawWeight(float input) {
     int y = AT() - 15;  // Weight y when timer is shown.
     if (b_timeOnTop)
       y = AT() + 9;
-    if (String(sec2sec(stopWatch.elapsed())) == "0s") {
+    if (strcmp(sec2sec(stopWatch.elapsed()), "0s") == 0) {
       y = AT();  //Weight y when timer is hidden.
     }
     u8g2.drawStr(x_decimalPoint, y, ".");
@@ -2001,7 +2002,7 @@ void drawWeight(float input) {
 }
 
 void drawTime() {
-  if (String(sec2sec(stopWatch.elapsed())) != "0s") {
+  if (strcmp(sec2sec(stopWatch.elapsed()), "0s") != 0) {
     u8g2.setFont(FONT_TIMER);
     int y = LCDHeight - 8;
     if (b_timeOnTop)

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -32,11 +32,11 @@ private:
   bool writeCredentialsToNvs(const String &ssid, const String &pass);
 
 public:
-  String getSSID() { return ssid; }
-  String getPass() { return pass; }
-  bool hasCredentials() { return ssid != ""; };
-  void saveCredentials(String ssid, String pass);
-  bool saveCredentialsForRestart(String ssid, String pass);
+  const String &getSSID() const { return ssid; }
+  const String &getPass() const { return pass; }
+  bool hasCredentials() const { return ssid != ""; };
+  void saveCredentials(const String &ssid, const String &pass);
+  bool saveCredentialsForRestart(const String &ssid, const String &pass);
   void init();
   void reset();
 };
@@ -237,7 +237,7 @@ void setupWifi() {
   WiFi.persistent(false);
 
   if (params.hasCredentials()) {
-    Serial.printf("trying to connect to wifi: %s\n", params.getSSID());
+    Serial.printf("trying to connect to wifi: %s\n", params.getSSID().c_str());
     connectToWifi();
     // STA advertises mDNS via the GOT_IP path (deferred to wifiSupervise), so
     // don't also register it here -- that would double-register the service.
@@ -361,11 +361,11 @@ void wifiSupervise() {
   }
 }
 
-void saveCredentials(String ssid, String pass) {
+void saveCredentials(const String &ssid, const String &pass) {
   params.saveCredentials(ssid, pass);
 }
 
-bool saveCredentialsForRestart(String ssid, String pass) {
+bool saveCredentialsForRestart(const String &ssid, const String &pass) {
   return params.saveCredentialsForRestart(ssid, pass);
 }
 
@@ -378,7 +378,7 @@ bool wifiCredentialsSaved() {
 // ------------------ WiFiParams ----------------------
 // ----------------------------------------------------
 
-void WiFiParams::saveCredentials(String ssid, String pass) {
+void WiFiParams::saveCredentials(const String &ssid, const String &pass) {
   if (!initialized) {
     init();
   }
@@ -395,7 +395,7 @@ void WiFiParams::saveCredentials(String ssid, String pass) {
   writeCredentialsToNvs(ssid, pass);
 }
 
-bool WiFiParams::saveCredentialsForRestart(String ssid, String pass) {
+bool WiFiParams::saveCredentialsForRestart(const String &ssid, const String &pass) {
   if (!initialized) {
     init();
   }


### PR DESCRIPTION
## Summary
Reducing runtime heap behavior
- return and pass WiFi credential strings by const reference instead of copying them
- compare existing OLED timer C strings directly instead of constructing temporary `String` objects
- bind the middleware request URL to the stable reference returned by ESPAsyncWebServer

Candidate A was evaluated but skipped. The six suspected dead globals have no references beyond their declarations and are absent from both the baseline and final ELF, so linker garbage collection already removes them and source deletion would save no RAM.

## Size comparison

| Metric | Baseline | Final | Change |
| --- | ---: | ---: | ---: |
| PlatformIO RAM | 60,044 B | 60,044 B | 0 B |
| DIRAM `.data` | 25,082 B | 25,082 B | 0 B |
| DIRAM `.bss` | 34,960 B | 34,960 B | 0 B |
| PlatformIO flash | 1,706,965 B | 1,705,873 B | -1,092 B |
| Flash code | 1,236,904 B | 1,235,984 B | -920 B |
| Flash data | 348,408 B | 348,236 B | -172 B |

No static RAM symbols were removed. The retained changes remove transient heap-allocation opportunities from WiFi credential returns and parameters, two live OLED timer comparisons, and each HTTP middleware request URL lookup.

## Verification

Each retained candidate passed its own build, size, and contract-test gate.

- `pio run -e esp32s3`
- `pio run -e esp32s3 -t size`
- `python tools/test_ai_docs_contract.py`
- `python tools/test_calibration_validation.py`
- `python tools/test_soft_sleep_ads_wake.py`
- `python tools/test_storage_migration_contract.py`
- full raw diff and `git diff --check`
- baseline and final ELF/map inspection with `xtensa-esp32s3-elf-nm`

No configuration, capacities, timing, protocols, networking behavior, persistence, UI output, runtime limits, or log text changed.