### PR TITLE
perf(power): light-sleep power management — BLE-wakeable sleep + 240MHz-when-live (AI FYI)

### DIFF
--- a/include/parameter.h
+++ b/include/parameter.h
@@ -109,6 +109,7 @@ unsigned long t_batteryIcon = 0;
 bool b_showBatteryIcon = true;
 // volatile: now also written from the AsyncTCP task (WS soft-sleep command).
 volatile bool b_softSleep = false;
+unsigned long t_lastSerialActivity = 0;
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
 bool b_gyroEnabled = true;
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,3 +92,37 @@ platform = native
 test_build_src = no
 test_framework = unity
 build_flags = -Iinclude
+
+# Tier-2 automatic light-sleep build (AI FYI, see PR). Opt-in, from-source: the
+# CONFIG_PM_* / tickless / BT-controller-sleep flags below are compile-time and
+# require rebuilding the framework from source (custom_sdkconfig triggers it).
+# The BT low-power clock is RTC_SLOW because this board has no external 32kHz
+# crystal (CONFIG_RTC_CLK_SRC_INT_RC). Pair with the CONFIG_PM_ENABLE-guarded
+# esp_pm_configure() + loop yield + UART wake in src/hds.ino. Build:
+#   pio run -e esp32s3_pm -t upload
+# custom_component_remove skips unused managed IDF components that the from-source
+# build would otherwise compile (esp-modbus fails a static assert); none are
+# #included by this firmware, so removal is image-identical.
+[env:esp32s3_pm]
+extends = env:esp32s3
+custom_component_remove =
+  espressif/esp-modbus
+  espressif/esp-sr
+  espressif/esp-zboss-lib
+  espressif/esp-zigbee-lib
+  espressif/esp_insights
+  espressif/esp_diagnostics
+  espressif/esp_diag_data_store
+  espressif/esp_rainmaker
+  espressif/rmaker_common
+  espressif/esp_modem
+  espressif/esp-dsp
+  chmorgan/esp-libhelix-mp3
+  espressif/qrcode
+custom_sdkconfig =
+  CONFIG_PM_ENABLE=y
+  CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
+  CONFIG_PM_DFS_INIT_AUTO=y
+  CONFIG_BT_CTRL_MODEM_SLEEP=y
+  CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
+  CONFIG_BT_CTRL_LPCLK_SEL_RTC_SLOW=y

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -426,6 +426,13 @@ void wifi_init() {
 
 MyUsbCallbacks usbCallbacks;
 
+#if CONFIG_PM_ENABLE
+// Held while the scale is connected + live (not soft-sleep), pinning the CPU at
+// max freq so on-scale extensions have full compute; released otherwise so DFS
+// scales down and light sleep engages.
+esp_pm_lock_handle_t s_activeFreqLock = nullptr;
+#endif
+
 // Map esp_reset_reason() to a short string for the boot log only. The raw
 // numeric code is what we ship in the ADS debug packet (byte 24); this is
 // purely for human-readable serial output.
@@ -895,6 +902,7 @@ void setup() {
     };
     esp_err_t pmrc = esp_pm_configure(&pmcfg);
     Serial.printf("[pm] esp_pm_configure ls=on 240/80 -> %s\n", esp_err_to_name(pmrc));
+    esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX, 0, "active", &s_activeFreqLock);
     uart_set_wakeup_threshold(UART_NUM_0, 3);
     esp_err_t urc = esp_sleep_enable_uart_wakeup(UART_NUM_0);
     Serial.printf("[pm] uart0 wake-on-rx -> %s\n", esp_err_to_name(urc));
