### PR TITLE
fix(build): pin release dependencies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
           # Key on platformio.ini so a platform/lib pin change busts the cache.
           # A static key froze CI on a stale cached `stable` platform zip (3.3.8)
           # even after the pin should have resolved a newer framework.
-          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini', 'requirements-platformio.txt') }}
       - uses: actions/setup-node@v4.1.0
 
       - uses: actions/setup-python@v4
@@ -47,12 +47,14 @@ jobs:
           python-version: "3.11"
 
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: python -m pip install --requirement requirements-platformio.txt
 
       - name: Build PlatformIO Project
         run: |
           pio run -e ${{ matrix.board }} 
           pio run -e ${{ matrix.board }} -t buildfs
+          pio --version > .pio.nosync/build/${{ matrix.board }}/dependencies.txt
+          pio pkg list -e ${{ matrix.board }} >> .pio.nosync/build/${{ matrix.board }}/dependencies.txt
 
       - name: Assert vendored partition table matches framework
         run: |
@@ -81,3 +83,4 @@ jobs:
             .pio.nosync/build/${{ matrix.board }}/bootloader.bin
             .pio.nosync/build/${{ matrix.board }}/partitions.bin
             .pio.nosync/build/${{ matrix.board }}/littlefs.bin
+            .pio.nosync/build/${{ matrix.board }}/dependencies.txt

--- a/.github/workflows/ota-contracts.yml
+++ b/.github/workflows/ota-contracts.yml
@@ -5,8 +5,11 @@ on:
     paths:
       - ".github/workflows/ota-contracts.yml"
       - ".github/workflows/release.yml"
+      - ".github/workflows/nightly.yml"
       - "include/*ota*.h"
       - "keys/ota/**"
+      - "platformio.ini"
+      - "requirements-platformio.txt"
       - "tools/*ota*.py"
       - "tools/*release_manifest*.py"
       - "tools/test_release_workflow_contract.py"

--- a/.github/workflows/ota-contracts.yml
+++ b/.github/workflows/ota-contracts.yml
@@ -30,3 +30,23 @@ jobs:
           python tools/test_release_workflow_contract.py
           python tools/test_ota_rollback_contract.py
           python tools/test_ota_public_key_header.py
+
+  dependency-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini', 'requirements-platformio.txt') }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --requirement requirements-platformio.txt
+      - run: pio run -e esp32s3
+      - run: pio run -e esp32s3 -t buildfs
+      - run: pio pkg list -e esp32s3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
               exit 1
             fi
           done
+          if [ ! -f requirements-platformio.txt ]; then
+            echo "Error: tag $TAG predates the dependency pin migration"
+            exit 1
+          fi
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,14 @@ jobs:
           # Key on platformio.ini so a platform/lib pin change busts the cache.
           # A static key froze CI on a stale cached `stable` platform zip (3.3.8)
           # even after the pin should have resolved a newer framework.
-          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini', 'requirements-platformio.txt') }}
 
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: python -m pip install --requirement requirements-platformio.txt
 
       - name: Configure OTA manifest public keys
         run: python tools/write_ota_public_key_header.py
@@ -93,6 +93,8 @@ jobs:
             exit 1
           fi
           mkdir -p release-files legacy-files
+          pio --version > release-files/dependencies.txt
+          pio pkg list -e esp32s3 >> release-files/dependencies.txt
           cp ".pio.nosync/build/esp32s3/firmware.bin" release-files/
           cp ".pio.nosync/build/esp32s3/littlefs.bin" release-files/
           for file in firmware.bin bootloader.bin partitions.bin littlefs.bin; do
@@ -138,12 +140,14 @@ jobs:
             --generate-notes \
             "HDS_FW_${TAG}.zip" \
             release-files/firmware.bin \
-            release-files/littlefs.bin
+            release-files/littlefs.bin \
+            release-files/dependencies.txt
           gh release upload "$TAG" release-files/manifest.sig
           gh release upload "$TAG" release-files/manifest.json
           gh release view "$TAG" --json assets --jq '.assets[].name' > release-assets.txt
           grep -Fx firmware.bin release-assets.txt
           grep -Fx littlefs.bin release-assets.txt
+          grep -Fx dependencies.txt release-assets.txt
           grep -Fx manifest.json release-assets.txt
           grep -Fx manifest.sig release-assets.txt
           gh release edit "$TAG" --draft=false

--- a/platformio.ini
+++ b/platformio.ini
@@ -61,17 +61,25 @@ build_flags =
 #
 lib_compat_mode = strict
 lib_deps =
-  ArduinoJson
-  bxparks/AceButton @ ^1.10.1
+  bblanchon/ArduinoJson @ 7.4.3
+  bxparks/AceButton @ 1.10.1
   https://github.com/decentespresso/ADS1232_ADC.git#24cd10d3037c878f751a057377303598a00f977e
