### PR TITLE
Preserve empty custom-build dispatch selections

### DIFF
--- a/cloudflare/custom-build-worker/src/worker.mjs
+++ b/cloudflare/custom-build-worker/src/worker.mjs
@@ -336,8 +336,8 @@ async function dispatchBuild(env, build) {
       ref: "main",
       inputs: {
         firmware_ref: build.configuration.firmware_ref,
-        features: build.configuration.features.join(","),
-        plugins: build.configuration.plugins.join(","),
+        features: build.configuration.features.join(",") || ",",
+        plugins: build.configuration.plugins.join(",") || ",",
         source_commit: build.sourceCommit,
         combination_hash: build.combinationHash,
         attempt_id: build.attemptId,

--- a/cloudflare/custom-build-worker/test/worker.test.mjs
+++ b/cloudflare/custom-build-worker/test/worker.test.mjs
@@ -169,19 +169,21 @@ test("publishes immutable cache entries and deduplicates public builds", async (
       const request = JSON.parse(options.body);
       assert.equal(request.inputs.source_commit, commit);
       if (dispatches === 1) {
-        assert.equal(request.inputs.combination_hash, "8b9b767cb97b5b2b2c8aec859219e8f9d207bab9cd41c0a986b2dab55e03bb86");
+        assert.equal(request.inputs.combination_hash, "e4bbbdaf4217d914bcb374b66567902893da2584daf0b4c04f5cca0bfb69816a");
+        assert.equal(request.inputs.features, ",");
+        assert.equal(request.inputs.plugins, ",");
       }
       return new Response(null, {status: 204});
     }
     throw new Error(`unexpected fetch: ${target}`);
   };
   try {
-    const selection = {firmware_ref: "main", features: ["wifi"], plugins: []};
+    const selection = {firmware_ref: "main", features: [], plugins: []};
     const missing = await api(env, "/api/v1/status", "POST", selection);
     assert.equal(missing.status, 200);
     const missingStatus = await missing.json();
     const hash = missingStatus.combination_hash;
-    assert.equal(hash, "8b9b767cb97b5b2b2c8aec859219e8f9d207bab9cd41c0a986b2dab55e03bb86");
+    assert.equal(hash, "e4bbbdaf4217d914bcb374b66567902893da2584daf0b4c04f5cca0bfb69816a");
     assert.equal(missingStatus.state, "missing");
 
     const sortedAssets = await api(env, "/api/v1/status", "POST", {


### PR DESCRIPTION
## Summary

- encode empty feature and plugin lists as a non-empty comma-separated sentinel
- prevent GitHub workflow defaults from replacing intentional empty selections
- cover the production BLE/USB-only dispatch path

## Root cause

GitHub substituted the `workflow_dispatch` defaults when the Worker sent empty strings. The workflow then built a different configuration, and the expected combination-hash check correctly rejected it.

Failed production run: https://github.com/decentespresso/openscale/actions/runs/31505692051

## Verification

- `node --test cloudflare/custom-build-worker/test/worker.test.mjs`
- `python tools/test_custom_build_execution.py`
- `git diff --check`