### PR TITLE
Avoid WebSocket weight formatting allocation

### DIFF
--- a/docs/AI_FIRMWARE_NOTES.md
+++ b/docs/AI_FIRMWARE_NOTES.md
@@ -74,10 +74,10 @@ The USB ADS debug packet keeps its 41-byte framing and checksum. Byte 24 is the 
 - `LittleFS.begin()` is idempotent.
 - Multiple WebSocket clients are supported.
 - Shared WebSocket session state resets only when the last client disconnects.
-- Broadcast with `websocket.printfAll(...)`, not a manual `getClients()` loop.
+- Broadcast with `websocket.printfAll(...)` or `websocket.textAll(...)`, not a manual `getClients()` loop.
 - Gate every broadcast-to-all helper with `wsBroadcastHeapOk()`.
 
-`printfAll` allocates per client. Arduino-ESP32 builds without exceptions, so `std::bad_alloc` aborts and reboots the device. Connection churn and half-open clients can exhaust heap. Low-heap behavior should skip broadcasts, not allocate.
+Broadcasts allocate a shared payload and per-client queue entries. `printfAll` also allocates a transient formatting buffer. Arduino-ESP32 builds without exceptions, so `std::bad_alloc` aborts and reboots the device. Connection churn and half-open clients can exhaust heap. Low-heap behavior should skip broadcasts, not allocate.
 
 ### WebSocket Heap Deep Reference
 

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -340,7 +340,7 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
                  f_maxDriftCompensation);
 }
 
-// Broadcast via printfAll(): it holds the library's client-list mutex and
+// Broadcast via textAll(): it holds the library's client-list mutex and
 // queues to each client independently. We deliberately do NOT gate on
 // availableForWriteAll() (it returns the minimum across clients, coupling every
 // client to the slowest), and we deliberately do NOT hand-iterate getClients()
@@ -351,7 +351,12 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
 void sendWebsocketWeightAll(float grams, unsigned long ms) {
   if (!b_wifiEnabled || websocket.count() == 0) return;
   if (!wsBroadcastHeapOk()) return;
-  websocket.printfAll("{\"grams\":%.2f,\"ms\":%lu}", grams, ms);
+  char message[96];
+  int messageLength = snprintf(message, sizeof(message),
+                               "{\"grams\":%.2f,\"ms\":%lu}", grams, ms);
+  if (messageLength <= 0 ||
+      static_cast<size_t>(messageLength) >= sizeof(message)) return;
+  websocket.textAll(message, static_cast<size_t>(messageLength));
 }
 
 void sendWebsocketError(AsyncWebSocketClient *client, const char *code, const char *message) {


### PR DESCRIPTION
## Summary

- Format weight broadcasts in a fixed stack buffer.
- Send the completed payload with `textAll()` instead of `printfAll()`.
- Document the shared and transient WebSocket allocations.

## Why

`printfAll()` creates a transient formatting allocation for every weight broadcast. Formatting once into a bounded buffer removes that allocation while retaining the existing broadcast heap gate.

## Validation

- `pio run -e esp32s3`
- `python tools/test_ai_docs_contract.py`