-  robtillaart/StopWatch @ ^0.3.5
-  adafruit/Adafruit ADS1X15 @ ^2.5.0
-  esp32async/AsyncTCP @ ^3.4.4
-  esp32async/ESPAsyncWebServer @ ^3.7.8
-  ayushsharma82/ElegantOTA @ ^3.1.7
-  adafruit/Adafruit MPU6050 @ ^2.2.6
-  sparkfun/SparkFun BMA400 Arduino Library @ ^1.0.0
-  olikraus/U8g2 @ ^2.36.12
+  robtillaart/StopWatch @ 0.3.6
+  adafruit/Adafruit ADS1X15 @ 2.6.2
+  adafruit/Adafruit BusIO @ 1.17.4
+  adafruit/Adafruit GFX Library @ 1.12.6
+  adafruit/Adafruit MPU6050 @ 2.2.9
+  adafruit/Adafruit SSD1306 @ 2.5.17
+  adafruit/Adafruit Unified Sensor @ 1.1.15
+  esp32async/AsyncTCP @ 3.5.0
+  esp32async/ESPAsyncWebServer @ 3.11.2
+  ayushsharma82/ElegantOTA @ 3.1.7
+  sparkfun/SparkFun BMA400 Arduino Library @ 1.0.0
+  olikraus/U8g2 @ 2.36.18
+
+lib_ignore =
+  Adafruit GFX Library
+  Adafruit SSD1306
 
 monitor_filters =
   esp32_exception_decoder

--- a/requirements-platformio.txt
+++ b/requirements-platformio.txt
@@ -1,0 +1,1 @@
+platformio==6.1.19

--- a/tools/test_release_workflow_contract.py
+++ b/tools/test_release_workflow_contract.py
@@ -6,6 +6,7 @@ import re
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "nightly.yml"
+OTA_WORKFLOW = ROOT / ".github" / "workflows" / "ota-contracts.yml"
 PLATFORMIO_CONFIG = ROOT / "platformio.ini"
 PLATFORMIO_REQUIREMENTS = ROOT / "requirements-platformio.txt"
 
@@ -31,10 +32,13 @@ def main():
     text = WORKFLOW.read_text(encoding="utf-8")
     assert_contains(text, 'TAG: ${{ github.event.inputs.tag }}')
     nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+    ota = OTA_WORKFLOW.read_text(encoding="utf-8")
     assert_contains(text, '[[ ! "$TAG" =~ ^v?[0-9]+\\.[0-9]+\\.[0-9]+$ ]]')
     assert_contains(text, 'git rev-parse --verify --end-of-options "refs/tags/$TAG^{commit}"')
     assert_contains(text, 'git checkout --detach "$TAG_COMMIT"')
     assert_contains(text, "tag $TAG predates the three-key OTA migration")
+    assert_contains(text, "tag $TAG predates the dependency pin migration")
+    assert_contains(text, '[ ! -f requirements-platformio.txt ]')
     assert_contains(text, "python tools/write_ota_public_key_header.py")
     assert_contains(text, "HDS_OTA_SIGNING_KEY_PEM secret is required")
     assert_contains(text, "keys/ota/hds_ota_manifest_public_key_{1..3}.pem")
@@ -59,6 +63,7 @@ def main():
     assert_contains(text, "--draft=false")
     assert_before(text, "openssl dgst -sha256 -verify", "python tools/generate_release_manifest.py")
     assert_before(text, "tag $TAG predates the three-key OTA migration", "python tools/write_ota_public_key_header.py")
+    assert_before(text, "tag $TAG predates the dependency pin migration", "python -m pip install --requirement requirements-platformio.txt")
     assert_before(text, "python tools/write_ota_public_key_header.py", "verifyManifestSignature previous-release/manifest.json")
     assert_before(text, "python tools/generate_release_manifest.py", "verifyManifestSignature release-files/manifest.json")
     assert_before(text, "verifyManifestSignature release-files/manifest.json", "gh release create")
@@ -79,6 +84,15 @@ def main():
         assert_contains(workflow, "hashFiles('platformio.ini', 'requirements-platformio.txt')")
         assert_contains(workflow, "pio pkg list -e")
         assert_not_contains(workflow, "pip install --upgrade platformio")
+    assert_contains(ota, '- "platformio.ini"')
+    assert_contains(ota, '- "requirements-platformio.txt"')
+    for command in (
+        "- run: python -m pip install --requirement requirements-platformio.txt",
+        "- run: pio run -e esp32s3\n",
+        "- run: pio run -e esp32s3 -t buildfs",
+        "- run: pio pkg list -e esp32s3",
+    ):
+        assert_contains(ota, command)
     assert_contains(nightly, "dependencies.txt")
     requirements = PLATFORMIO_REQUIREMENTS.read_text(encoding="utf-8").splitlines()
     if requirements != ["platformio==6.1.19"]:

