### PR TITLE
perf(power): Tier-2 automatic light sleep, -64% idle (AI FYI)

### DIFF
--- a/include/parameter.h
+++ b/include/parameter.h
@@ -109,6 +109,7 @@ unsigned long t_batteryIcon = 0;
 bool b_showBatteryIcon = true;
 // volatile: now also written from the AsyncTCP task (WS soft-sleep command).
 volatile bool b_softSleep = false;
+unsigned long t_lastSerialActivity = 0;
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
 bool b_gyroEnabled = true;
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,3 +92,37 @@ platform = native
 test_build_src = no
 test_framework = unity
 build_flags = -Iinclude
+
+# Tier-2 automatic light-sleep build (AI FYI, see PR). Opt-in, from-source: the
+# CONFIG_PM_* / tickless / BT-controller-sleep flags below are compile-time and
+# require rebuilding the framework from source (custom_sdkconfig triggers it).
+# The BT low-power clock is RTC_SLOW because this board has no external 32kHz
+# crystal (CONFIG_RTC_CLK_SRC_INT_RC). Pair with the CONFIG_PM_ENABLE-guarded
+# esp_pm_configure() + loop yield + UART wake in src/hds.ino. Build:
+#   pio run -e esp32s3_pm -t upload
+# custom_component_remove skips unused managed IDF components that the from-source
+# build would otherwise compile (esp-modbus fails a static assert); none are
+# #included by this firmware, so removal is image-identical.
+[env:esp32s3_pm]
+extends = env:esp32s3
+custom_component_remove =
+  espressif/esp-modbus
+  espressif/esp-sr
+  espressif/esp-zboss-lib
+  espressif/esp-zigbee-lib
+  espressif/esp_insights
+  espressif/esp_diagnostics
+  espressif/esp_diag_data_store
+  espressif/esp_rainmaker
+  espressif/rmaker_common
+  espressif/esp_modem
+  espressif/esp-dsp
+  chmorgan/esp-libhelix-mp3
+  espressif/qrcode
+custom_sdkconfig =
+  CONFIG_PM_ENABLE=y
+  CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+  CONFIG_PM_DFS_INIT_AUTO=y
+  CONFIG_BT_CTRL_MODEM_SLEEP=y
+  CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
+  CONFIG_BT_CTRL_LPCLK_SEL_RTC_SLOW=y

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1,5 +1,8 @@
 #include <Arduino.h>
 #include <cstring>
+#include "esp_pm.h"
+#include "esp_sleep.h"
+#include "driver/uart.h"
 #include "config.h"
 
 #include "parameter.h"
@@ -882,6 +885,21 @@ void setup() {
   } else {
     hdsOtaRollbackMarkValid();
   }
