### PR TITLE
Reduce AsyncTCP task stack to 8 KiB

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -50,6 +50,7 @@ build_flags =
 ;  -DESP32
   -I.pio.nosync/generated/include
   -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
   ; Cap each WS client's outbound queue (lib default 32) so a backed-up or
   ; half-open client (connection churn) can't hoard heap. Bounds aggregate heap


### PR DESCRIPTION
## Summary

- Set `CONFIG_ASYNC_TCP_STACK_SIZE` to 8192 bytes.
- Recover 8 KiB of heap from the previous 16 KiB default.

## Validation

- `pio run -e esp32s3`
- Hardware stress test with four WebSocket clients, BLE disconnect/reconnect, and ElegantOTA completed without resets, watchdogs, or stack-canary failures.
- The telemetry-equipped test build retained at least 4,988 bytes of AsyncTCP stack.
