### PR TITLE
fix(release): derive firmware version from tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
               exit 1
             fi
           done
+          if ! grep -Fq "HDS_FIRMWARE_VERSION" git_rev_macro.py || ! grep -Fq "HDS_FIRMWARE_VERSION" include/config.h; then
+            echo "Error: tag $TAG predates the release version injection migration"
+            exit 1
+          fi
           echo "HDS_FIRMWARE_VERSION=${TAG#v}" >> "$GITHUB_ENV"
 
       - uses: actions/cache@v3
@@ -122,7 +126,7 @@ jobs:
               PREVIOUS_MANIFEST_ARGS=(--previous-manifest previous-release/manifest.json)
             fi
           fi
-          python tools/generate_release_manifest.py --tag "$HDS_FIRMWARE_VERSION" --output-dir release-files --catalog --catalog-min-version v3.1.13 "${PREVIOUS_MANIFEST_ARGS[@]}"
+          python tools/generate_release_manifest.py --tag "$TAG" --output-dir release-files --catalog --catalog-min-version v3.1.13 "${PREVIOUS_MANIFEST_ARGS[@]}"
           if [ ! -f release-files/manifest.sig ]; then
             echo "Error: manifest.sig not generated"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
               exit 1
             fi
           done
+          echo "HDS_FIRMWARE_VERSION=${TAG#v}" >> "$GITHUB_ENV"
 
       - uses: actions/cache@v3
         with:
@@ -68,6 +69,10 @@ jobs:
         run: |
           set -euo pipefail
           pio run -e esp32s3 || exit 1
+          if ! grep -aFq "FW: $HDS_FIRMWARE_VERSION" .pio.nosync/build/esp32s3/firmware.bin; then
+            echo "Error: firmware does not contain version $HDS_FIRMWARE_VERSION"
+            exit 1
+          fi
           pio run -e esp32s3 -t buildfs || exit 1
 
       - name: Prepare release assets
@@ -117,7 +122,7 @@ jobs:
               PREVIOUS_MANIFEST_ARGS=(--previous-manifest previous-release/manifest.json)
             fi
           fi
-          python tools/generate_release_manifest.py --tag "$TAG" --output-dir release-files --catalog --catalog-min-version v3.1.13 "${PREVIOUS_MANIFEST_ARGS[@]}"
+          python tools/generate_release_manifest.py --tag "$HDS_FIRMWARE_VERSION" --output-dir release-files --catalog --catalog-min-version v3.1.13 "${PREVIOUS_MANIFEST_ARGS[@]}"
           if [ ! -f release-files/manifest.sig ]; then
             echo "Error: manifest.sig not generated"
             exit 1

--- a/git_rev_macro.py
+++ b/git_rev_macro.py
@@ -1,4 +1,11 @@
+import os
+import re
 import subprocess
