### PR TITLE
fix(ota): generate public keys for every build

### DIFF
--- a/.github/workflows/ota-contracts.yml
+++ b/.github/workflows/ota-contracts.yml
@@ -29,3 +29,19 @@ jobs:
           python tools/test_release_workflow_contract.py
           python tools/test_ota_rollback_contract.py
           python tools/test_ota_public_key_header.py
+
+  public-key-header-platforms:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: |
+          python tools/test_ota_public_key_header.py
+          python ota_public_key_header.py

--- a/.github/workflows/ota-contracts.yml
+++ b/.github/workflows/ota-contracts.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/release.yml"
       - "include/*ota*.h"
       - "keys/ota/**"
+      - "ota_public_key_header.py"
+      - "platformio.ini"
       - "tools/*ota*.py"
       - "tools/*release_manifest*.py"
       - "tools/test_release_workflow_contract.py"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you only want to burn the firmware, please read How to upload HEX file.<br />
 
 Beginning with firmware version 3.0.0, OpenScale now uses [Platform.io](https://platformio.org) for development, building and flashing the firmware.  
 
-To build and flash the scale from your computer, make sure you have the `pio` command line tool installed.  
+To build and flash the scale from your computer, make sure you have the `pio` command line tool and OpenSSL installed. Set `OPENSSL` to its executable path if it is not available through `PATH`; Git for Windows is also detected when `git.exe` is on `PATH`.
 After this, one can simply use `$pio run -t upload` and platformio will build and flash the firmware to the connected Esp32s3 chip.
 
 

--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -17,6 +17,7 @@ Firmware-only flashing does not update `web_apps/`. Flash LittleFS when the on-d
 ## PlatformIO Details
 
 - `platformio.ini` uses `.pio.nosync` as the workspace directory.
+- Every PlatformIO build validates the repository OTA public keys and regenerates `.pio.nosync/generated/include/ota_public_key.h`.
 - `web_apps/` is the LittleFS data directory.
 - `git_rev_macro.py` injects `GIT_REV`; non-git source trees fall back to `nogit0`.
 - `CONFIG_ASYNC_TCP_RUNNING_CORE=1` pins AsyncTCP to core 1.

--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -18,6 +18,7 @@ Firmware-only flashing does not update `web_apps/`. Flash LittleFS when the on-d
 
 - `platformio.ini` uses `.pio.nosync` as the workspace directory.
 - Every PlatformIO build validates the repository OTA public keys and regenerates `.pio.nosync/generated/include/ota_public_key.h`.
+- Firmware builds require OpenSSL through `OPENSSL`, `PATH`, or Git for Windows with `git.exe` on `PATH`; clean targets do not.
 - `web_apps/` is the LittleFS data directory.
 - `git_rev_macro.py` injects `GIT_REV`; non-git source trees fall back to `nogit0`.
 - `CONFIG_ASYNC_TCP_RUNNING_CORE=1` pins AsyncTCP to core 1.

--- a/ota_public_key_header.py
+++ b/ota_public_key_header.py
@@ -1,3 +1,14 @@
 import runpy
+from pathlib import Path
 
-runpy.run_path("tools/write_ota_public_key_header.py", run_name="__main__")
+try:
+    Import("env")
+except NameError:
+    generator = Path(__file__).resolve().parent / "tools" / "write_ota_public_key_header.py"
+else:
+    generator = None if env.IsCleanTarget() else env.subst(
+        "$PROJECT_DIR/tools/write_ota_public_key_header.py"
+    )
+
+if generator is not None:
+    runpy.run_path(str(generator), run_name="__main__")

--- a/ota_public_key_header.py
+++ b/ota_public_key_header.py
@@ -1,0 +1,3 @@
+import runpy
+
+runpy.run_path("tools/write_ota_public_key_header.py", run_name="__main__")

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,9 @@ framework = arduino
 # Advisory pre-build check: warns (build log + CI annotation) when the pinned
 # platform above is behind the latest pioarduino stable release, so a deliberate
 # pin doesn't silently rot. Never fails the build; skip with HDS_SKIP_PLATFORM_CHECK=1.
-extra_scripts = pre:check_platform_freshness.py
+extra_scripts =
+  pre:check_platform_freshness.py
+  pre:ota_public_key_header.py
 # Partition table: vendored copy of the upstream arduino-esp32 default_8MB.csv.
 # The board (esp32-s3-devkitc-1, 8 MB flash) already defaults to this layout,
 # so this line is currently a no-op. It makes the implicit default explicit so

--- a/tools/test_ota_public_key_header.py
+++ b/tools/test_ota_public_key_header.py
@@ -8,6 +8,8 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "tools" / "write_ota_public_key_header.py"
+PLATFORMIO_INI = ROOT / "platformio.ini"
+PREBUILD_SCRIPT = ROOT / "ota_public_key_header.py"
 
 
 def load_module():
@@ -91,9 +93,32 @@ class OtaPublicKeyHeaderTest(unittest.TestCase):
     def test_requires_openssl(self):
         module = load_module()
         module.KEY_FILES = PUBLIC_KEYS
-        with mock.patch.object(module.shutil, "which", return_value=None):
+        with mock.patch.object(module.shutil, "which", return_value=None), mock.patch.dict(
+            module.os.environ, {"OPENSSL": "", "ProgramFiles": ""}
+        ):
             with self.assertRaisesRegex(SystemExit, "OpenSSL is required"):
                 module.main()
+
+    def test_finds_git_for_windows_openssl(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            executable = Path(temp_dir) / "Git" / "usr" / "bin" / "openssl.exe"
+            executable.parent.mkdir(parents=True)
+            executable.touch()
+            with mock.patch.object(module.shutil, "which", return_value=None), mock.patch.dict(
+                module.os.environ, {"OPENSSL": "", "ProgramFiles": temp_dir}
+            ):
+                self.assertEqual(module.openssl_path(), str(executable))
+
+    def test_platformio_runs_public_key_generator(self):
+        self.assertIn(
+            "pre:ota_public_key_header.py",
+            PLATFORMIO_INI.read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            'runpy.run_path("tools/write_ota_public_key_header.py", run_name="__main__")',
+            PREBUILD_SCRIPT.read_text(encoding="utf-8"),
+        )
 
 
 if __name__ == "__main__":

--- a/tools/test_ota_public_key_header.py
+++ b/tools/test_ota_public_key_header.py
@@ -1,4 +1,5 @@
 import importlib.util
+import runpy
 import subprocess
 import tempfile
 import unittest
@@ -94,21 +95,37 @@ class OtaPublicKeyHeaderTest(unittest.TestCase):
         module = load_module()
         module.KEY_FILES = PUBLIC_KEYS
         with mock.patch.object(module.shutil, "which", return_value=None), mock.patch.dict(
-            module.os.environ, {"OPENSSL": "", "ProgramFiles": ""}
+            module.os.environ, {"OPENSSL": ""}
         ):
             with self.assertRaisesRegex(SystemExit, "OpenSSL is required"):
                 module.main()
 
-    def test_finds_git_for_windows_openssl(self):
+    def test_finds_openssl_relative_to_git_on_path(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as temp_dir:
-            executable = Path(temp_dir) / "Git" / "usr" / "bin" / "openssl.exe"
+            git = Path(temp_dir) / "custom-git" / "cmd" / "git.exe"
+            git.parent.mkdir(parents=True)
+            git.touch()
+            executable = git.parent.parent / "usr" / "bin" / "openssl.exe"
             executable.parent.mkdir(parents=True)
             executable.touch()
-            with mock.patch.object(module.shutil, "which", return_value=None), mock.patch.dict(
-                module.os.environ, {"OPENSSL": "", "ProgramFiles": temp_dir}
-            ):
-                self.assertEqual(module.openssl_path(), str(executable))
+            with mock.patch.object(
+                module.shutil, "which", side_effect=lambda value: str(git) if value == "git" else None
+            ), mock.patch.dict(module.os.environ, {"OPENSSL": ""}):
+                self.assertEqual(Path(module.openssl_path()).resolve(), executable.resolve())
+
+    def test_platformio_clean_skips_public_key_generator(self):
+        class CleanEnvironment:
+            def IsCleanTarget(self):
+                return True
+
+        with mock.patch.object(runpy, "run_path") as run_path:
+            exec(
+                PREBUILD_SCRIPT.read_text(encoding="utf-8"),
+                {"Import": lambda _: None, "env": CleanEnvironment()},
+            )
+
+        run_path.assert_not_called()
 
     def test_platformio_runs_public_key_generator(self):
         self.assertIn(
@@ -116,7 +133,7 @@ class OtaPublicKeyHeaderTest(unittest.TestCase):
             PLATFORMIO_INI.read_text(encoding="utf-8"),
         )
         self.assertIn(
-            'runpy.run_path("tools/write_ota_public_key_header.py", run_name="__main__")',
+            "$PROJECT_DIR/tools/write_ota_public_key_header.py",
             PREBUILD_SCRIPT.read_text(encoding="utf-8"),
         )
 

--- a/tools/write_ota_public_key_header.py
+++ b/tools/write_ota_public_key_header.py
@@ -17,9 +17,15 @@ KEY_FILES = tuple(
 
 def openssl_path():
     executable = shutil.which(os.environ.get("OPENSSL", "openssl"))
-    if executable is None:
-        raise SystemExit("OpenSSL is required; set OPENSSL to its executable path")
-    return executable
+    if executable is not None:
+        return executable
+    program_files = os.environ.get("ProgramFiles")
+    if program_files:
+        for relative_path in ("Git/usr/bin/openssl.exe", "Git/mingw64/bin/openssl.exe"):
+            executable = Path(program_files) / relative_path
+            if executable.is_file():
+                return str(executable)
+    raise SystemExit("OpenSSL is required; set OPENSSL to its executable path")
 
 
 def canonical_public_key_der(executable, path):

--- a/tools/write_ota_public_key_header.py
+++ b/tools/write_ota_public_key_header.py
@@ -19,10 +19,15 @@ def openssl_path():
     executable = shutil.which(os.environ.get("OPENSSL", "openssl"))
     if executable is not None:
         return executable
-    program_files = os.environ.get("ProgramFiles")
-    if program_files:
-        for relative_path in ("Git/usr/bin/openssl.exe", "Git/mingw64/bin/openssl.exe"):
-            executable = Path(program_files) / relative_path
+    git = shutil.which("git")
+    if git:
+        git_root = Path(git).resolve().parent.parent
+        for relative_path in (
+            "usr/bin/openssl.exe",
+            "mingw64/bin/openssl.exe",
+            "mingw32/bin/openssl.exe",
+        ):
+            executable = git_root / relative_path
             if executable.is_file():
                 return str(executable)
     raise SystemExit("OpenSSL is required; set OPENSSL to its executable path")


### PR DESCRIPTION
## Summary

- validate and generate the three-key OTA header before PlatformIO build targets
- skip OTA key generation for PlatformIO clean targets
- discover OpenSSL through `OPENSSL`, `PATH`, or a Git for Windows installation located from `git.exe` on `PATH`
- use `$PROJECT_DIR` for the PlatformIO generator path while keeping the wrapper directly runnable
- test key parsing and generation on Linux, macOS, and Windows
- document OpenSSL as a firmware-build requirement

This fixes ordinary local or nightly builds compiling without the generated three-key header and then reporting `Signature failed` for a correctly signed manifest. Builds require only the committed public keys. The private release key remains required only by the release signing workflow.

## Validation

- `pio run -e esp32s3 -t clean` succeeded with `OPENSSL` set to an incompatible executable, proving clean skips key parsing
- OTA public-key tests passed on Windows, including a custom Git installation root
- standalone `python ota_public_key_header.py` regenerated all three key macros
- `pio run -e esp32s3 -j 1`
- `pio run -e esp32s3 -t buildfs -j 1`
- release-manifest, pull OTA, release workflow, rollback, and AI documentation contract tests
- workflow YAML parse and `git diff --check`

No device flash was performed for this build-tooling change.