### PR TITLE
fix(ota): retain LittleFS recovery through validation

### DIFF
--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -71,7 +71,7 @@ The single LittleFS partition has no independent rollback slot. Do not weaken si
 
 `include/ota_rollback.h` overrides Arduino's weak `verifyRollbackLater()` so `ESP_OTA_IMG_PENDING_VERIFY` images are not auto-marked valid during `initArduino()`.
 
-`setup()` calls `hdsOtaRollbackBegin()` after reset-reason capture. Without pending filesystem work it calls `hdsOtaRollbackMarkValid()` after setup validation. With pending work, validity is deferred until target recovery succeeds and pending state is cleared.
+`setup()` calls `hdsOtaRollbackBegin()` after reset-reason capture. Without pending filesystem work it calls `hdsOtaRollbackMarkValid()` after setup validation. With pending work, validity is deferred until target recovery succeeds; recovery metadata is cleared only after application validity marking succeeds.
 
 ## Reboot Routing
 

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -55,8 +55,8 @@ Flow:
 
 1. Current firmware stores both manifests, writes `firmware.bin` to the inactive app slot, and reboots.
 2. The new firmware calls `hdsOtaRollbackBegin()`, detects pending LittleFS work, and runs `pullOtaResumePendingLittleFs()` before application validity marking.
