### PR TITLE
fix(ble): throttle heartbeat disconnect retries

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -11,6 +11,7 @@ enum BleState {
 };
 volatile BleState bleState = DISCONNECTED;
 const unsigned long HEARTBEAT_TIMEOUT = 5000;
+const unsigned long HEARTBEAT_DISCONNECT_RETRY_INTERVAL = 10000;
 const unsigned long BLE_STATUS_RESPONSE_TIMEOUT = 2000;
 unsigned long t_lastDisconnectAttempt = 0;
 unsigned long t_lastDisconnectAttemptNotice = 0;
@@ -350,15 +351,16 @@ void ble_init() {
 
 void disconnectBLE() {
   if (!bleHasLiveClient() || pServer == nullptr || connId == 0xFFFF) return;
-  Serial.println("***No heartbeat for 5 seconds. Disconnecting BLE...***");
-  if (millis() - t_lastDisconnectAttempt < 5000) {
-    if (millis() - t_lastDisconnectAttemptNotice > 1000){
+  const unsigned long now = millis();
+  if (now - t_lastDisconnectAttempt < HEARTBEAT_TIMEOUT) {
+    if (now - t_lastDisconnectAttemptNotice > 1000){
       Serial.println("Disconnect attempt too frequent, skipping...");
-      t_lastDisconnectAttemptNotice = millis();
+      t_lastDisconnectAttemptNotice = now;
     }
     return;
   }
-  t_lastDisconnectAttempt = millis();
+  Serial.println("***No heartbeat for 5 seconds. Disconnecting BLE...***");
+  t_lastDisconnectAttempt = now;
   pServer->disconnect(connId, 0x13);
 }
 

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1455,7 +1455,7 @@ void loop() {
   if (bleHasLiveClient() && b_requireHeartBeat && millis() - t_firstConnect > HEARTBEAT_TIMEOUT) {
     if (millis() - t_heartBeat > HEARTBEAT_TIMEOUT) {
       disconnectBLE();
-      t_heartBeat = millis() + 10000;
+      t_heartBeat = millis();
     }
   }
 #ifdef HEARTBEATICON

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1452,11 +1452,14 @@ void loop() {
     return;
   }
 
-  if (bleHasLiveClient() && b_requireHeartBeat && millis() - t_firstConnect > HEARTBEAT_TIMEOUT) {
-    if (millis() - t_heartBeat > HEARTBEAT_TIMEOUT) {
-      disconnectBLE();
-      t_heartBeat = millis();
-    }
+  const unsigned long now = millis();
+  if (bleHasLiveClient()
+      && b_requireHeartBeat
+      && now - t_firstConnect > HEARTBEAT_TIMEOUT
+      && now - t_heartBeat > HEARTBEAT_TIMEOUT
+      && (t_lastDisconnectAttempt == 0
+          || now - t_lastDisconnectAttempt >= HEARTBEAT_DISCONNECT_RETRY_INTERVAL)) {
+    disconnectBLE();
   }
 #ifdef HEARTBEATICON
   if (millis() - t_heartBeat < 500)

--- a/tools/test_ble_subscription_contract.py
+++ b/tools/test_ble_subscription_contract.py
@@ -130,12 +130,27 @@ def main():
         raise AssertionError("BLE disconnect runs while holding the FFF4 mailbox lock")
     loop = function_body(hds, "loop")
     assert_contains(loop, "processBleStatusResponse();")
-    assert_contains(loop, "if (bleHasLiveClient() && b_requireHeartBeat", "t_heartBeat = millis();")
-    if "t_heartBeat = millis() +" in loop:
-        raise AssertionError("heartbeat timeout stores a future elapsed-time origin")
+    assert_contains(
+        loop,
+        "now - t_heartBeat > HEARTBEAT_TIMEOUT",
+        "t_lastDisconnectAttempt == 0",
+        "now - t_lastDisconnectAttempt >= HEARTBEAT_DISCONNECT_RETRY_INTERVAL",
+        "disconnectBLE();",
+    )
+    if "t_heartBeat =" in loop:
+        raise AssertionError("heartbeat timeout mutates heartbeat activity state")
+    assert_contains(ble, "const unsigned long HEARTBEAT_DISCONNECT_RETRY_INTERVAL = 10000;")
 
     heartbeat_disconnect = function_body(ble, "disconnectBLE")
-    assert_contains(heartbeat_disconnect, "if (!bleHasLiveClient()")
+    assert_contains(
+        heartbeat_disconnect,
+        "if (!bleHasLiveClient()",
+        "now - t_lastDisconnectAttempt < HEARTBEAT_TIMEOUT",
+        "t_lastDisconnectAttempt = now;",
+    )
+    heartbeat_log = heartbeat_disconnect.index("***No heartbeat for 5 seconds. Disconnecting BLE...***")
+    if heartbeat_disconnect[:heartbeat_log].count("return;") < 2:
+        raise AssertionError("heartbeat disconnect log runs before retry throttling")
 
     for name in ("buttonCircle_DoubleClicked", "buttonSquare_DoubleClicked"):
         body = function_body(hds, name)

--- a/tools/test_ble_subscription_contract.py
+++ b/tools/test_ble_subscription_contract.py
@@ -128,8 +128,11 @@ def main():
         raise AssertionError("status notify runs while holding the FFF4 mailbox lock")
     if pending.rindex("portEXIT_CRITICAL(&bleFff4Mux)") > pending.index("pServer->disconnect(currentConnId, 0x13);"):
         raise AssertionError("BLE disconnect runs while holding the FFF4 mailbox lock")
-    assert_contains(function_body(hds, "loop"), "processBleStatusResponse();")
-    assert_contains(function_body(hds, "loop"), "if (bleHasLiveClient() && b_requireHeartBeat")
+    loop = function_body(hds, "loop")
+    assert_contains(loop, "processBleStatusResponse();")
+    assert_contains(loop, "if (bleHasLiveClient() && b_requireHeartBeat", "t_heartBeat = millis();")
+    if "t_heartBeat = millis() +" in loop:
+        raise AssertionError("heartbeat timeout stores a future elapsed-time origin")
 
     heartbeat_disconnect = function_body(ble, "disconnectBLE")
     assert_contains(heartbeat_disconnect, "if (!bleHasLiveClient()")


### PR DESCRIPTION
# Summary

- Keep `t_heartBeat` as the timestamp of actual heartbeat activity.
- Use `t_lastDisconnectAttempt` for a wrap-safe 10-second disconnect retry cooldown.
- Log the heartbeat disconnect only after the existing internal rate-limit check passes.

# Root Cause

The main loop assigned `t_heartBeat = millis() + 10000` after requesting a disconnect, then treated that future value as a past origin in `millis() - t_heartBeat`. Unsigned subtraction wrapped immediately and called `disconnectBLE()` on nearly every loop iteration until the asynchronous disconnect callback cleared the connection. The actual BLE disconnect was already throttled internally, but the log occurred before that throttle.

# Implementation

The first missing-heartbeat disconnect remains eligible after the five-second heartbeat timeout. If the connection remains live, later attempts require 10 seconds since `t_lastDisconnectAttempt`. The timeout path never writes `t_heartBeat`, so disconnect retries cannot appear as heartbeat activity or trigger `HEARTBEATICON`.

`disconnectBLE()` records one `millis()` sample, applies its internal elapsed-time guard, then logs and records the actual attempt immediately before calling `pServer->disconnect()`.

# Scope

The change is limited to heartbeat disconnect timing in `include/ble.h` and `src/hds.ino`, plus focused coverage in `tools/test_ble_subscription_contract.py`. Heartbeat parsing, connection tracking, disconnect reason, advertising, and protocol behavior are unchanged.

# Regression Coverage

`tools/test_ble_subscription_contract.py` rejects heartbeat-state mutation in `loop()`, requires the wrap-safe `t_lastDisconnectAttempt` retry condition and explicit 10-second interval, and verifies that the disconnect log follows retry throttling.

# Verification

- `python tools/test_ble_subscription_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.
- GitHub checks - passed, including native tests and `firmware (esp32s3)`.

# Hardware Verification

Not run. No physical BLE timeout or delayed disconnect callback was exercised.

# Risks and Mitigations

The asynchronous disconnect delay was not measured on hardware. The change reuses the existing disconnect-attempt timestamp and adds no mutable state, task, lock, or allocation.