+
+
+firmwareVersion = os.environ.get("HDS_FIRMWARE_VERSION")
+if firmwareVersion is not None and re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", firmwareVersion) is None:
+    raise SystemExit("HDS_FIRMWARE_VERSION must match X.Y.Z")
 
 revision = (
     subprocess.check_output(["git", "rev-parse", "HEAD"])
@@ -7,3 +14,5 @@ revision = (
     
 )
 print("'-DGIT_REV=\"%s\"'" % revision[:6])
+if firmwareVersion is not None:
+    print("'-DHDS_FIRMWARE_VERSION=\"%s\"'" % firmwareVersion)

--- a/include/config.h
+++ b/include/config.h
@@ -31,7 +31,10 @@
 //#define CHECKBATTERY
 
 //SCALE CONFIG
-#define LINE1 (char*)"FW: 3.1.13"
+#ifndef HDS_FIRMWARE_VERSION
+#define HDS_FIRMWARE_VERSION "3.1.13-dev"
+#endif
+#define LINE1 (char*)"FW: " HDS_FIRMWARE_VERSION
 #define LINE2 (char*)"Built-date "
 #define LINE3 __DATE__ //Serial number
 #define VERSION /*version*/ LINE1, /*compile date*/ LINE2, /*sn*/ LINE3

--- a/tools/test_release_workflow_contract.py
+++ b/tools/test_release_workflow_contract.py
@@ -1,7 +1,9 @@
+import json
 import os
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -35,6 +37,8 @@ def main():
     assert_contains(text, 'git rev-parse --verify --end-of-options "refs/tags/$TAG^{commit}"')
     assert_contains(text, 'git checkout --detach "$TAG_COMMIT"')
     assert_contains(text, "tag $TAG predates the three-key OTA migration")
+    assert_contains(text, "tag $TAG predates the release version injection migration")
+    assert_contains(text, 'grep -Fq "HDS_FIRMWARE_VERSION" git_rev_macro.py || ! grep -Fq "HDS_FIRMWARE_VERSION" include/config.h')
     assert_contains(text, "python tools/write_ota_public_key_header.py")
     assert_contains(text, 'echo "HDS_FIRMWARE_VERSION=${TAG#v}" >> "$GITHUB_ENV"')
     assert_contains(text, "HDS_OTA_SIGNING_KEY_PEM secret is required")
@@ -47,7 +51,7 @@ def main():
     assert_contains(text, "--previous-manifest previous-release/manifest.json")
     assert_contains(text, "--catalog-min-version v3.1.13")
     assert_contains(text, 'grep -aFq "FW: $HDS_FIRMWARE_VERSION" .pio.nosync/build/esp32s3/firmware.bin')
-    assert_contains(text, "python tools/generate_release_manifest.py --tag \"$HDS_FIRMWARE_VERSION\" --output-dir release-files --catalog --catalog-min-version v3.1.13")
+    assert_contains(text, "python tools/generate_release_manifest.py --tag \"$TAG\" --output-dir release-files --catalog --catalog-min-version v3.1.13")
     assert_contains(text, "gh release create")
     assert_contains(text, "--draft")
     assert_contains(text, "gh release upload")
@@ -60,6 +64,7 @@ def main():
     assert_contains(text, "--draft=false")
     assert_before(text, "openssl dgst -sha256 -verify", "python tools/generate_release_manifest.py")
     assert_before(text, "tag $TAG predates the three-key OTA migration", "python tools/write_ota_public_key_header.py")
+    assert_before(text, "tag $TAG predates the release version injection migration", "python tools/write_ota_public_key_header.py")
     assert_before(text, "python tools/write_ota_public_key_header.py", "verifyManifestSignature previous-release/manifest.json")
     assert_before(text, 'echo "HDS_FIRMWARE_VERSION=${TAG#v}"', "pio run -e esp32s3")
     assert_before(text, 'grep -aFq "FW: $HDS_FIRMWARE_VERSION"', "python tools/generate_release_manifest.py")
@@ -99,6 +104,48 @@ def main():
     )
     if result.returncode == 0:
         raise AssertionError("build metadata accepted an unnormalized firmware version")
+
+    with tempfile.TemporaryDirectory() as tempDir:
+        root = Path(tempDir)
+        buildDir = root / "build"
+        outputDir = root / "release-files"
+        buildDir.mkdir()
+        (buildDir / "firmware.bin").write_bytes(b"firmware")
+        (buildDir / "littlefs.bin").write_bytes(b"littlefs")
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"HDS_OTA_SIGNING_KEY_FILE", "HDS_OTA_SIGNING_KEY_PEM", "HDS_RELEASE_NOTES_URL"}
+        }
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "tools" / "generate_release_manifest.py"),
+                "--tag",
+                "v9.8.7",
+                "--build-dir",
+                str(buildDir),
+                "--output-dir",
+                str(outputDir),
+                "--repository",
+                "decentespresso/openscale",
+            ],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(result.stderr)
+        manifest = json.loads((outputDir / "manifest.json").read_text(encoding="utf-8"))
+        if manifest["version"] != "9.8.7":
+            raise AssertionError("release workflow did not normalize manifest version")
+        expectedReleaseUrl = "https://github.com/decentespresso/openscale/releases/tag/v9.8.7"
+        if manifest["release_notes_url"] != expectedReleaseUrl:
+            raise AssertionError("release workflow stripped v from release notes URL")
+        expectedFirmwareUrl = "https://github.com/decentespresso/openscale/releases/download/v9.8.7/firmware.bin"
+        if manifest["firmware"]["url"] != expectedFirmwareUrl:
+            raise AssertionError("release workflow stripped v from firmware URL")
 
     print("release workflow contract tests passed")
 

--- a/tools/test_release_workflow_contract.py
+++ b/tools/test_release_workflow_contract.py
@@ -1,8 +1,13 @@
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+CONFIG = ROOT / "include" / "config.h"
+BUILD_METADATA = ROOT / "git_rev_macro.py"
 
 
 def assert_contains(text, needle):
@@ -23,6 +28,7 @@ def assert_before(text, left, right):
 
 
 def main():
+    config = CONFIG.read_text(encoding="utf-8")
     text = WORKFLOW.read_text(encoding="utf-8")
     assert_contains(text, 'TAG: ${{ github.event.inputs.tag }}')
     assert_contains(text, '[[ ! "$TAG" =~ ^v?[0-9]+\\.[0-9]+\\.[0-9]+$ ]]')
@@ -30,6 +36,7 @@ def main():
     assert_contains(text, 'git checkout --detach "$TAG_COMMIT"')
     assert_contains(text, "tag $TAG predates the three-key OTA migration")
     assert_contains(text, "python tools/write_ota_public_key_header.py")