+
+#if CONFIG_PM_ENABLE
+  {
+    esp_pm_config_t pmcfg = {
+      .max_freq_mhz = 240,
+      .min_freq_mhz = 80,
+      .light_sleep_enable = true,
+    };
+    esp_err_t pmrc = esp_pm_configure(&pmcfg);
+    Serial.printf("[pm] esp_pm_configure ls=on 240/80 -> %s\n", esp_err_to_name(pmrc));
+    uart_set_wakeup_threshold(UART_NUM_0, 3);
+    esp_err_t urc = esp_sleep_enable_uart_wakeup(UART_NUM_0);
+    Serial.printf("[pm] uart0 wake-on-rx -> %s\n", esp_err_to_name(urc));
+  }
+#endif
 }
 
 /**
@@ -1605,6 +1623,7 @@ void loop() {
       data[len++] = Serial.read();
     }
     usbCallbacks.onStream(data, len);  // Process serial byte stream
+    t_lastSerialActivity = millis();
   }
   usbCallbacks.poll();
 
@@ -1785,6 +1804,14 @@ void loop() {
       }
     }
   }
+
+#if CONFIG_PM_ENABLE
+  if (millis() - t_lastSerialActivity > 250) {
+    vTaskDelay(pdMS_TO_TICKS(10));
+  } else {
+    vTaskDelay(1);
+  }
+#endif
 }
 
 


### PR DESCRIPTION
> **⚠️ AI-written, FYI only.** This entire change and its testing were done by an AI agent (Claude) on a hardware-in-the-loop bench. It is posted for review and discussion, **not** as something that has to be merged. Numbers are from a single V8.1 unit.

## What this changes

Enables ESP-IDF **automatic light sleep** so the SoC powers down between events instead of running the core continuously. Idle-ON current drops from **110.6 mA to 39.7 mA (-64%)**.

Three parts:
1. **sdkconfig** (new opt-in from-source env `[env:esp32s3_pm]`): `CONFIG_PM_ENABLE` + `FREERTOS_USE_TICKLESS_IDLE` + `esp_pm_configure(light_sleep=on)`, and the NimBLE controller's low-power clock on `RTC_SLOW` (internal RC) — **this board has no external 32 kHz crystal** (`CONFIG_RTC_CLK_SRC_INT_RC`), and the default main-crystal LP clock dies in light sleep.
2. **A blocking yield at the end of `loop()`** — the actual unlock (see below).
3. **Serial hardening** for light sleep — UART wake-on-rx + a stay-awake grace window.

All runtime code is guarded by `#if CONFIG_PM_ENABLE`, so the **stock precompiled build (`env:esp32s3`) is completely unchanged**.

## How it was found

A config-only attempt (PM flags + `esp_pm_configure`) gave **no benefit — 87.7 mA, worse than plain 80 MHz scaling**, and never dipped toward a sleep floor. Root cause: `loop()` has no blocking call (`pureScale()` -> `scale.update()` is non-blocking), so the loop task never yields, the FreeRTOS idle task never runs, and tickless idle can never enter. Adding one `vTaskDelay` at the end of `loop()` was the whole fix:

| Build | Idle | vs baseline |
|---|---:|---:|
| baseline idle-ON | 110.6 mA | — |
| PM flags only, no yield | 87.7 mA | none (loop never blocks) |
| **PM + loop yield** | **39.7 mA** | **-64%** |

Min dips to ~30 mA (asleep), max ~50 mA (awake) = real light-sleep duty-cycling.

## Serial hardening

Light sleep turns off the UART clock, so incoming bytes were dropped mid-command. Fixed with:
- `esp_sleep_enable_uart_wakeup(UART_NUM_0)` (+ threshold) so an incoming byte wakes the SoC;
- a **stay-awake grace window**: `t_lastSerialActivity` is stamped when serial bytes arrive, and the loop only yields the sleep-enabling `vTaskDelay(10ms)` when serial has been quiet >250 ms; during a burst it uses `vTaskDelay(1)` (below the tickless-idle threshold) so it stays awake and responsive without busy-spinning.

Result: serial functional regression **8/8 consistently** (5/5 runs during development), **idle power unchanged** (the grace window costs nothing at idle — it only stays awake during actual serial traffic).

## How it was tested

Committed-code verification: boot log shows `[pm] esp_pm_configure ls=on 240/80 -> ESP_OK` and `[pm] uart0 wake-on-rx -> ESP_OK`; USB-serial functional regression 8/8 (boot, weight stream *through* light sleep, `v`, oledoff/oledon, tare, stability); idle 39.7 mA @ 5.2 V on the KM003C. Build/flash: `pio run -e esp32s3_pm -t upload`.

## Relationship to #118

This is an **alternative to, not stacked on, #118** (manual CPU 80 MHz scaling). PM/DFS does frequency scaling automatically, so the manual `setCpuFrequencyMhz` calls from #118 would conflict; this branch is cut from `main` without them. If Tier-2 is adopted, it supersedes #118.

## Known gaps / NOT verified

- **BLE over-the-air not tested** — host BLE tooling is blocked non-interactively on the test Mac. It boots and advertises without crashing on the internal-RC LP clock, but pairing/streaming *under light sleep* (with the sloppier RC clock) needs a phone/app test. This is the most important thing to check before trusting it.
- The **first byte after a sleep period is still lost** (it trips the UART wake and is consumed) — absorbed by a host-side wake-preamble convention, not a firmware bug, but worth a protocol note.
- The yield is a **crude fixed 10 ms**, not synced to the load cell. A DRDY-interrupt-driven block would be cleaner and likely lower still.
- Requires a **from-source framework rebuild** (the sdkconfig flags are compile-time); slower than the precompiled path.
- Single V8.1 bench unit, full battery, room temperature.


---
**Update:** #121 builds directly on this branch (it includes these two commits) and extends it into a full power profile — BLE-wakeable low-power sleep and a 240 MHz pin when connected + live (for the upcoming extension mechanism), all verified over real BLE. If you're evaluating the light-sleep approach, #121 is the fuller version.
