### PR TITLE
fix(ci): keep snapshots updater-compatible

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,4 +83,9 @@ jobs:
             .pio.nosync/build/${{ matrix.board }}/bootloader.bin
             .pio.nosync/build/${{ matrix.board }}/partitions.bin
             .pio.nosync/build/${{ matrix.board }}/littlefs.bin
-            .pio.nosync/build/${{ matrix.board }}/dependencies.txt
+
+      - name: Save dependency inventory
+        uses: actions/upload-artifact@v4
+        with:
+          name: HDS-dependencies-${{steps.slugify.outputs.sha}}
+          path: .pio.nosync/build/${{ matrix.board }}/dependencies.txt

--- a/tools/test_release_workflow_contract.py
+++ b/tools/test_release_workflow_contract.py
@@ -173,7 +173,12 @@ def main():
         "- run: pio pkg list -e esp32s3",
     ):
         assert_contains(ota, command)
-    assert_contains(nightly, "dependencies.txt")
+    snapshotArtifact = nightly.split("name: HDS-snapshot-", 1)[1].split("- name: Save dependency inventory", 1)[0]
+    for filename in ("firmware.bin", "bootloader.bin", "partitions.bin", "littlefs.bin"):
+        assert_contains(snapshotArtifact, filename)
+    assert_not_contains(snapshotArtifact, "dependencies.txt")
+    assert_contains(nightly, "name: HDS-dependencies-")
+    assert_contains(nightly, ".pio.nosync/build/${{ matrix.board }}/dependencies.txt")
     requirements = PLATFORMIO_REQUIREMENTS.read_text(encoding="utf-8").splitlines()
     if requirements != ["platformio==6.1.19"]:
         raise AssertionError("PlatformIO Core must be pinned exactly")


### PR DESCRIPTION
## Summary

- keep `HDS-snapshot-*` limited to the four updater `.bin` files
- upload `dependencies.txt` as a separate `HDS-dependencies-*` artifact
- enforce the separation in the release workflow contract

## Why

PR #100 added the dependency inventory to the firmware snapshot artifact. That made new snapshot ZIPs incompatible with the HDS updater, which accepts exactly four firmware files.

## Validation

- `python tools/test_release_workflow_contract.py`
- YAML parse of `.github/workflows/nightly.yml`
- `python tools/test_ai_docs_contract.py`
- `git diff --check`