### PR TITLE
Bound pull OTA catalog memory

### DIFF
--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -27,7 +27,7 @@ Release builds publish WiFi OTA assets at the GitHub Release root:
 
 The release workflow creates draft releases, uploads binary assets first, uploads `manifest.sig` and `manifest.json` last, then publishes the release.
 
-Catalog manifests merge the previous latest stable signed manifest, dedupe by model, PCB, version, chip, and environment, sort newest to oldest, and keep production entries at `v3.1.13+`.
+Catalog manifests merge the previous latest stable signed manifest, dedupe by model, PCB, version, chip, and environment, sort newest to oldest, and keep the latest 10 production entries at `v3.1.13+`. Generated JSON is compact and limited to 16 KiB.
 
 ## Picker Rules
 

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -94,7 +94,7 @@ m+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 -----END CERTIFICATE-----
 )PEM";
 
-static const size_t HDS_OTA_MANIFEST_MAX_BYTES = 32768;
+static const size_t HDS_OTA_MANIFEST_MAX_BYTES = 16384;
 static const size_t HDS_OTA_MANIFEST_SIGNATURE_MAX_BYTES = 1024;
 static const size_t HDS_OTA_BUFFER_BYTES = 1024;
 static const unsigned long HDS_OTA_WIFI_TIMEOUT_MS = 45000;
@@ -105,7 +105,7 @@ static const unsigned long HDS_OTA_CONFIRM_TIMEOUT_MS = 15000;
 static const unsigned long HDS_OTA_CONFIRM_HOLD_MS = 1200;
 static const unsigned long HDS_OTA_PICK_TIMEOUT_MS = 30000;
 static const uint32_t HDS_OTA_TASK_STACK_BYTES = 24576;
-static const uint8_t HDS_OTA_MAX_RELEASE_CHOICES = 16;
+static const uint8_t HDS_OTA_MAX_RELEASE_CHOICES = 10;
 static const char *HDS_OTA_CHIP = "esp32s3";
 static const char *HDS_OTA_ENVIRONMENT = "esp32s3";
 static const char *HDS_OTA_PARTITION_SCHEMA = "esp32s3-default-8mb-ota-spiffs-1536k";
@@ -1319,15 +1319,17 @@ void pullOtaRunUpdate() {
     pullOtaFail("Clock failed", "TLS blocked");
     return;
   }
-  String body;
-  if (!pullOtaFetchSignedManifest(body)) {
-    pullOtaFail("Signature failed");
-    return;
-  }
   PullOtaReleaseList catalog;
-  if (!pullOtaParseManifest(body, catalog)) {
-    pullOtaFail("Manifest invalid");
-    return;
+  {
+    String body;
+    if (!pullOtaFetchSignedManifest(body)) {
+      pullOtaFail("Signature failed");
+      return;
+    }
+    if (!pullOtaParseManifest(body, catalog)) {
+      pullOtaFail("Manifest invalid");
+      return;
+    }
   }
   PullOtaReleaseList releases;
   pullOtaBuildSelectableReleases(catalog, releases);

--- a/tools/generate_release_manifest.py
+++ b/tools/generate_release_manifest.py
@@ -21,8 +21,8 @@ DEFAULT_FS_PARTITION_LABEL = "spiffs"
 DEFAULT_FS_PARTITION_SIZE = 1572864
 DEFAULT_FS_SCHEMA = 1
 DEFAULT_CATALOG_MIN_VERSION = "v3.1.13"
-MAX_CATALOG_RELEASES = 16
-MAX_MANIFEST_BYTES = 32768
+MAX_CATALOG_RELEASES = 10
+MAX_MANIFEST_BYTES = 16384
 STABLE_VERSION_RE = re.compile(r"^v?([0-9]+)\.([0-9]+)\.([0-9]+)$")
 
 
@@ -145,7 +145,7 @@ def build_manifest(
 
 
 def write_manifest(manifest, path):
-    manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    manifest_bytes = (json.dumps(manifest, separators=(",", ":")) + "\n").encode("utf-8")
     if len(manifest_bytes) > MAX_MANIFEST_BYTES:
         raise ValueError(f"manifest exceeds {MAX_MANIFEST_BYTES} bytes")
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/test_generate_release_manifest.py
+++ b/tools/test_generate_release_manifest.py
@@ -296,18 +296,21 @@ class GenerateReleaseManifestTest(unittest.TestCase):
 
         catalog = module.build_catalog_manifest(latest, [previous], min_version="v3.1.13")
 
-        self.assertEqual(len(catalog["releases"]), module.MAX_CATALOG_RELEASES)
+        self.assertEqual(module.MAX_CATALOG_RELEASES, 10)
+        self.assertEqual(module.MAX_MANIFEST_BYTES, 16384)
+        self.assertEqual(len(catalog["releases"]), 10)
         self.assertEqual(catalog["releases"][0]["version"], "3.1.60")
         with tempfile.TemporaryDirectory() as temp_dir:
             manifest_path = Path(temp_dir) / "manifest.json"
             module.write_manifest(catalog, manifest_path)
             self.assertLessEqual(manifest_path.stat().st_size, module.MAX_MANIFEST_BYTES)
+            self.assertNotIn("\n  ", manifest_path.read_text(encoding="utf-8"))
 
     def test_release_manifest_rejects_oversized_output(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             manifest_path = Path(temp_dir) / "manifest.json"
-            with self.assertRaisesRegex(ValueError, "manifest exceeds 32768 bytes"):
+            with self.assertRaisesRegex(ValueError, "manifest exceeds 16384 bytes"):
                 module.write_manifest(
                     {"release_notes_url": "x" * module.MAX_MANIFEST_BYTES},
                     manifest_path,

--- a/tools/test_pull_ota_contract.py
+++ b/tools/test_pull_ota_contract.py
@@ -46,6 +46,8 @@ def main():
     assert_contains(PULL_OTA_HEADER, "pullOtaManifestCompatible")
     assert_contains(PULL_OTA_HEADER, "pullOtaSelectRelease")
     assert_contains(PULL_OTA_HEADER, "PullOtaReleaseList")
+    assert_contains(PULL_OTA_HEADER, "HDS_OTA_MANIFEST_MAX_BYTES = 16384")
+    assert_contains(PULL_OTA_HEADER, "HDS_OTA_MAX_RELEASE_CHOICES = 10")
     assert_contains(PULL_OTA_HEADER, "pullOtaReleaseCanRunFromCurrent")
     assert_contains(PULL_OTA_HEADER, 'HDS_OTA_MIN_INSTALL_VERSION = "3.1.13"')
     assert_contains(PULL_OTA_HEADER, "pullOtaCompareVersions(manifest.version, HDS_OTA_MIN_INSTALL_VERSION) < 0")


### PR DESCRIPTION
## Summary

- Keep at most the latest 10 releases in OTA catalogs.
- Cap manifests at 16 KiB in both generation and firmware download paths.
- Serialize compact JSON.
- Release the raw manifest buffer immediately after parsing.

## Why

The previous 16-release, 32 KiB limits allowed unnecessary temporary heap use during signed manifest processing. Ten releases cover the latest release plus nine prior versions.

## Validation

- `python tools/test_generate_release_manifest.py`
- `python tools/test_pull_ota_contract.py`
- `python tools/test_ai_docs_contract.py`
- `pio run -e esp32s3`
- Hardware fetch/signature/parse test passed for the current 924-byte bootstrap manifest. Full pull OTA installation remains deferred until a release target is available.