@@ -1587,6 +1595,19 @@ void loop() {
   // so a SLEEP_OFF / POWER_OFF queued from the AsyncTCP task takes effect
   // here on the loop task rather than racing peripheral drivers.
   processWsPendingCmds();
+
+#if CONFIG_PM_ENABLE
+  {
+    static bool prevActive = false;
+    bool active = deviceConnected && !b_softSleep;
+    if (active != prevActive && s_activeFreqLock != nullptr) {
+      if (active) esp_pm_lock_acquire(s_activeFreqLock);
+      else        esp_pm_lock_release(s_activeFreqLock);
+      prevActive = active;
+      Serial.printf("[pm] cpu %s (connected+live=%d)\n", active ? "pinned 240" : "released->DFS", active);
+    }
+  }
+#endif
 
   if (b_powerOff){
     shut_down_now_nobeep();

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1,5 +1,8 @@
 #include <Arduino.h>
 #include <cstring>
+#include "esp_pm.h"
+#include "esp_sleep.h"
+#include "driver/uart.h"
 #include "config.h"
 
 #include "parameter.h"
@@ -882,6 +885,21 @@ void setup() {
   } else {
     hdsOtaRollbackMarkValid();
   }
+
+#if CONFIG_PM_ENABLE
+  {
+    esp_pm_config_t pmcfg = {
+      .max_freq_mhz = 240,
+      .min_freq_mhz = 80,
+      .light_sleep_enable = true,
+    };
+    esp_err_t pmrc = esp_pm_configure(&pmcfg);
+    Serial.printf("[pm] esp_pm_configure ls=on 240/80 -> %s\n", esp_err_to_name(pmrc));
+    uart_set_wakeup_threshold(UART_NUM_0, 3);
+    esp_err_t urc = esp_sleep_enable_uart_wakeup(UART_NUM_0);
+    Serial.printf("[pm] uart0 wake-on-rx -> %s\n", esp_err_to_name(urc));
+  }
+#endif
 }
 
 /**
@@ -1605,6 +1623,7 @@ void loop() {
       data[len++] = Serial.read();
     }
     usbCallbacks.onStream(data, len);  // Process serial byte stream
+    t_lastSerialActivity = millis();
   }
   usbCallbacks.poll();
 
@@ -1785,6 +1804,14 @@ void loop() {
       }
     }
   }
+
+#if CONFIG_PM_ENABLE
+  if (millis() - t_lastSerialActivity > 250) {
+    vTaskDelay(pdMS_TO_TICKS(10));
+  } else {
+    vTaskDelay(1);
+  }
+#endif
 }
 
 

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1806,10 +1806,12 @@ void loop() {
   }
 
 #if CONFIG_PM_ENABLE
-  if (millis() - t_lastSerialActivity > 250) {
-    vTaskDelay(pdMS_TO_TICKS(10));
-  } else {
+  if (millis() - t_lastSerialActivity <= 250) {
     vTaskDelay(1);
+  } else if (b_softSleep) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+  } else {
+    vTaskDelay(pdMS_TO_TICKS(10));
   }
 #endif
 }


### PR DESCRIPTION
> **⚠️ AI-written, FYI only.** This change and its testing were done by an AI agent (Claude) on a hardware-in-the-loop bench (KM003C USB power analyzer + real BLE via the tcl-ble-osx CoreBluetooth driver). Posted for review and discussion, **not** as something that has to be merged. Numbers are from a single V8.1 unit, full battery, room temperature.

Builds on the automatic light sleep in #119 (its two commits are included here) and turns it into a complete, demand-matched power profile. Three commits:
1. Tier-2 automatic light sleep (= #119).
2. BLE-wakeable low-power sleep (soft-sleep yields 50 ms so the SoC light-sleeps between BLE events).
3. **Pin CPU to 240 MHz when connected + live** (extension headroom).

**Deep sleep is untouched:** double-tap-O and the BLE "off" command (`03 0A 02`) still fully power down the radio (µA, button/charger wake only).

## The resulting power profile (all measured over real BLE)

| State | Power | CPU |
|---|---:|---|
| Deep sleep (double-tap / BLE "off") | µA | radio off |
| Connected + **soft-sleep** (BLE "sleep" `03 0A 04 01`) | **31.4 mA** | released → light-sleep |
| Not connected, idle (advertising) | ~40 mA | DFS + light-sleep |
| Connected + **live** (weighing / extensions) | **64.4 mA** | **240 MHz pinned** |
| *(stock idle-ON, for reference)* | *110.6 mA* | *240 fixed* |

## 1–2. BLE-wakeable low-power sleep

Makes the "sleep" state (`03 0A 04 01` — scale sleeps but stays connected so the app can wake it) genuinely low-power. Stock "sleep" only turns off the OLED + peripheral rails; the CPU stays at 240 MHz and BLE never sleeps. This lets the SoC light-sleep between connection events.

**Apples-to-apples, connected + BLE-wakeable sleep:** stock **103.8 mA** → this **31.4 mA** = **−70% (3.3×)**, with wake unchanged (**5/5 at ~105 ms**, stable connection, 0 disconnects).

## 3. 240 MHz pin when connected + live

For the upcoming on-scale extension mechanism: hold an `ESP_PM_CPU_FREQ_MAX` lock while `(deviceConnected && !b_softSleep)` so extensions get full compute during active connected use; release it otherwise so DFS scales down and light sleep engages. Measured: connected + live **64.4 mA** (240 pinned) vs connected + soft-sleep **31.4 mA** (released → light-sleep, **unchanged** — the sleep savings are fully preserved), wake still 5/5. Using a PM lock rather than a raw `setCpuFrequencyMhz` is deliberate — the latter fights DFS.

## How it was verified

Real BLE central (macOS via tcl-ble-osx): connect, stream weight (~10 Hz), 5 sleep→wake cycles — notifications stop in sleep and resume on wake, wake latency a consistent ~105 ms, 0 disconnects / 0 write errors. This also settled the standing risk that the light-sleep firmware (BLE on the internal RC clock — this board has no 32 kHz crystal) might not hold a BLE connection. **It does — rock stable.** All runtime code is `#if CONFIG_PM_ENABLE`-guarded, so the stock precompiled build is unchanged. Build: `pio run -e esp32s3_pm -t upload`.

## What I tried that did NOT help (and reverted)

Requesting a slow BLE connection interval / high slave latency on soft-sleep entry (`ble_gap_update_params`) to cut radio wakeups further. Measured: **no power change** (wake latency stayed 105 ms → macOS as central rejected the request; CoreBluetooth is documented to clamp/ignore peripheral connection-parameter requests) **and it broke wake reliability** (1/5 + a disconnect from the per-cycle param toggling). Reverted. It may help with a phone central that honors conn-param requests, but that can't be validated on this bench.

## Known gaps / not verified

- Measured **over USB**, so all mA figures include the CH340 bridge chip (~a few mA) that powers the bench cable. On battery that's gone, so the true draw is lower and the **relative sleep win is even larger than 3.3×**. Exact battery-side figures need a shunt / PPK2.
- The **Decent heartbeat must keep flowing during sleep** or the scale disconnects (~5 s, `b_requireHeartBeat`) and can no longer be BLE-woken. Left as-is deliberately (soft-sleep is typically USB-plugged, where the auto-off path is gated off anyway).
- The **240 mA figure is with the CPU pinned but doing light work** — a busy extension draws more on top; if some extensions are light-duty the lock could later be made opt-in per-extension.
- Relationship to the other AI-FYI PRs: this **includes #119** (Tier-2 light sleep) and is an **alternative to #118** (manual CPU scaling, which DFS subsumes). It needs a **from-source framework rebuild** (the `CONFIG_PM_*` flags are compile-time); the `[env:esp32s3_pm]` env carries them.
