### PR TITLE
Audit AI Markdown guidance and documentation contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .vscode/extensions.json
 .vscode/launch.json
 .DS_Store
-
+.codegraph/
 # Python
 __pycache__/
 *.py[cod]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Use `docs/AI_REPO_MAP.md` first for orientation. Read broader docs only when the
 - Do not call I2C, SPI, OLED, power-gating, or blocking hardware work from AsyncTCP callbacks.
 - Do not call `WiFi.setSleep(false)`.
 - New global firmware state belongs in `include/parameter.h`.
-- New cross-task globals shared with `loop()` must be `volatile`.
+- New cross-task globals shared with `loop()` must be `volatile` and protected by the owning queue, critical section, or other synchronization mechanism; `volatile` alone is not synchronization.
 - A full-screen U8g2 renderer owns its firstPage() / nextPage() loop. Draw helpers called from an existing frame must not start a nested page loop.
 - Do not add `printfAll` broadcasts without `wsBroadcastHeapOk()`.
 - Do not accumulate `String` byte-by-byte from a known-length buffer.

--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -17,14 +17,31 @@ Firmware-only flashing does not update `web_apps/`. Flash LittleFS when the on-d
 ## PlatformIO Details
 
 - `platformio.ini` uses `.pio.nosync` as the workspace directory.
+- PlatformIO Core is pinned by `requirements-platformio.txt`; install it with `python -m pip install --requirement requirements-platformio.txt` before running PlatformIO.
+- `platformio.ini` pins the pioarduino platform URL and every `lib_deps` entry to an explicit registry version or git commit. Treat `platformio.ini` and `requirements-platformio.txt` as pinned dependency inputs, not optional setup files.
+- CI records the PlatformIO version and `pio pkg list -e <environment>` in `dependencies.txt` for release and nightly dependency inventories.
 - Every PlatformIO build validates the repository OTA public keys and regenerates `.pio.nosync/generated/include/ota_public_key.h`.
 - Firmware builds require OpenSSL through `OPENSSL`, `PATH`, or Git for Windows with `git.exe` on `PATH`; clean targets do not.
 - `web_apps/` is the LittleFS data directory.
 - `gzip_web_assets.py` generates deterministic `.gz` siblings before LittleFS image builds.
 - `git_rev_macro.py` injects `GIT_REV`; non-git source trees fall back to `nogit0`.
-- `CONFIG_ASYNC_TCP_RUNNING_CORE=1` pins AsyncTCP to core 1.
+- `CONFIG_ASYNC_TCP_RUNNING_CORE=1` pins AsyncTCP to core 1, and `CONFIG_ASYNC_TCP_STACK_SIZE=8192` gives the AsyncTCP task an 8 KiB stack.
 - `ELEGANTOTA_USE_ASYNC_WEBSERVER=1` is set; `ElegantOTA.loop()` runs in `loop()`.
+- `check_platform_freshness.py` compares the explicit pioarduino pin with the latest stable release as an advisory pre-build check. It never fails offline builds; set `HDS_SKIP_PLATFORM_CHECK=1` only when the check should be skipped deliberately.
 - `.gitattributes` enforces LF line endings repo-wide.
+
+## Focused Checks
+
+Run the checks that cover the build inputs and generated filesystem assets:
+
+```sh
+python tools/test_ai_docs_contract.py
+python tools/test_mdns_name_contract.py
+python tools/test_gzip_web_assets.py
+python tools/test_release_workflow_contract.py
+pio run -e esp32s3
+pio run -e esp32s3 -t buildfs
+```
 
 ## Serial Capture
 

--- a/docs/AI_DISPLAY_NOTES.md
+++ b/docs/AI_DISPLAY_NOTES.md
@@ -66,7 +66,6 @@ loop()
        -> drawButton()
        -> drawBle()
        -> drawHeartBeat()
-       -> drawGrinder()
        -> drawTare()
        -> drawShutdownFail()
        -> drawAbout()
@@ -147,7 +146,6 @@ Occupied regions include:
 - top corners: pressed-button icons
 - bottom left: BLE and WiFi
 - bottom right: battery
-- lower center: grinder status
 - bottom center: tare marker
 - center and upper/lower areas: weight and timer
 
