### PR TITLE
fix(ble): preserve soft sleep on disconnect

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -62,6 +62,12 @@ bool clearBleFff4Connection(uint16_t connectionHandle) {
   return isCurrent;
 }
 
+void restoreDisplayAfterBleDisconnect() {
+  if (b_softSleep) return;
+  b_u8g2Sleep = false;
+  remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
+}
+
 
 class MyServerCallbacks : public BLEServerCallbacks {
 #if defined(CONFIG_NIMBLE_ENABLED)
@@ -90,8 +96,7 @@ class MyServerCallbacks : public BLEServerCallbacks {
 #ifdef BUZZER
     b_beep = storageGetInt(KEY_BEEP, 1);
 #endif
-    b_u8g2Sleep = false;
-    remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
+    restoreDisplayAfterBleDisconnect();
     Serial.print("Device disconnected (connId: ");
     Serial.print(desc->conn_handle);
     Serial.println("), restarting advertising...");
@@ -121,8 +126,7 @@ class MyServerCallbacks : public BLEServerCallbacks {
 #ifdef BUZZER
     b_beep = storageGetInt(KEY_BEEP, 1);
 #endif
-    b_u8g2Sleep = false;
-    remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
+    restoreDisplayAfterBleDisconnect();
     Serial.println("Device disconnected, restarting advertising...");
     delay(100);
     pAdvertising->start();

--- a/tools/test_soft_sleep_ads_wake.py
+++ b/tools/test_soft_sleep_ads_wake.py
@@ -93,6 +93,18 @@ def main():
         ],
     )
 
+    ble_disconnect_display = method_body(BLE_HEADER, "restoreDisplayAfterBleDisconnect")
+    assert_ordered(
+        ble_disconnect_display,
+        [
+            "if (b_softSleep) return;",
+            "b_u8g2Sleep = false;",
+            "remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
+        ],
+    )
+    if read(BLE_HEADER).count("restoreDisplayAfterBleDisconnect();") != 2:
+        raise AssertionError("all BLE disconnect callbacks must preserve soft sleep")
+
     ws_handler = read(WEBSOCKET_HEADER)
     assert_ordered(
         ws_handler,


### PR DESCRIPTION
# Summary

- Preserve the soft-sleep display state when a normal BLE client disconnects.
- Continue restoring the OLED after disconnects when the scale is awake.
- Cover both BLE callback variants with the existing soft-sleep contract.

# Root Cause

Both `MyServerCallbacks::onDisconnect()` variants unconditionally cleared `b_u8g2Sleep` and queued `WSP_DISPLAY_ON`. That disconnect policy ignored `b_softSleep`, even though soft sleep has already queued or applied shutdown of the OLED and accessory power rails.

# Scope

The change is limited to `include/ble.h` and `tools/test_soft_sleep_ads_wake.py`. It centralizes the existing disconnect display restoration behind a soft-sleep guard. BLE connection tracking, advertising, buzzer restoration, explicit display commands, wake behavior, grinder/custom environments, and unrelated power flows are unchanged.

# Safety / Reliability Impact

The main loop no longer receives an OLED power-on command after a BLE disconnect while soft sleep is active. This keeps display state aligned with the switched power rails and preserves the existing rule that BLE callbacks queue hardware work rather than touching the OLED directly.

# Compatibility

Awake disconnect behavior is unchanged: the display is restored and advertising restarts. A client that explicitly wakes the scale still uses the existing soft-wake path. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_soft_sleep_ads_wake.py` now verifies that `restoreDisplayAfterBleDisconnect()` checks `b_softSleep` before changing display state and that both compile-time disconnect callbacks use the helper. Before the fix the helper and guard are absent; after the fix the contract passes.

# Verification

- `python tools/test_soft_sleep_ads_wake.py` - passed: `soft sleep ADS wake tests passed`.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed after rebasing onto current `origin/main`.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical OLED, power rail, ESP32-S3, or BLE peer was exercised.

# Evidence

Before the fix, both disconnect callbacks assigned `b_u8g2Sleep = false` and queued `WSP_DISPLAY_ON` without considering `b_softSleep`. The rebased standard build passed. The only compiler diagnostics were the two pre-existing volatile-increment warnings in `src/wifi_setup.cpp`.

# Documentation Impact

`docs/AI_PROTOCOL_NOTES.md`, `docs/AI_GPIO_NOTES.md`, and `docs/AI_FIRMWARE_NOTES.md` were reviewed. Their existing ownership and soft-wake rules remain accurate, so no duplicate documentation was added.

# Risks and Mitigations

Physical power sequencing was not tested. The change only suppresses a display-on request while the existing soft-sleep flag is active, and the focused contract covers both disconnect callback variants.

# Related Work

No matching existing GitHub issue or pull request was found during read-only searches.