--- a/tools/test_release_workflow_contract.py
+++ b/tools/test_release_workflow_contract.py
@@ -1,8 +1,13 @@
+import configparser
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "nightly.yml"
+PLATFORMIO_CONFIG = ROOT / "platformio.ini"
+PLATFORMIO_REQUIREMENTS = ROOT / "requirements-platformio.txt"
 
 
 def assert_contains(text, needle):
@@ -25,6 +30,7 @@ def assert_before(text, left, right):
 def main():
     text = WORKFLOW.read_text(encoding="utf-8")
     assert_contains(text, 'TAG: ${{ github.event.inputs.tag }}')
+    nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
     assert_contains(text, '[[ ! "$TAG" =~ ^v?[0-9]+\\.[0-9]+\\.[0-9]+$ ]]')
     assert_contains(text, 'git rev-parse --verify --end-of-options "refs/tags/$TAG^{commit}"')
     assert_contains(text, 'git checkout --detach "$TAG_COMMIT"')
@@ -47,6 +53,7 @@ def main():
     assert_contains(text, "release-files/manifest.sig")
     assert_contains(text, "release-files/manifest.json")
     assert_contains(text, "verifyManifestSignature previous-release/manifest.json previous-release/manifest.sig")
+    assert_contains(text, "release-files/dependencies.txt")
     assert_contains(text, "verifyManifestSignature release-files/manifest.json release-files/manifest.sig")
     assert_contains(text, "gh release edit")
     assert_contains(text, "--draft=false")
@@ -67,8 +74,29 @@ def main():
     assert_not_contains(text, "HDS_LITTLEFS_REQUIRED")
     assert_not_contains(text, "test_catalog_" + "min_version")
     assert_not_contains(text, "TEST_CATALOG_" + "MIN_VERSION")
-    print("release workflow contract tests passed")
+    for workflow in (text, nightly):
+        assert_contains(workflow, "python -m pip install --requirement requirements-platformio.txt")
+        assert_contains(workflow, "hashFiles('platformio.ini', 'requirements-platformio.txt')")
+        assert_contains(workflow, "pio pkg list -e")
+        assert_not_contains(workflow, "pip install --upgrade platformio")
+    assert_contains(nightly, "dependencies.txt")
+    requirements = PLATFORMIO_REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+    if requirements != ["platformio==6.1.19"]:
+        raise AssertionError("PlatformIO Core must be pinned exactly")
+    config = configparser.ConfigParser(interpolation=None)
+    config.read(PLATFORMIO_CONFIG, encoding="utf-8")
+    dependencies = tuple(
+        dependency.strip()
+        for dependency in config["env:esp32s3"]["lib_deps"].splitlines()
+        if dependency.strip()
+    )
+    registryPin = re.compile(r"[^/\s]+/.+ @ [0-9]+\.[0-9]+\.[0-9]+$")
+    gitPin = re.compile(r"https://github\.com/.+\.git#[0-9a-f]{40}$")
+    for dependency in dependencies:
+        if registryPin.fullmatch(dependency) is None and gitPin.fullmatch(dependency) is None:
+            raise AssertionError(f"dependency is not pinned exactly: {dependency}")
 
+    print("release workflow contract tests passed")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Problem

Release and nightly builds allowed dependency resolution to drift because PlatformIO Core was upgraded at build time, ArduinoJson had no version constraint, and several library constraints accepted newer compatible releases.

## Change

- pin PlatformIO Core to `6.1.19` in a checked-in requirements file
- pin every declared PlatformIO library to an exact registry version or Git commit
- explicitly pin the otherwise transitive Adafruit dependencies
- keep the unused GFX and SSD1306 libraries ignored so the firmware build graph and binary size do not change
- include the resolved PlatformIO package inventory as `dependencies.txt` in nightly artifacts and GitHub releases
- include both dependency inputs in the PlatformIO cache key
- build firmware and LittleFS and list the resolved package graph in path-filtered pull-request CI
- reject release tags that predate the dependency-pin migration before installing or building
- extend the OTA/release contract checks to enforce exact pins, the PR build, and the tag migration guard

This removes the reviewed library and PlatformIO version drift and records what each build resolved. It does not claim that the complete GitHub Actions environment is bit-for-bit hermetic.

## Validation

- installed `platformio==6.1.19` from `requirements-platformio.txt`
- `pio run -e esp32s3`
- `pio run -e esp32s3 -t buildfs`
- final firmware image size: 1,717,509 bytes, unchanged from the baseline build
- `pio pkg list -e esp32s3`
- OTA public-key, manifest, pull-OTA, release-workflow, rollback, and AI documentation contract tests
- all workflow YAML parsed
- `git diff --check`

No device flash or release workflow dispatch was performed for this build-tooling-only change.