@@ -204,8 +202,6 @@ t_actionMessageDelay
 ```
 
 Preserve `t_menuExitTime` protection so an exit press does not immediately trigger normal tare, timer, shutdown, or BLE-connected behavior.
-
-The grinder number editor is an interaction reference for Back, decrement, increment, Save, and hold acceleration. Extract a generic helper before using it for unrelated settings rather than coupling new display UI to grinder-named functions.
 
 ## Persistent Display Options
 
@@ -269,7 +265,7 @@ Hardware checks for layout work:
 - timer stopped and running
 - both timer positions
 - positive, negative, large, and overweight values
-- BLE, WiFi, battery, charging, grinder, tare, ADC recovery, shutdown, debug, and about states
+- BLE, WiFi, battery, charging, tare, ADC recovery, shutdown, debug, and about states
 - both rotations
 - display sleep and soft-sleep wake
 - clipping, controller offset, flicker, and partial-page artifacts

--- a/docs/AI_FIRMWARE_NOTES.md
+++ b/docs/AI_FIRMWARE_NOTES.md
@@ -77,6 +77,8 @@ The USB ADS debug packet keeps its 41-byte framing and checksum. Byte 24 is the 
 - Broadcast with `websocket.printfAll(...)` or `websocket.textAll(...)`, not a manual `getClients()` loop.
 - Gate every broadcast-to-all helper with `wsBroadcastHeapOk()`.
 
+The weight broadcast hot path in `sendWebsocketWeightAll()` must format the complete payload into a bounded stack buffer and call `textAll()`. Do not reintroduce per-frame `printfAll()` formatting allocations; keep the heap gate before the broadcast.
+
 Broadcasts allocate a shared payload and per-client queue entries. `printfAll` also allocates a transient formatting buffer. Arduino-ESP32 builds without exceptions, so `std::bad_alloc` aborts and reboots the device. Connection churn and half-open clients can exhaust heap. Low-heap behavior should skip broadcasts, not allocate.
 
 ### WebSocket Heap Deep Reference

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -71,6 +71,12 @@ The single LittleFS partition has no independent rollback slot. Do not weaken si
 
 `setup()` calls `hdsOtaRollbackBegin()` after reset-reason capture. Without pending filesystem work it calls `hdsOtaRollbackMarkValid()` after setup validation. With pending work, validity is deferred until target recovery succeeds and pending state is cleared.
 
+## Reboot Routing
+
+ElegantOTA auto-reboot stays disabled with `ElegantOTA.setAutoReboot(false)`. Successful ElegantOTA and pull OTA paths call `remoteQueueResetAt()` so the main loop owns the reset and normal teardown instead of a task or callback calling `ESP.restart()` directly.
+
+The rollback path withdraws WiFi and mDNS with `stopWifi()` before `esp_ota_mark_app_invalid_rollback_and_reboot()`. Do not bypass this routing: a direct reboot can leave the service advertised until resolver caches expire.
+
 ## OTA Files And Tests
 
 Core files:
@@ -90,5 +96,6 @@ python tools/test_pull_ota_contract.py
 python tools/test_release_workflow_contract.py
 python tools/test_ota_rollback_contract.py
 python tools/test_ota_public_key_header.py
+python tools/test_ota_reboot_routing_contract.py
 pio run -e esp32s3
 ```

--- a/docs/AI_PROTOCOL_NOTES.md
+++ b/docs/AI_PROTOCOL_NOTES.md
@@ -23,6 +23,14 @@ BLE and USB both route Decent commands through `handleDecentBinaryCommand()`. Th
 
 Do not duplicate command interpretation in BLE and USB. Add shared behavior to the dispatcher and only add sink methods when the transports genuinely perform the effect differently.
 
+## BLE Notification State
+
+A live BLE connection does not imply an FFF4 notification subscription. A client becomes eligible for outbound FFF4 notifications only after its current connection handle subscribes to the characteristic.
+
+All outbound FFF4 paths pass through `bleCanNotifyCurrent()`. The shared gate checks the feature state, characteristic, live connection, and current subscription before touching the characteristic.
+
+Display status responses are deferred through a mailbox. The BLE callback queues the response, and `processBleStatusResponse()` drains it from the main loop. The mailbox waits two seconds for the FFF4 subscription, then rechecks the connection handle, connection generation, pending requests, and subscription before disconnecting. A newer request or reused connection cancels stale recovery.
+
 ## Framing And Checksums
 
 Decent binary frames begin with model byte `0x03`. Checksums are XORs of the preceding bytes.
@@ -32,7 +40,7 @@ Decent binary frames begin with model byte `0x03`. Checksums are XORs of the pre
 - A short USB form is accepted after the receive timeout; a complete valid checksummed form takes precedence.
 - Shared seven-byte response builders calculate byte 6 from bytes 0 through 5.
 - The `03 0A` LED response stores weight in bytes 2-3, battery state in byte 4, firmware major in byte 5, and checksum in byte 6. The firmware byte must be assigned before calculating the checksum.
