### PR TITLE
fix(protocol): checksum LED response packets

### DIFF
--- a/include/decent_protocol.h
+++ b/include/decent_protocol.h
@@ -248,8 +248,6 @@ static inline void buildLedResponsePacket(byte data[7]) {
   }
 
   byte verHigh = (byte)(((major / 10) << 4) | (major % 10));
-  byte verLow = (byte)((minor << 4) | patch);
-
   float weight = f_displayedValue;
   byte weightByte1, weightByte2;
   encodeWeight(weight, weightByte1, weightByte2);
@@ -278,7 +276,7 @@ static inline void buildLedResponsePacket(byte data[7]) {
   data[3] = weightByte2;
   data[4] = batteryByte;
   data[5] = verHigh;
-  data[6] = verLow;
+  data[6] = decentXor(data, 6);
 }
 
 static inline void handleDecentHeartbeatFlag(uint8_t flag) {

--- a/include/decent_protocol.h
+++ b/include/decent_protocol.h
@@ -131,11 +131,7 @@ static inline bool decentRequireLength(const char *transport, size_t actual, siz
 }
 
 static inline uint8_t decentXor(const uint8_t *data, size_t len) {
-  uint8_t xorValue = 0x03;
-  for (size_t i = 1; i < len - 1; i++) {
-    xorValue ^= data[i];
-  }
-  return xorValue;
+  return decentPayloadChecksum(data, len);
 }
 
 static inline void encodeWeight(float weight, byte &byte1, byte &byte2) {

--- a/tools/test_decent_protocol_contract.py
+++ b/tools/test_decent_protocol_contract.py
@@ -24,7 +24,10 @@ def function_body(text, name):
 
 def main():
     protocol = PROTOCOL_HEADER.read_text(encoding="utf-8")
+    xor_helper = function_body(protocol, "decentXor")
     led_response = function_body(protocol, "buildLedResponsePacket")
+    if "return decentPayloadChecksum(data, len);" not in xor_helper:
+        raise AssertionError("response checksum does not cover every payload byte")
     firmware_index = led_response.index("data[5] = verHigh;")
     checksum_index = led_response.index("data[6] = decentXor(data, 6);")
     if checksum_index < firmware_index:

--- a/tools/test_decent_protocol_contract.py
+++ b/tools/test_decent_protocol_contract.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL_HEADER = ROOT / "include" / "decent_protocol.h"
+
+
+def function_body(text, name):
+    match = re.search(rf"\b\w+\s+{re.escape(name)}\([^;{{}}]*\)\s*{{", text)
+    if match is None:
+        raise AssertionError(f"missing function: {name}")
+    opening = text.index("{", match.start())
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated function: {name}")
+
+
+def main():
+    protocol = PROTOCOL_HEADER.read_text(encoding="utf-8")
+    led_response = function_body(protocol, "buildLedResponsePacket")
+    firmware_index = led_response.index("data[5] = verHigh;")
+    checksum_index = led_response.index("data[6] = decentXor(data, 6);")
+    if checksum_index < firmware_index:
+        raise AssertionError("LED response checksum precedes firmware byte")
+    if "verLow" in led_response:
+        raise AssertionError("LED response byte 6 is not reserved for the checksum")
+    print("Decent protocol contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Fix the shared `03 0A` LED response so byte 6 contains the XOR checksum required by Decent clients.
- Keep the firmware-major byte in byte 5 and leave weight and battery encoding unchanged.
- Make the shared response checksum helper cover every payload byte.
- Add a focused source contract covering checksum placement and payload coverage for both BLE and USB users of the shared builder.

# Root Cause

`buildLedResponsePacket()` retained an obsolete low-version byte in byte 6 when the packet builder was centralized. Its shared checksum helper also treated the supplied payload length as a complete frame length and omitted byte 5. Every seven-byte response and the current Decent client contract use byte 6 for the XOR of bytes 0 through 5. There was no focused regression check for this response builder.

# Scope

The change is limited to `include/decent_protocol.h` and `tools/test_decent_protocol_contract.py`. It affects the shared LED/status response emitted over BLE and USB. Command dispatch, weight encoding, battery calculation, other response packets, grinder/custom environments, and web protocols are unchanged.

# Safety / Reliability Impact

This restores protocol validation for normal BLE and USB clients. It does not alter hardware, power, task ownership, persistent state, OTA behavior, heap usage, or WiFi coexistence.

# Compatibility

The packet now matches the documented Decent framing contract: bytes 0 through 5 are payload and byte 6 is their XOR checksum. BLE and USB continue to emit identical payloads through the same builder. No breaking behavior is intended. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_decent_protocol_contract.py` extracts `decentXor()` and `buildLedResponsePacket()`. It requires the shared helper to checksum the complete supplied payload, requires the firmware byte to precede `data[6] = decentXor(data, 6)`, and rejects reintroduction of `verLow` into the response.

# Verification

- `python tools/test_decent_protocol_contract.py` - passed: `Decent protocol contract tests passed`.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed after the complete two-commit fix.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical ESP32-S3, BLE peer, or USB client was exercised.

# Evidence

Before the fix, byte 6 was assigned the parsed minor/patch nibble and the checksum helper omitted the nonzero firmware-major byte at byte 5. The rebased standard build passed. The only compiler diagnostics were the two pre-existing volatile-increment warnings in `src/wifi_setup.cpp`.

# Documentation Impact

`docs/AI_PROTOCOL_NOTES.md` was reviewed and already states the correct `03 0A` byte layout and checksum rule, so no duplicate documentation was added.

# Risks and Mitigations

Physical transport behavior was not tested. The focused contract and standard firmware build cover the shared packet implementation and compile integration.

# Related Work

No matching existing GitHub issue or pull request was found during read-only inspection.
