### PR TITLE
Preserve Pull OTA LittleFS rollback

### DIFF
--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -29,6 +29,8 @@ The release workflow creates draft releases, uploads binary assets first, upload
 
 Catalog manifests merge the previous latest stable signed manifest, dedupe by model, PCB, version, chip, and environment, sort newest to oldest, and keep the latest 10 production entries at `v3.1.13+`. Generated JSON is compact and limited to 16 KiB.
 
+When the installed release has aged out of the latest catalog, firmware fetches that release's own signed manifest using both supported tag forms. It accepts only the compatible top-level release entry with the exact installed version and required LittleFS metadata. Firmware rollback remains local in the other app slot; this fallback supplies the signed asset metadata needed to restore the single shared LittleFS partition.
+
 ## Picker Rules
 
 The on-device WiFi Update menu accepts stable numeric `vX.Y.Z` or `X.Y.Z` entries only.

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -206,6 +206,16 @@ String pullOtaCurrentVersion() {
   return version;
 }
 
+bool pullOtaCurrentReleaseVersion(String &version) {
+  version = pullOtaCurrentVersion();
+  char normalized[18];
+  if (!pullOtaNormalizeVersionPrefix(version.c_str(), normalized, sizeof(normalized))) {
+    return false;
+  }
+  version = normalized;
+  return true;
+}
+
 bool pullOtaParseVersionTriplet(String version, uint16_t parts[3]) {
   version.trim();
   PullOtaVersionTriplet parsed;
@@ -232,6 +242,11 @@ int pullOtaCompareVersions(const String &left, const String &right) {
 
 bool pullOtaUrlAllowed(const String &url) {
   return url.startsWith(HDS_OTA_ASSET_URL_PREFIX);
+}
+
+bool pullOtaManifestUrlAllowed(const String &url) {
+  return url == HDS_OTA_MANIFEST_URL ||
+         (pullOtaUrlAllowed(url) && url.endsWith("/manifest.json"));
 }
 
 bool pullOtaShaLooksValid(String value) {
@@ -427,7 +442,10 @@ bool pullOtaHasNewerRelease(const PullOtaReleaseList &list) {
 bool pullOtaFindCurrentRelease(
     const PullOtaReleaseList &catalog,
     PullOtaManifest &current) {
-  String currentVersion = pullOtaCurrentVersion();
+  String currentVersion;
+  if (!pullOtaCurrentReleaseVersion(currentVersion)) {
+    return false;
+  }
   for (uint8_t i = 0; i < catalog.count; i++) {
     if (pullOtaCompareVersions(catalog.releases[i].version, currentVersion) == 0 &&
         catalog.releases[i].littlefs.present &&
@@ -498,6 +516,25 @@ bool pullOtaParseManifest(const String &body, PullOtaManifest &manifest) {
     return false;
   }
   manifest = list.releases[0];
+  return true;
+}
+
+bool pullOtaParseRollbackManifest(
+    const String &body,
+    const String &currentVersion,
+    PullOtaManifest &manifest) {
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) {
+    return false;
+  }
+  JsonObject root = doc.as<JsonObject>();
+  PullOtaManifest candidate;
+  if (root.isNull() || !pullOtaParseManifestObject(root, candidate) ||
+      pullOtaCompareVersions(candidate.version, currentVersion) != 0 ||
+      !candidate.littlefs.present || !candidate.littlefs.required) {
+    return false;
+  }
+  manifest = candidate;
   return true;
 }
 
@@ -750,10 +787,14 @@ bool pullOtaReadHttpBytes(
   return length > 0 && (contentLength <= 0 || length == (size_t)contentLength);
 }
 
-bool pullOtaFetchManifest(String &body) {
+bool pullOtaFetchManifest(const String &manifestUrl, String &body) {
+  body = "";
+  if (!pullOtaManifestUrlAllowed(manifestUrl)) {
+    return false;
+  }
   HTTPClient http;
   WiFiClientSecure client;
-  if (!pullOtaBeginHttp(http, client, HDS_OTA_MANIFEST_URL)) {
+  if (!pullOtaBeginHttp(http, client, manifestUrl)) {
     return false;
   }
   int code = http.GET();
@@ -766,18 +807,20 @@ bool pullOtaFetchManifest(String &body) {
   return ok;
 }
 
-String pullOtaManifestSignatureUrl() {
-  String manifestUrl = HDS_OTA_MANIFEST_URL;
+String pullOtaManifestSignatureUrl(const String &manifestUrl) {
   String manifestName = "manifest.json";
-  if (!manifestUrl.endsWith(manifestName)) {
+  if (!pullOtaManifestUrlAllowed(manifestUrl) || !manifestUrl.endsWith(manifestName)) {
     return "";
   }
   return manifestUrl.substring(0, manifestUrl.length() - manifestName.length()) +
          "manifest.sig";
 }
 
-bool pullOtaFetchManifestSignature(uint8_t *signature, size_t &signatureLen) {
-  String signatureUrl = pullOtaManifestSignatureUrl();
+bool pullOtaFetchManifestSignature(
+    const String &manifestUrl,
+    uint8_t *signature,
+    size_t &signatureLen) {
+  String signatureUrl = pullOtaManifestSignatureUrl(manifestUrl);
   if (signatureUrl.length() == 0) {
     return false;
   }
@@ -797,16 +840,42 @@ bool pullOtaFetchManifestSignature(uint8_t *signature, size_t &signatureLen) {
   return ok;
 }
 
-bool pullOtaFetchSignedManifest(String &body) {
-  if (!pullOtaFetchManifest(body)) {
+bool pullOtaFetchSignedManifest(const String &manifestUrl, String &body) {
+  if (!pullOtaFetchManifest(manifestUrl, body)) {
     return false;
   }
   uint8_t signature[HDS_OTA_MANIFEST_SIGNATURE_MAX_BYTES];
   size_t signatureLen = 0;
-  if (!pullOtaFetchManifestSignature(signature, signatureLen)) {
+  if (!pullOtaFetchManifestSignature(manifestUrl, signature, signatureLen)) {
     return false;
   }
   return pullOtaVerifyManifestSignature(body, signature, signatureLen);
+}
+
+bool pullOtaFetchSignedManifest(String &body) {
+  return pullOtaFetchSignedManifest(HDS_OTA_MANIFEST_URL, body);
+}
+
+String pullOtaReleaseManifestUrl(const String &version, bool prefixedTag) {
+  return String(HDS_OTA_ASSET_URL_PREFIX) + (prefixedTag ? "v" : "") +
+         version + "/manifest.json";
+}
+
+bool pullOtaFetchCurrentReleaseManifest(PullOtaManifest &manifest) {
+  String currentVersion;
+  if (!pullOtaCurrentReleaseVersion(currentVersion)) {
+    return false;
+  }
+  const bool prefixedTags[] = {true, false};
+  for (bool prefixedTag : prefixedTags) {
+    String body;
+    if (pullOtaFetchSignedManifest(
+            pullOtaReleaseManifestUrl(currentVersion, prefixedTag), body) &&
+        pullOtaParseRollbackManifest(body, currentVersion, manifest)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool pullOtaEnsureWifi(unsigned long timeoutMs = HDS_OTA_WIFI_TIMEOUT_MS) {
@@ -1319,28 +1388,32 @@ void pullOtaRunUpdate() {
     pullOtaFail("Clock failed", "TLS blocked");
     return;
   }
-  PullOtaReleaseList catalog;
-  {
-    String body;
-    if (!pullOtaFetchSignedManifest(body)) {
-      pullOtaFail("Signature failed");
-      return;
-    }
-    if (!pullOtaParseManifest(body, catalog)) {
-      pullOtaFail("Manifest invalid");
-      return;
-    }
-  }
   PullOtaReleaseList releases;
-  pullOtaBuildSelectableReleases(catalog, releases);
-  if (releases.count == 0) {
-    pullOtaDraw("Newest stable", pullOtaCurrentVersion().c_str());
-    delay(2000);
-    b_ota = false;
-    return;
-  }
   PullOtaManifest rollbackManifest;
-  if (!pullOtaFindCurrentRelease(catalog, rollbackManifest)) {
+  bool rollbackFound = false;
+  {
+    PullOtaReleaseList catalog;
+    {
+      String body;
+      if (!pullOtaFetchSignedManifest(body)) {
+        pullOtaFail("Signature failed");
+        return;
+      }
+      if (!pullOtaParseManifest(body, catalog)) {
+        pullOtaFail("Manifest invalid");
+        return;
+      }
+    }
+    pullOtaBuildSelectableReleases(catalog, releases);
+    if (releases.count == 0) {
+      pullOtaDraw("Newest stable", pullOtaCurrentVersion().c_str());
+      delay(2000);
+      b_ota = false;
+      return;
+    }
+    rollbackFound = pullOtaFindCurrentRelease(catalog, rollbackManifest);
+  }
+  if (!rollbackFound && !pullOtaFetchCurrentReleaseManifest(rollbackManifest)) {
     pullOtaFail("Rollback missing");
     return;
   }

--- a/include/pull_ota_version.h
+++ b/include/pull_ota_version.h
@@ -1,7 +1,9 @@
 #ifndef PULL_OTA_VERSION_H
 #define PULL_OTA_VERSION_H
 
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
 struct PullOtaVersionTriplet {
   uint16_t parts[3] = {0, 0, 0};
@@ -47,6 +49,21 @@ inline bool pullOtaVersionIsStable(const char *version) {
 inline bool pullOtaVersionHasComparablePrefix(const char *version, PullOtaVersionTriplet &parsed) {
   return pullOtaParseVersionPrefix(version, parsed) &&
          (*parsed.suffix == '\0' || *parsed.suffix == '-');
+}
+
+inline bool pullOtaNormalizeVersionPrefix(
+    const char *version,
+    char *normalized,
+    size_t normalizedSize) {
+  PullOtaVersionTriplet parsed;
+  if (normalized == nullptr || normalizedSize == 0 ||
+      !pullOtaVersionHasComparablePrefix(version, parsed)) {
+    return false;
+  }
+  int length = snprintf(
+      normalized, normalizedSize, "%u.%u.%u",
+      parsed.parts[0], parsed.parts[1], parsed.parts[2]);
+  return length > 0 && static_cast<size_t>(length) < normalizedSize;
 }
 
 inline int pullOtaCompareVersionPrefixes(const char *left, const char *right) {

--- a/test/test_pull_ota_version/test_main.cpp
+++ b/test/test_pull_ota_version/test_main.cpp
@@ -26,6 +26,18 @@ void testComparisonHandlesVersionBounds() {
   TEST_ASSERT_FALSE(pullOtaVersionIsStable("65536.0.0"));
 }
 
+void testVersionPrefixNormalization() {
+  char normalized[18];
+  TEST_ASSERT_TRUE(pullOtaNormalizeVersionPrefix("v3.1.13", normalized, sizeof(normalized)));
+  TEST_ASSERT_EQUAL_STRING("3.1.13", normalized);
+  TEST_ASSERT_TRUE(pullOtaNormalizeVersionPrefix("3.1.13", normalized, sizeof(normalized)));
+  TEST_ASSERT_EQUAL_STRING("3.1.13", normalized);
+  TEST_ASSERT_TRUE(pullOtaNormalizeVersionPrefix("3.1.13-dev", normalized, sizeof(normalized)));
+  TEST_ASSERT_EQUAL_STRING("3.1.13", normalized);
+  TEST_ASSERT_FALSE(pullOtaNormalizeVersionPrefix("3.1", normalized, sizeof(normalized)));
+  TEST_ASSERT_FALSE(pullOtaNormalizeVersionPrefix("3.1.13garbage", normalized, sizeof(normalized)));
+}
+
 struct TestRelease {
   const char *key;
   const char *version;
@@ -58,6 +70,7 @@ int main() {
   RUN_TEST(testStableVersionsStayStrict);
   RUN_TEST(testDevBuildUsesNumericPrefix);
   RUN_TEST(testComparisonHandlesVersionBounds);
+  RUN_TEST(testVersionPrefixNormalization);
   RUN_TEST(testCatalogSortsDeduplicatesAndCaps);
   return UNITY_END();
 }

--- a/tools/test_generate_release_manifest.py
+++ b/tools/test_generate_release_manifest.py
@@ -274,34 +274,46 @@ class GenerateReleaseManifestTest(unittest.TestCase):
 
             self.assertEqual([release["version"] for release in catalog["releases"]], ["3.1.14", "3.1.13"])
 
-    def test_release_catalog_caps_entries_and_serialized_size(self):
+    def test_release_catalog_cap_keeps_per_release_rollback_manifest(self):
         module = load_module()
-        latest = {
-            "model": "hds",
-            "version": "3.1.60",
-            "chip": "esp32s3",
-            "environment": "esp32s3",
-        }
-        previous = {
-            "releases": [
-                {
-                    "model": "hds",
-                    "version": f"3.1.{version}",
-                    "chip": "esp32s3",
-                    "environment": "esp32s3",
-                }
-                for version in range(13, 60)
-            ]
-        }
-
-        catalog = module.build_catalog_manifest(latest, [previous], min_version="v3.1.13")
-
-        self.assertEqual(module.MAX_CATALOG_RELEASES, 10)
-        self.assertEqual(module.MAX_MANIFEST_BYTES, 16384)
-        self.assertEqual(len(catalog["releases"]), 10)
-        self.assertEqual(catalog["releases"][0]["version"], "3.1.60")
         with tempfile.TemporaryDirectory() as temp_dir:
-            manifest_path = Path(temp_dir) / "manifest.json"
+            build_dir = Path(temp_dir)
+            (build_dir / "firmware.bin").write_bytes(b"firmware")
+            (build_dir / "littlefs.bin").write_bytes(b"littlefs")
+            oldest = module.build_manifest(
+                build_dir=build_dir,
+                tag="v3.1.13",
+                repository="decentespresso/openscale",
+                model="hds",
+                min_from="3.1.13",
+            )
+            latest = module.build_manifest(
+                build_dir=build_dir,
+                tag="v3.1.23",
+                repository="decentespresso/openscale",
+                model="hds",
+                min_from="3.1.13",
+            )
+            previous = {
+                "releases": [
+                    {**oldest, "version": f"3.1.{version}"}
+                    for version in range(13, 23)
+                ]
+            }
+            catalog = module.build_catalog_manifest(
+                latest, [previous], min_version="v3.1.13"
+            )
+
+            self.assertEqual(module.MAX_CATALOG_RELEASES, 10)
+            self.assertEqual(module.MAX_MANIFEST_BYTES, 16384)
+            self.assertEqual(
+                [release["version"] for release in catalog["releases"]],
+                [f"3.1.{version}" for version in range(23, 13, -1)],
+            )
+            self.assertNotIn("3.1.13", [release["version"] for release in catalog["releases"]])
+            self.assertEqual(oldest["version"], "3.1.13")
+            self.assertTrue(oldest["littlefs"]["required"])
+            manifest_path = build_dir / "manifest.json"
             module.write_manifest(catalog, manifest_path)
             self.assertLessEqual(manifest_path.stat().st_size, module.MAX_MANIFEST_BYTES)
             self.assertNotIn("\n  ", manifest_path.read_text(encoding="utf-8"))
@@ -317,7 +329,7 @@ class GenerateReleaseManifestTest(unittest.TestCase):
                 )
             self.assertFalse(manifest_path.exists())
 
-    def test_manifest_signature_rejects_mismatched_key(self):
+    def test_manifest_signature_accepts_matching_and_rejects_mismatched_key(self):
         openssl = os.environ.get("OPENSSL") or shutil.which("openssl")
         if openssl is None:
             self.skipTest("openssl is not installed")
@@ -326,6 +338,7 @@ class GenerateReleaseManifestTest(unittest.TestCase):
             manifest_path = root / "manifest.json"
             signature_path = root / "manifest.sig"
             signing_key = root / "signing.pem"
+            signing_public_key = root / "signing-public.pem"
             wrong_key = root / "wrong.pem"
             wrong_public_key = root / "wrong-public.pem"
             manifest_path.write_text('{"version":"3.1.13"}\n', encoding="utf-8")
@@ -340,6 +353,11 @@ class GenerateReleaseManifestTest(unittest.TestCase):
                 capture_output=True,
             )
             subprocess.run(
+                [openssl, "pkey", "-in", signing_key, "-pubout", "-out", signing_public_key],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
                 [openssl, "pkey", "-in", wrong_key, "-pubout", "-out", wrong_public_key],
                 check=True,
                 capture_output=True,
@@ -350,11 +368,16 @@ class GenerateReleaseManifestTest(unittest.TestCase):
                 capture_output=True,
             )
 
+            matching_result = subprocess.run(
+                [openssl, "dgst", "-sha256", "-verify", signing_public_key, "-signature", signature_path, manifest_path],
+                capture_output=True,
+            )
             result = subprocess.run(
                 [openssl, "dgst", "-sha256", "-verify", wrong_public_key, "-signature", signature_path, manifest_path],
                 capture_output=True,
             )
 
+            self.assertEqual(matching_result.returncode, 0)
             self.assertNotEqual(result.returncode, 0)
 
 

--- a/tools/test_ota_rollback_contract.py
+++ b/tools/test_ota_rollback_contract.py
@@ -23,6 +23,7 @@ def main():
     assert_contains(PULL_OTA_HEADER, "pullOtaEnsureWifi(HDS_OTA_PENDING_WIFI_TIMEOUT_MS)")
     assert_contains(PULL_OTA_HEADER, "hdsOtaRollbackMarkValid();")
     assert_contains(PULL_OTA_HEADER, "pullOtaFindCurrentRelease(catalog, rollbackManifest)")
+    assert_contains(PULL_OTA_HEADER, "pullOtaFetchCurrentReleaseManifest(rollbackManifest)")
     assert_contains(PULL_OTA_HEADER, "pullOtaBeginRollbackLittleFsAttempt()")
     assert_contains(PULL_OTA_HEADER, "maxAttempts = pending.restore ? 1 : 2")
     assert_contains(PULL_OTA_HEADER, "loaded.filesystemDirty")

--- a/tools/test_pull_ota_contract.py
+++ b/tools/test_pull_ota_contract.py
@@ -37,11 +37,13 @@ def main():
     assert_contains(PULL_OTA_HEADER, "pullOtaPublicKeysConfigured")
     assert_contains(PULL_OTA_HEADER, "for (const char *key : publicKeys)")
     assert_contains(PULL_OTA_HEADER, "pullOtaFetchSignedManifest")
+    assert_contains(PULL_OTA_HEADER, "pullOtaManifestUrlAllowed")
     assert_contains(PULL_OTA_HEADER, "pullOtaVerifyManifestSignature")
     assert_contains(PULL_OTA_HEADER, "pullOtaFetchManifestSignature")
     assert_contains(PULL_OTA_HEADER, "mbedtls_pk_verify")
     assert_contains(PULL_OTA_HEADER, "sha256Matches")
     assert_contains(PULL_OTA_HEADER, "pullOtaParseVersionTriplet")
+    assert_contains(PULL_OTA_HEADER, "pullOtaNormalizeVersionPrefix")
     assert_contains(PULL_OTA_HEADER, "Update.begin(asset.size, command)")
     assert_contains(PULL_OTA_HEADER, "pullOtaManifestCompatible")
     assert_contains(PULL_OTA_HEADER, "pullOtaSelectRelease")
@@ -61,10 +63,23 @@ def main():
     assert_contains(PULL_OTA_HEADER, "pullOtaParseManifest(body, catalog)")
     assert_contains(PULL_OTA_HEADER, "pullOtaBuildSelectableReleases(catalog, releases)")
     assert_contains(PULL_OTA_HEADER, "pullOtaFindCurrentRelease(catalog, rollbackManifest)")
+    assert_contains(PULL_OTA_HEADER, "pullOtaFetchCurrentReleaseManifest(rollbackManifest)")
+    assert_contains(PULL_OTA_HEADER, "pullOtaReleaseManifestUrl(currentVersion, prefixedTag)")
+    assert_contains(PULL_OTA_HEADER, "const bool prefixedTags[] = {true, false}")
+    assert_contains(PULL_OTA_HEADER, "pullOtaFetchSignedManifest(")
+    assert_contains(PULL_OTA_HEADER, "pullOtaParseRollbackManifest(body, currentVersion, manifest)")
+    assert_contains(PULL_OTA_HEADER, "pullOtaParseManifestObject(root, candidate)")
+    assert_contains(PULL_OTA_HEADER, "pullOtaCompareVersions(candidate.version, currentVersion) != 0")
+    assert_contains(PULL_OTA_HEADER, "!candidate.littlefs.present || !candidate.littlefs.required")
     assert_before(
         PULL_OTA_HEADER,
         "if (releases.count == 0)",
         "pullOtaFindCurrentRelease(catalog, rollbackManifest)",
+    )
+    assert_before(
+        PULL_OTA_HEADER,
+        "rollbackFound = pullOtaFindCurrentRelease(catalog, rollbackManifest)",
+        "!rollbackFound && !pullOtaFetchCurrentReleaseManifest(rollbackManifest)",
     )
     assert_contains(PULL_OTA_HEADER, "wifi_init();")
     assert_contains(PULL_OTA_HEADER, "pullOtaStorePendingLittleFs")


### PR DESCRIPTION
## Summary

- fetch the installed release's own signed manifest when it has aged out of the 10-entry latest catalog
- accept only exact-version, hardware-compatible, required LittleFS rollback metadata
- support both `vX.Y.Z` and `X.Y.Z` release tags without increasing the catalog or manifest limits
- remove the temporary Pull OTA heap diagnostics

## Root cause

The bounded latest catalog can omit an older installed release, but Pull OTA requires that release's signed LittleFS URL, size, and SHA-256 before installation. Without it, the update aborts with `Rollback missing` even though compatible newer releases are available.

## Impact

Firmware rollback still uses the existing second app slot. Only the shared LittleFS recovery metadata is fetched from the installed release's signed per-release manifest. If that manifest is missing, unsigned, mismatched, or incompatible, the update stops before writing firmware or LittleFS.

## Validation

- `python tools/test_generate_release_manifest.py`
- `python tools/test_pull_ota_contract.py`
- `python tools/test_ota_rollback_contract.py`
- `python tools/test_release_workflow_contract.py`
- `python tools/test_ota_public_key_header.py`
- `python tools/test_ai_docs_contract.py`
- `pio test -e native -f test_pull_ota_version`
- `pio run -e esp32s3`
- `git diff --check`