### PR TITLE
Generate deterministic gzip assets and enable cache revalidation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,18 @@ jobs:
           python-version: "3.11"
       - run: python tools/test_ai_docs_contract.py
 
+  gzip-assets:
+    name: Gzip asset generation contract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: python tools/test_gzip_web_assets.py
+
   build:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+
+/web_apps/**/*.gz

--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -20,6 +20,7 @@ Firmware-only flashing does not update `web_apps/`. Flash LittleFS when the on-d
 - Every PlatformIO build validates the repository OTA public keys and regenerates `.pio.nosync/generated/include/ota_public_key.h`.
 - Firmware builds require OpenSSL through `OPENSSL`, `PATH`, or Git for Windows with `git.exe` on `PATH`; clean targets do not.
 - `web_apps/` is the LittleFS data directory.
+- `gzip_web_assets.py` generates deterministic `.gz` siblings before LittleFS image builds.
 - `git_rev_macro.py` injects `GIT_REV`; non-git source trees fall back to `nogit0`.
 - `CONFIG_ASYNC_TCP_RUNNING_CORE=1` pins AsyncTCP to core 1.
 - `ELEGANTOTA_USE_ASYNC_WEBSERVER=1` is set; `ElegantOTA.loop()` runs in `loop()`.

--- a/gzip_web_assets.py
+++ b/gzip_web_assets.py
@@ -1,0 +1,72 @@
+import gzip
+import io
+from pathlib import Path
+
+
+COMPRESSIBLE_SUFFIXES = frozenset({".html", ".js", ".css", ".svg"})
+
+
+def gzipBytes(content):
+    output = io.BytesIO()
+    with gzip.GzipFile(
+        filename="",
+        mode="wb",
+        compresslevel=9,
+        fileobj=output,
+        mtime=0,
+    ) as archive:
+        archive.write(content)
+    return output.getvalue()
+
+
+def syncGzipAssets(dataDir):
+    root = Path(dataDir)
+    if not root.is_dir():
+        raise FileNotFoundError(root)
+
+    written = 0
+    removed = 0
+    for sourcePath in sorted(root.rglob("*")):
+        if not sourcePath.is_file() or sourcePath.suffix.lower() not in COMPRESSIBLE_SUFFIXES:
+            continue
+        gzipPath = sourcePath.with_name(sourcePath.name + ".gz")
+        compressed = gzipBytes(sourcePath.read_bytes())
+        if len(compressed) >= sourcePath.stat().st_size:
+            if gzipPath.exists():
+                gzipPath.unlink()
+                removed += 1
+            continue
+        if gzipPath.exists() and gzipPath.read_bytes() == compressed:
+            continue
+        temporaryPath = gzipPath.with_name("." + gzipPath.name + ".tmp")
+        temporaryPath.write_bytes(compressed)
+        temporaryPath.replace(gzipPath)
+        written += 1
+
+    for gzipPath in sorted(root.rglob("*.gz")):
+        sourcePath = gzipPath.with_suffix("")
+        if sourcePath.suffix.lower() in COMPRESSIBLE_SUFFIXES and not sourcePath.is_file():
+            gzipPath.unlink()
+            removed += 1
+
+    return written, removed
+
+
+def platformioSyncGzipAssets(source, target, env):
+    written, removed = syncGzipAssets(env.subst("$PROJECT_DATA_DIR"))
+    print("[gzip-assets] wrote={}, removed={}".format(written, removed))
+
+
+try:
+    Import("env")
+except NameError:
+    pass
+else:
+    if not env.IsCleanTarget() and not env.IsIntegrationDump():
+        env.AddPreAction("$BUILD_DIR/littlefs.bin", platformioSyncGzipAssets)
+
+
+if __name__ == "__main__":
+    projectDir = Path(__file__).resolve().parent
+    written, removed = syncGzipAssets(projectDir / "web_apps")
+    print("[gzip-assets] wrote={}, removed={}".format(written, removed))

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -32,7 +32,7 @@ static const size_t WIFI_SETUP_MAX_SSID_BYTES = 32;
 static const size_t WIFI_SETUP_MAX_PASS_BYTES = 64;
 static const unsigned long WIFI_SETUP_RESTART_DELAY_MS = 500;
 static const char *LITTLEFS_CACHE_CONTROL =
