### PR TITLE
Record custom-build production completion

### DIFF
--- a/docs/custom-build/base_plan.md
+++ b/docs/custom-build/base_plan.md
@@ -4,7 +4,11 @@
 
 OpenScale should build reproducible custom firmware from an unchanged firmware revision, compile-time features, and approved plugin packages. Plugins may contain version-specific patch files and LittleFS assets, but they are applied only in a temporary build checkout. The normal firmware source tree contains no activated plugin code.
 
-The existing configurator will later become the shared interface for existing downloads and new build requests. Unknown plugin sources, uploaded ZIP files, and arbitrary patch URLs remain excluded.
+The existing configurator is the shared interface for existing downloads and new build requests. Unknown plugin sources, uploaded ZIP files, and arbitrary patch URLs remain excluded.
+
+## Status
+
+Phases 1 through 4 were implemented, deployed, and production-validated on 2026-08-11. The remaining GitHub App repository-scope restriction is tracked as least-privilege hardening rather than a new implementation phase.
 
 ## Current State
 
@@ -14,12 +18,13 @@ The existing configurator will later become the shared interface for existing do
 - Pull OTA requires WiFi, but neither the web server nor the runtime `littlefs` feature.
 - The existing Pull OTA flow still installs the mandatory `firmware.bin` and `littlefs.bin` assets to separate partitions.
 - `hello-web` is an approved asset plugin without a firmware patch.
-- The configurator now uses the local Phase 4 status/build API contract. Production deployment remains pending.
+- The GitHub Pages configurator uses the deployed Phase 4 status/build API at `openscale-custom-builds.odevstudio.workers.dev`.
 - The custom workflow resolves an allowed firmware ref to an exact commit and applies approved patches only in a temporary checkout.
 - Custom artifacts use a canonical combination hash and a complete local cache entry. Actions artifacts remain time-limited.
 - The only user-facing custom-build download is one ZIP containing the four flashable BIN images. Its manifest and dependency inventory remain service metadata.
 - The private R2 Standard cache and read gateway are provisioned at `openscale-custom-builds.odevstudio.workers.dev`, with 180-day artifact retention. The Worker and GitHub Actions share an encrypted upload token.
 - The build service resolves `main` to an exact commit and derives the combination hash from the trusted service catalog at that commit.
+- A production BLE/USB-only request completed from cache miss through public download, and its ZIP contained exactly the four required flash images.
 
 ## Invariants
 

--- a/docs/custom-build/plan_3_phase.md
+++ b/docs/custom-build/plan_3_phase.md
@@ -33,12 +33,12 @@ A successful combination stores these objects under its hash:
 
 ## Implementation
 
-1. Generate the canonical input and combination hash in the existing Python tool. Implemented locally.
-2. Calculate the hash before building and use it in the workflow, artifact name, and build manifest. Implemented locally.
-3. Before compilation, check whether a complete successful entry already exists. Implemented for complete local entries.
-4. On a hit, return the existing download metadata without rebuilding. Implemented against the trusted Worker manifest endpoint.
-5. Publish successful files atomically under the hash. Implemented locally.
-6. Never mark failed or incomplete uploads as cache hits. Implemented locally.
+1. Generate the canonical input and combination hash in the existing Python tool.
+2. Calculate the hash before building and use it in the workflow, artifact name, and build manifest.
+3. Before compilation, check whether a complete successful entry already exists.
+4. On a hit, return the existing download metadata without rebuilding.
+5. Publish successful files atomically under the hash.
+6. Never mark failed or incomplete uploads as cache hits.
 7. Expire every `v1/` cache entry after 180 days. A later request rebuilds it under the same hash.
 
 ## Storage Decision

--- a/docs/custom-build/plan_4_phase.md
+++ b/docs/custom-build/plan_4_phase.md
@@ -10,13 +10,15 @@ The Cloudflare Workers Free plan currently includes 100,000 requests per day wit
 
 ## Hosting
 
-The configurator is `docs/custom-build/index.html`. After this branch is merged, enable GitHub Pages with `main` and `/docs` as the source. It will then be available at `https://decentespresso.github.io/openscale/custom-build/`. No custom DNS domain is required.
+The configurator is `docs/custom-build/index.html`. GitHub Pages serves `main` and `/docs` at `https://decentespresso.github.io/openscale/custom-build/`. No custom DNS domain is required.
 
 The Cloudflare Worker uses `openscale-custom-builds.odevstudio.workers.dev` for the API and artifact downloads. The R2 bucket remains private and has no `r2.dev` endpoint.
 
 ## Implementation Status
 