-3. The target filesystem gets at most two attempts. Each attempt is recorded before network or write work; `fs_dirty` is recorded before `Update.begin()` can modify the partition.
-4. A successful target write passes size/schema, raw SHA-256, and mount checks. Pending state is then cleared, the new application is marked valid, and the device reboots.
+3. Recovery first accepts an already-written filesystem that passes size/schema, raw SHA-256, and mount checks. Otherwise, the target filesystem gets at most two attempts. Each attempt is recorded before network or write work; `fs_dirty` is recorded before `Update.begin()` can modify the partition.
+4. A successful target write passes the same checks. The new application is then marked valid before pending state is cleared, and the device reboots.
 5. If both attempts fail before filesystem writing begins, `setup()` calls `hdsOtaRollback("LittleFS update")`; the previous application remains paired with its unchanged filesystem.
 6. If writing may have begun, recovery first replaces pending state with the previous application's matching signed filesystem asset, then rolls the application back. The previous application gets one recorded restore attempt.
 7. A failed restore stops at `UPDATE ERROR`. A successful restore clears pending state and reboots.

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -1344,7 +1344,7 @@ bool pullOtaResumePendingLittleFs() {
   uint8_t attempts = pending.restore ? 0 : pending.targetAttempts;
   bool filesystemWriteStarted = pending.filesystemDirty;
   bool updated = pullOtaVerifyPendingLittleFs(pending);
-  while (attempts < maxAttempts) {
+  while (!updated && attempts < maxAttempts) {
     attempts++;
     bool attemptRecorded = pending.restore
         ? !pending.restoreAttempted && pullOtaBeginRollbackLittleFsAttempt()

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -1343,7 +1343,7 @@ bool pullOtaResumePendingLittleFs() {
   uint8_t maxAttempts = pending.restore ? 1 : 2;
   uint8_t attempts = pending.restore ? 0 : pending.targetAttempts;
   bool filesystemWriteStarted = pending.filesystemDirty;
-  bool updated = false;
+  bool updated = pullOtaVerifyPendingLittleFs(pending);
   while (attempts < maxAttempts) {
     attempts++;
     bool attemptRecorded = pending.restore
@@ -1369,11 +1369,11 @@ bool pullOtaResumePendingLittleFs() {
     }
     return false;
   }
+  hdsOtaRollbackMarkValid();
   if (!pullOtaClearPendingLittleFs()) {
     pullOtaFail("FS state failed");
     pullOtaRecoveryError();
   }
-  hdsOtaRollbackMarkValid();
   pullOtaDraw("Update done", "Restarting");
   delay(1500);
   remoteQueueResetAt(millis());

--- a/tools/test_ai_docs_contract.py
+++ b/tools/test_ai_docs_contract.py
@@ -66,10 +66,10 @@ def main():
     resume_start = find_call(pull_ota, "pullOtaResumePendingLittleFs")
     resume_end = find_call(pull_ota, "pullOtaRunUpdate", resume_start)
     resume_body = pull_ota[resume_start:resume_end]
-    if find_call(resume_body, "pullOtaClearPendingLittleFs") >= find_call(
-        resume_body, "hdsOtaRollbackMarkValid"
+    if find_call(resume_body, "hdsOtaRollbackMarkValid") >= find_call(
+        resume_body, "pullOtaClearPendingLittleFs"
     ):
-        raise AssertionError("successful LittleFS recovery must clear pending state before validity marking")
+        raise AssertionError("successful LittleFS recovery must mark the app valid before clearing recovery state")
     if not re.search(
         r"maxAttempts\s*=\s*pending\.restore\s*\?\s*1\s*:\s*2",
         resume_body,

--- a/tools/test_ota_rollback_contract.py
+++ b/tools/test_ota_rollback_contract.py
@@ -42,7 +42,8 @@ def main():
     resume_start = pull_ota.index("bool pullOtaResumePendingLittleFs()")
     resume_end = pull_ota.index("void pullOtaRunUpdate()", resume_start)
     resume = pull_ota[resume_start:resume_end]
-    if resume.index("bool updated = pullOtaVerifyPendingLittleFs(pending);") >= resume.index("while (attempts < maxAttempts)"):
+    recovery_loop = "while (!updated && attempts < maxAttempts)"
+    if resume.index("bool updated = pullOtaVerifyPendingLittleFs(pending);") >= resume.index(recovery_loop):
         raise AssertionError("pending LittleFS must be verified before consuming another attempt")
     print("OTA rollback contract tests passed")
 

--- a/tools/test_ota_rollback_contract.py
+++ b/tools/test_ota_rollback_contract.py
@@ -38,6 +38,12 @@ def main():
     assert_contains(ROLLBACK_HEADER, 'preferences.putUInt("attempts"')
     assert_contains(ROLLBACK_HEADER, "LittleFS.begin()")
     assert_contains(ROLLBACK_HEADER, "LittleFS.totalBytes()")
+    pull_ota = PULL_OTA_HEADER.read_text(encoding="utf-8")
+    resume_start = pull_ota.index("bool pullOtaResumePendingLittleFs()")
+    resume_end = pull_ota.index("void pullOtaRunUpdate()", resume_start)
+    resume = pull_ota[resume_start:resume_end]
+    if resume.index("bool updated = pullOtaVerifyPendingLittleFs(pending);") >= resume.index("while (attempts < maxAttempts)"):
+        raise AssertionError("pending LittleFS must be verified before consuming another attempt")
     print("OTA rollback contract tests passed")
 
 


### PR DESCRIPTION
# Summary

- Keep staged LittleFS recovery metadata until the new application has been marked valid.
- Recognize an already-written matching filesystem and skip the rewrite loop.
- Align the OTA and AI-documentation contracts with the crash-resumable finalization order.

# Root Cause

`pullOtaResumePendingLittleFs()` cleared the `ota_fs` recovery namespace before calling `hdsOtaRollbackMarkValid()`. If local checks or app-valid marking then rolled the application back, the previous application inherited the target filesystem without the signed rollback metadata needed to restore its matching filesystem. Simply reversing the calls would leave a power-loss window after validity marking, so resume also needs to accept a filesystem that already matches the pending signed asset. The first implementation captured that verification result but did not gate the retry loop with it, allowing a redundant failed rewrite to corrupt a filesystem that had already passed validation.

# Scope

The change is limited to staged LittleFS finalization in `include/pull_ota.h`, its focused contracts, and `docs/AI_OTA_NOTES.md`. Manifest signing, URL allowlisting, download/write mechanics, retry limits, rollback assets, firmware slot selection, web assets, grinder/custom environments, and non-pull OTA paths are unchanged.

# Safety / Reliability Impact

Rollback metadata remains available for every failure that can still return to the previous app. After the app is valid, a reboot before metadata clearing can safely resume by verifying the existing filesystem without rewriting it or consuming another attempt. No new persistent keys, tasks, or heap allocations are introduced.

# Compatibility

The signed asset format, NVS schema, attempt limits, and update UI remain unchanged. Existing pending transactions gain a verify-before-retry path. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_ota_rollback_contract.py` requires verification before the attempt loop and requires the loop to stop when verification succeeds. `tools/test_ai_docs_contract.py` requires application validity marking before recovery-state clearing. `tools/test_pull_ota_contract.py` continues to cover the surrounding staged update contract. Before the fix the loop ignored the successful verification flag; after the fix all three pass.

# Verification

- `python tools/test_ota_rollback_contract.py` - passed.
- `python tools/test_pull_ota_contract.py` - passed.
- `python tools/test_ai_docs_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed after rebasing onto current `origin/main`.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical update, forced validation failure, NVS fault, network interruption, or power-loss injection was exercised.

# Evidence

Before the fix, successful filesystem verification was followed by `pullOtaClearPendingLittleFs()` and only then `hdsOtaRollbackMarkValid()`. The candidate reverses that finalization order, uses the existing signed size/schema, raw SHA-256, and mount verifier, and does not enter the rewrite loop after that verifier succeeds. The rebased standard build passed.

# Documentation Impact

`docs/AI_OTA_NOTES.md` now records verify-before-retry recovery and validity-before-clear finalization. The existing documentation contract was updated to enforce the corrected invariant.

# Risks and Mitigations

Power-loss behavior is covered structurally but not on hardware. The resume path reuses the existing complete filesystem verifier and adds no new durable state, limiting the change to ordering and idempotence.

# Related Work

No matching existing GitHub issue or pull request was found during read-only searches.