+    assert_contains(text, 'echo "HDS_FIRMWARE_VERSION=${TAG#v}" >> "$GITHUB_ENV"')
     assert_contains(text, "HDS_OTA_SIGNING_KEY_PEM secret is required")
     assert_contains(text, "keys/ota/hds_ota_manifest_public_key_{1..3}.pem")
     assert_contains(text, "gh release list")
@@ -39,7 +46,8 @@ def main():
     assert_contains(text, "openssl dgst -sha256 -verify")
     assert_contains(text, "--previous-manifest previous-release/manifest.json")
     assert_contains(text, "--catalog-min-version v3.1.13")
-    assert_contains(text, "python tools/generate_release_manifest.py --tag \"$TAG\" --output-dir release-files --catalog --catalog-min-version v3.1.13")
+    assert_contains(text, 'grep -aFq "FW: $HDS_FIRMWARE_VERSION" .pio.nosync/build/esp32s3/firmware.bin')
+    assert_contains(text, "python tools/generate_release_manifest.py --tag \"$HDS_FIRMWARE_VERSION\" --output-dir release-files --catalog --catalog-min-version v3.1.13")
     assert_contains(text, "gh release create")
     assert_contains(text, "--draft")
     assert_contains(text, "gh release upload")
@@ -53,6 +61,8 @@ def main():
     assert_before(text, "openssl dgst -sha256 -verify", "python tools/generate_release_manifest.py")
     assert_before(text, "tag $TAG predates the three-key OTA migration", "python tools/write_ota_public_key_header.py")
     assert_before(text, "python tools/write_ota_public_key_header.py", "verifyManifestSignature previous-release/manifest.json")
+    assert_before(text, 'echo "HDS_FIRMWARE_VERSION=${TAG#v}"', "pio run -e esp32s3")
+    assert_before(text, 'grep -aFq "FW: $HDS_FIRMWARE_VERSION"', "python tools/generate_release_manifest.py")
     assert_before(text, "python tools/generate_release_manifest.py", "verifyManifestSignature release-files/manifest.json")
     assert_before(text, "verifyManifestSignature release-files/manifest.json", "gh release create")
     assert_before(text, "release-files/manifest.sig", "release-files/manifest.json")
@@ -67,8 +77,30 @@ def main():
     assert_not_contains(text, "HDS_LITTLEFS_REQUIRED")
     assert_not_contains(text, "test_catalog_" + "min_version")
     assert_not_contains(text, "TEST_CATALOG_" + "MIN_VERSION")
-    print("release workflow contract tests passed")
 
+    assert_contains(config, '#define LINE1 (char*)"FW: " HDS_FIRMWARE_VERSION')
+    environment = {**os.environ, "HDS_FIRMWARE_VERSION": "9.8.7"}
+    result = subprocess.run(
+        [sys.executable, str(BUILD_METADATA)],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or '-DHDS_FIRMWARE_VERSION="9.8.7"' not in result.stdout:
+        raise AssertionError("build metadata did not emit the firmware version macro")
+    environment["HDS_FIRMWARE_VERSION"] = "v9.8.7"
+    result = subprocess.run(
+        [sys.executable, str(BUILD_METADATA)],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        raise AssertionError("build metadata accepted an unnormalized firmware version")
+
+    print("release workflow contract tests passed")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Problem

The release tag and manifest version can currently disagree with the version embedded in the firmware because `include/config.h` maintains it independently.

## Change

- normalize the validated release tag into `HDS_FIRMWARE_VERSION` for the firmware build
- pass the original tag to the manifest generator so `manifest.version` is normalized while GitHub release and asset URLs retain the tag's `v` prefix
- reject tags that predate the version-injection hook before building
- inject the normalized version into `LINE1` through the existing PlatformIO build-metadata hook
- fail before the filesystem build, signing, or publishing unless `firmware.bin` contains the expected version
- label ordinary builds without a release version as `3.1.13-dev`

## Validation

- release workflow contract with `v9.8.7`, asserting manifest version `9.8.7` and release/asset URLs under `v9.8.7`
- ESP32-S3 firmware build with `HDS_FIRMWARE_VERSION=9.8.7`
- confirmed the resulting binary contains `FW: 9.8.7`
- ESP32-S3 LittleFS build
- OTA public-key, release-manifest, pull OTA, release-workflow, rollback, and AI documentation contract tests
- release workflow YAML parse
- malformed build versions rejected by the build-metadata hook
- `git diff --check`

## Draft limitation

The real release workflow was not dispatched because it would publish a GitHub release. The local synthetic-version build exercises the same PlatformIO macro and binary check.