-- Weight packets use command `0xCE` and signed tenths of a gram, clamped to the `int16_t` range.
+- Weight packets use command `0xCE` and signed tenths of a gram. Decent fixed-point values are rounded to the nearest tenth rather than truncated, then clamped to the `int16_t` range.
 
 ADS debug responses are separate fixed formats: the debug packet is 41 bytes and the reset response is 5 bytes. Keep their Python helpers, decoder, and firmware builders aligned.
 
@@ -65,6 +73,7 @@ Use the smallest relevant set:
 python tools/test_ads_debug_protocol.py
 python tools/test_decode_ads_debug.py
 python tools/test_soft_sleep_ads_wake.py
+python tools/test_ble_subscription_contract.py
 pio run -e esp32s3
 ```
 

--- a/docs/AI_RELEASE_NOTES.md
+++ b/docs/AI_RELEASE_NOTES.md
@@ -57,7 +57,8 @@ documentation contract across the complete set.
 | Repository-wide agent rules | `AGENTS.md` |
 | Paths and subsystem entry points | `docs/AI_REPO_MAP.md` |
 | PlatformIO, build, flash, serial, LittleFS | `docs/AI_BUILD_NOTES.md` |
-| Runtime, callbacks, tasks, timers, weighing, display | `docs/AI_FIRMWARE_NOTES.md` |
+| Runtime, callbacks, tasks, timers, weighing | `docs/AI_FIRMWARE_NOTES.md` |
+| OLED, setup menus, layout, display options | `docs/AI_DISPLAY_NOTES.md` |
 | Pins, boards, electrical behavior, wake, sleep holds | `docs/AI_GPIO_NOTES.md` |
 | BLE, USB, WebSocket, Decent binary, integrations | `docs/AI_PROTOCOL_NOTES.md` |
 | NVS, defaults, schemas, migration, reset | `docs/AI_STORAGE_NOTES.md` |
@@ -102,6 +103,7 @@ release still:
 - checks out and builds the tagged commit;
 - builds `firmware.bin` and `littlefs.bin`;
 - produces the legacy firmware ZIP;
+- publishes `dependencies.txt` with the tagged PlatformIO version and dependency inventory;
 - requires the OTA signing key and matching public key;
 - verifies the previous signed catalog before reuse;
 - generates and verifies the new signed catalog;
@@ -120,6 +122,12 @@ At minimum, run:
 
 ```sh
 python tools/test_ai_docs_contract.py
+python tools/test_ble_subscription_contract.py
+python tools/test_mdns_name_contract.py
+python tools/test_ota_reboot_routing_contract.py
+python tools/test_grinder_feature_flag_contract.py
+python tools/test_gzip_web_assets.py
+pio test -e native
 python tools/test_release_workflow_contract.py
 python tools/test_generate_release_manifest.py
 python tools/test_pull_ota_contract.py
@@ -171,7 +179,7 @@ Only after explicit authorization:
 2. Dispatch `Release firmware` with that exact tag.
 3. Inspect the complete workflow result and raw failures.
 4. Confirm the release points to the intended commit.
-5. Confirm the legacy ZIP and required OTA assets are present.
+5. Confirm the legacy ZIP, required OTA assets, and `dependencies.txt` are present.
 6. Confirm the release is neither draft nor prerelease.
 7. Check the manifest version, hardware, environment, partitions, assets, and
    minimum supported source version.

--- a/docs/AI_REPO_MAP.md
+++ b/docs/AI_REPO_MAP.md
@@ -9,7 +9,8 @@ Local build, flash, OTA, editor, cache, and CAD files are omitted unless they ar
 | Work | Start with | Then read |
 | --- | --- | --- |
 | Build, dependencies, framework, filesystem image | `platformio.ini`, matching `.github/workflows/` file | `docs/AI_BUILD_NOTES.md` |
-| Board pins, wake, sleep holds, feature flags | `include/config.h`, `include/power.h`, `src/hds.ino` | `docs/AI_GPIO_NOTES.md` |
+| Board pins, wake, sleep holds | `include/config.h`, `include/power.h`, `src/hds.ino` | `docs/AI_GPIO_NOTES.md` |
+| Compile-time feature flags, build environments | `platformio.ini`, `include/config.h`, `src/hds.ino` | `docs/AI_BUILD_NOTES.md` |
 | Global firmware state | `include/parameter.h`, then every reader and writer | `docs/AI_FIRMWARE_NOTES.md` |
 | Main loop, buttons, weighing, OLED | `docs/AI_DISPLAY_NOTES.md`, `src/hds.ino`, `include/menu.h`, `include/display.h`, `include/finger_detection.h` | `docs/AI_FIRMWARE_NOTES.md` |
 | Calibration, ADC, tare stability | `include/calibration_validation.h`, `include/menu.h`, `src/hds.ino` | `docs/AI_FIRMWARE_NOTES.md` |