-    "no-store, no-cache, must-revalidate, max-age=0";
+    "no-cache, must-revalidate, max-age=0";
 
 static bool httpIsPageLoadRequest(const String &url) {
   return url == "/" || url.endsWith(".html");
@@ -99,6 +99,7 @@ void startWebServer() {
       // LittleFS apps are updated in-place; avoid stale inline JS/CSS and modules
       // after a firmware/filesystem update.
       server.serveStatic("/", LittleFS, "/")
+          .setTryGzipFirst(true)
           .setDefaultFile("index.html")
           .setCacheControl(LITTLEFS_CACHE_CONTROL);
       Serial.println("Serving web-apps");

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,7 @@ framework = arduino
 extra_scripts =
   pre:check_platform_freshness.py
   pre:ota_public_key_header.py
+  post:gzip_web_assets.py
 # Partition table: vendored copy of the upstream arduino-esp32 default_8MB.csv.
 # The board (esp32-s3-devkitc-1, 8 MB flash) already defaults to this layout,
 # so this line is currently a no-op. It makes the implicit default explicit so

--- a/tools/test_gzip_web_assets.py
+++ b/tools/test_gzip_web_assets.py
@@ -1,0 +1,127 @@
+import gzip
+import importlib.util
+import os
+import runpy
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = PROJECT_ROOT / "gzip_web_assets.py"
+SPEC = importlib.util.spec_from_file_location("gzip_web_assets", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+syncGzipAssets = MODULE.syncGzipAssets
+
+
+class FakeEnvironment:
+    def __init__(self, clean=False, integrationDump=False):
+        self.clean = clean
+        self.integrationDump = integrationDump
+        self.preActions = []
+
+    def IsCleanTarget(self):
+        return self.clean
+
+    def IsIntegrationDump(self):
+        return self.integrationDump
+
+    def AddPreAction(self, target, callback):
+        self.preActions.append((target, callback))
+
+
+class GzipWebAssetsTest(unittest.TestCase):
+    def testSyncsDeterministicSmallerAssets(self):
+        with tempfile.TemporaryDirectory() as temporaryDirectory:
+            root = Path(temporaryDirectory)
+            assets = {
+                "index.html": b"<main>scale</main>" * 400,
+                "modules/app.js": b"export const weight = 0;\n" * 400,
+                "styles/app.css": b".weight{font-variant-numeric:tabular-nums}\n" * 400,
+                "icons/scale.svg": b"<svg><path d='M0 0h10v10z'/></svg>" * 400,
+            }
+            for relativePath, content in assets.items():
+                path = root / relativePath
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(content)
+
+            unsupported = root / "photo.png"
+            unsupported.write_bytes(b"png" * 400)
+            unsupportedGzip = root / "photo.png.gz"
+            unsupportedGzip.write_bytes(b"keep")
+            tiny = root / "tiny.js"
+            tiny.write_bytes(b"x")
+
+            written, removed = syncGzipAssets(root)
+            self.assertEqual((written, removed), (4, 0))
+            self.assertEqual(unsupportedGzip.read_bytes(), b"keep")
+            self.assertFalse((root / "tiny.js.gz").exists())
+
+            firstOutputs = {}
+            for relativePath, content in assets.items():
+                gzipPath = root / (relativePath + ".gz")
+                compressed = gzipPath.read_bytes()
+                firstOutputs[relativePath] = compressed
+                self.assertEqual(gzip.decompress(compressed), content)
+                self.assertEqual(compressed[3], 0)
+                self.assertEqual(compressed[4:8], b"\x00\x00\x00\x00")
+                self.assertEqual(compressed[8], 2)
+                self.assertLess(len(compressed), len(content))
+                os.utime(gzipPath, ns=(1_000_000_000, 1_000_000_000))
+
+            self.assertEqual(syncGzipAssets(root), (0, 0))
+            for relativePath in assets:
+                gzipPath = root / (relativePath + ".gz")
+                self.assertEqual(gzipPath.stat().st_mtime_ns, 1_000_000_000)
+
+            for relativePath, expected in firstOutputs.items():
+                gzipPath = root / (relativePath + ".gz")
+                gzipPath.unlink()
+                syncGzipAssets(root)
+                self.assertEqual(gzipPath.read_bytes(), expected)
+
+            changedSource = root / "modules/app.js"
+            changedSource.write_bytes(changedSource.read_bytes() + b"changed\n" * 200)
+            originalOutput = firstOutputs["modules/app.js"]
+            syncGzipAssets(root)
+            self.assertNotEqual((root / "modules/app.js.gz").read_bytes(), originalOutput)
+            self.assertEqual(
+                gzip.decompress((root / "modules/app.js.gz").read_bytes()),
+                changedSource.read_bytes(),
+            )
+
+            orphanSource = root / "styles/app.css"
+            orphanGzip = root / "styles/app.css.gz"
+            orphanSource.unlink()
+            self.assertTrue(orphanGzip.exists())
+            self.assertEqual(syncGzipAssets(root), (0, 1))
+            self.assertFalse(orphanGzip.exists())
+
+    def testRegistersLittleFsPreAction(self):
+        environment = FakeEnvironment()
+        runpy.run_path(
+            str(MODULE_PATH),
+            init_globals={"Import": lambda name: None, "env": environment},
+            run_name="platformio_gzip_web_assets",
+        )
+        self.assertEqual(len(environment.preActions), 1)
+        target, callback = environment.preActions[0]
+        self.assertEqual(target, "$BUILD_DIR/littlefs.bin")
+        self.assertEqual(callback.__name__, "platformioSyncGzipAssets")
+
+    def testSkipsCleanAndIntegrationTargets(self):
+        for environment in (
+            FakeEnvironment(clean=True),
+            FakeEnvironment(integrationDump=True),
+        ):
+            runpy.run_path(
+                str(MODULE_PATH),
+                init_globals={"Import": lambda name: None, "env": environment},
+                run_name="platformio_gzip_web_assets",
+            )
+            self.assertEqual(environment.preActions, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Generate deterministic level-9 gzip siblings for HTML, JavaScript, CSS, and SVG assets immediately before LittleFS image creation.
- Keep only gzip files that are smaller than their sources, avoid unchanged rewrites, remove orphans, and keep generated files ignored.
- Serve static assets gzip-first and change cache control from `no-store` to mandatory revalidation so the existing ETag path can return bodyless `304 Not Modified` responses.
- Add focused generator contract coverage and a pull-request CI job.

## Why

The current `no-store` directive prevents browsers from retaining static assets, so ETag revalidation cannot avoid retransmitting unchanged bodies. Allowing storage while requiring revalidation preserves freshness and enables the existing conditional-request behavior.

## Validation

- `python tools/test_gzip_web_assets.py`
- `python tools/test_ai_docs_contract.py`
- `git diff --check`
- `pio run -e esp32s3`
- `pio run -e esp32s3 -t buildfs`
- Firmware and LittleFS flashed successfully to COM5
- `index.html` returned `Content-Encoding: gzip`
- Cache-Control was `no-cache, must-revalidate, max-age=0`
- ETag `"013CDB88"` revalidated to HTTP 304 with a zero-byte body
- The browser UI loaded normally with live connected state and no console warnings or errors

The 20 compressible assets total 167,814 bytes raw and 39,249 bytes gzip. The resulting LittleFS image is 1,572,864 bytes. Generated gzip files are ignored and untracked.
