### PR TITLE
Round Decent fixed-point values

### DIFF
--- a/include/decent_protocol.h
+++ b/include/decent_protocol.h
@@ -147,7 +147,7 @@ static inline void encodeWeight(float weight, byte &byte1, byte &byte2) {
   } else if (scaled < -32768.0f) {
     scaled = -32768.0f;
   }
-  int16_t weightInt = (int16_t)scaled;
+  int16_t weightInt = (int16_t)roundf(scaled);
   uint16_t encoded = (uint16_t)weightInt;
   byte1 = (byte)((encoded >> 8) & 0xFF);
   byte2 = (byte)(encoded & 0xFF);


### PR DESCRIPTION
## Summary

- round Decent protocol values to the nearest tenth before encoding
- preserve the existing finite-value handling and signed 16-bit clamping

## Root cause

The shared encoder converted the scaled float with a direct integer cast, which truncates toward zero. Weight notifications such as 10.19 g were therefore encoded as 10.1 g instead of 10.2 g.

The shared change also makes voltage, gyro, and LED-response fixed-point values use the same correct rounding behavior.

## Validation

- `pio run -e esp32s3`