--- a/tools/test_ai_docs_contract.py
+++ b/tools/test_ai_docs_contract.py
@@ -31,6 +31,10 @@ def main():
         raise AssertionError("README.md access-point credentials do not match setupAP()")
 
     ota_notes = read("docs/AI_OTA_NOTES.md")
+    display_notes = read("docs/AI_DISPLAY_NOTES.md")
+    protocol_notes = read("docs/AI_PROTOCOL_NOTES.md")
+    build_notes = read("docs/AI_BUILD_NOTES.md")
+    release_notes = read("docs/AI_RELEASE_NOTES.md")
     hds_source = read("src/hds.ino")
     pull_ota = read("include/pull_ota.h")
     rollback = read("include/ota_rollback.h")
@@ -73,6 +77,40 @@ def main():
         r"\bone (?:recorded )?restore attempt\b", ota_notes
     ):
         raise AssertionError("AI_OTA_NOTES.md attempt limits are stale")
+
+    display_flow = re.search(
+        r"Normal display flow:\s*```text(?P<flow>.*?)```",
+        display_notes,
+        re.DOTALL,
+    )
+    if display_flow is None:
+        raise AssertionError("AI_DISPLAY_NOTES.md missing the normal display flow")
+    if re.search(r"\bgrinder\b|drawGrinder", display_flow.group("flow"), re.IGNORECASE):
+        raise AssertionError("AI_DISPLAY_NOTES.md presents feature-gated grinder UI as default")
+
+    if "`bleCanNotifyCurrent()`" not in protocol_notes or "test_ble_subscription_contract.py" not in protocol_notes:
+        raise AssertionError("AI_PROTOCOL_NOTES.md is missing the BLE subscription contract")
+
+    if "8 KiB" not in build_notes or "CONFIG_ASYNC_TCP_STACK_SIZE=8192" not in build_notes:
+        raise AssertionError("AI_BUILD_NOTES.md is missing the 8 KiB AsyncTCP stack")
+    for snippet in ("`platformio.ini`", "`requirements-platformio.txt`", "`lib_deps`", "`dependencies.txt`"):
+        if snippet not in build_notes:
+            raise AssertionError(f"AI_BUILD_NOTES.md is missing pinned dependency input: {snippet}")
+
+    if "`remoteQueueResetAt()`" not in ota_notes or "test_ota_reboot_routing_contract.py" not in ota_notes:
+        raise AssertionError("AI_OTA_NOTES.md is missing the reboot-routing contract")
+
+    for snippet in (
+        "`docs/AI_DISPLAY_NOTES.md`",
+        "test_ble_subscription_contract.py",
+        "test_mdns_name_contract.py",
+        "test_ota_reboot_routing_contract.py",
+        "test_gzip_web_assets.py",
+        "pio test -e native",
+        "`dependencies.txt`",
+    ):
+        if snippet not in release_notes:
+            raise AssertionError(f"AI_RELEASE_NOTES.md is missing current release check or asset: {snippet}")
 
     repo_map = read("docs/AI_REPO_MAP.md")
     references = set(re.findall(r"`([^`]+)`", repo_map))


### PR DESCRIPTION
## Summary

- Correct AI notes for feature-gated display behavior, BLE FFF4 subscription state, fixed-point rounding, WebSocket allocation safety, pinned build inputs, and OTA reboot routing.
- Route compile-time feature flags through the build guidance.
- Extend the AI documentation contract with focused checks for the stale-prone invariants and release audit coverage.

## Validation

- `python tools/test_ai_docs_contract.py`
- `python tools/test_ble_subscription_contract.py`
- `python tools/test_mdns_name_contract.py`
- `python tools/test_ota_reboot_routing_contract.py`
- `python tools/test_grinder_feature_flag_contract.py`
- `python tools/test_gzip_web_assets.py`
- `python tools/test_release_workflow_contract.py`
- `pio test -e native`
- `git diff --check`

The ESP32 firmware and filesystem builds were not run because this PR changes documentation and host-side contracts only.