-The repository contains the Phase 4 API, Durable Object coordinator, trusted service catalog, exact source-commit workflow inputs, authenticated build status callbacks, and configurator integration. The local contract tests pass. The GitHub App is installed and the Worker secrets are provisioned. Before production deployment, an organization owner must restrict the installation to `decentespresso/openscale`, and the trusted service catalog must be present on `main` so public requests can resolve it.
+The Phase 4 API, Durable Object coordinator, trusted service catalog, exact source-commit workflow inputs, authenticated build status callbacks, and configurator integration are deployed. GitHub Pages and the Worker are live, and a production BLE/USB-only request completed successfully. The temporary local GitHub App private-key file was deleted after that test.
+
+The GitHub App installation currently covers the organization because the installer is not the organization owner. Restricting it to `decentespresso/openscale` remains the target least-privilege configuration. The Worker still fixes dispatches to `decentespresso/openscale`; the wider installation is documented security hardening, not a functional deployment blocker.
 
 The initial server limits are three new builds per client per day, twenty new builds globally per day, and two attempts per combination. Duplicate requests do not consume another build slot. Client rate-limit hashes expire after 24 hours, while GitHub controls runner concurrency.
 
@@ -24,7 +26,7 @@ Each attempt has a two-hour lease and a UUID fencing token. The Durable Object a
 
 ## Required Secrets
 
-The Worker requires `RATE_LIMIT_SALT`, `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY_PKCS8`. The private key value is the GitHub App key converted to unencrypted PKCS#8 DER and base64 encoded. The GitHub App receives Actions write access and must be installed only on `decentespresso/openscale`. Existing `UPLOAD_TOKEN` continues to authenticate artifact uploads and workflow status callbacks.
+The Worker requires `RATE_LIMIT_SALT`, `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY_PKCS8`. The private key value is the GitHub App key converted to unencrypted PKCS#8 DER and base64 encoded. The GitHub App receives Actions write access and should be restricted to `decentespresso/openscale`. Existing `UPLOAD_TOKEN` continues to authenticate artifact uploads and workflow status callbacks.
 
 ## Components
 
@@ -66,9 +68,7 @@ Cloudflare Worker
 
 ## Compile Coverage Gate
 
-The current CI proves the standard firmware, grinder environment, one custom configuration, dependency resolution, patch application, hashing, and cache contracts. It does not yet prove every valid feature set. This is a test-coverage gap, not evidence that the remaining combinations fail to compile.
-
-Before the public service is deployed, CI must compile a representative matrix covering: no optional features; WiFi only; WiFi with the web server and no runtime LittleFS; WebSocket; ElegantOTA; Pull OTA without the web server; Grinder; and a plugin with assets. The full set of 62 valid core combinations is not required unless the representative matrix exposes interaction failures.
+CI proves the standard firmware, grinder environment, dependency resolution, patch application, hashing, cache contracts, and the representative custom matrix: no optional features; WiFi only; WiFi with the web server and no runtime LittleFS; WebSocket; ElegantOTA; Pull OTA without the web server; Grinder; and a plugin with assets. The full set of 62 valid core combinations remains unnecessary unless this matrix exposes an interaction failure.
 
 ## Operations and Security
 
@@ -82,6 +82,16 @@ Before the public service is deployed, CI must compile a representative matrix c
 ## Pull OTA Behavior
 
 Selecting `pull-ota` includes the existing OLED/button client. It remains pointed at the official signed release channel. An official update replaces the custom build and its plugin selection. The public build service signs no custom OTA manifests.
+
+## Production Validation
+
+Production validation completed on 2026-08-11:
+
+- GitHub Pages and the Worker returned successful responses from the allowed origin, while an unrelated origin was rejected.
+- Unknown features and disallowed firmware refs were rejected before dispatch.
+- A missing BLE/USB-only combination progressed through GitHub Actions to `ready`.
+- Its public ZIP contained exactly `firmware.bin`, `bootloader.bin`, `partitions.bin`, and `littlefs.bin`, with no factory image or separate public BIN downloads.
+- The completed entry remained publicly readable through the status and download endpoints.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- mark the four custom-build phases as deployed and production-validated
- replace stale local and pre-deployment status text with the live GitHub Pages, Worker, R2, and compile-matrix state
- record the successful BLE/USB build and the remaining GitHub App repository-scope hardening

## Verification
- production Pages, CORS, validation, status, and artifact HEAD checks
- python tools/test_ai_docs_contract.py
- git diff --check