### PR TITLE
fix(usb): restore text tare and timer actions

### DIFF
--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -165,6 +165,7 @@ public:
   void (*setTrackingUpdateInterval)(float);
   void (*buttonSquare_Pressed)();
   void (*buttonCircle_Pressed)();
+  void (*toggleTimer)();
 
   static const size_t USB_RX_BUFFER_SIZE = 160;
   static const unsigned long USB_RX_FRAME_TIMEOUT_MS = 30;
@@ -421,14 +422,18 @@ public:
     }
 
     if (inputString.startsWith("tare")) {
-      if (buttonCircle_Pressed != NULL) {
+      if ((b_menu || b_calibration || b_showChargingUI) && buttonCircle_Pressed != NULL) {
         buttonCircle_Pressed();
+      } else {
+        requestRemoteTare();
       }
     }
 
     if (inputString.startsWith("set")) {
-      if (buttonSquare_Pressed != NULL) {
+      if ((b_menu || b_calibration || b_showChargingUI) && buttonSquare_Pressed != NULL) {
         buttonSquare_Pressed();
+      } else if (toggleTimer != NULL) {
+        toggleTimer();
       }
     }
 

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -449,6 +449,7 @@ void setup() {
   usbCallbacks.setTrackingUpdateInterval = setTrackingUpdateInterval;
   usbCallbacks.buttonSquare_Pressed = buttonSquare_Pressed;
   usbCallbacks.buttonCircle_Pressed = buttonCircle_Pressed;
+  usbCallbacks.toggleTimer = scaleTimer;
 #ifdef ESP32
   releaseWakePinsFromRtcMode();
 #endif

--- a/tools/test_usb_text_actions_contract.py
+++ b/tools/test_usb_text_actions_contract.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+USB_HEADER = ROOT / "include" / "usbcomm.h"
+HDS_SOURCE = ROOT / "src" / "hds.ino"
+
+
+def block_after(text, marker):
+    start = text.index(marker)
+    opening = text.index("{", start)
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated block: {marker}")
+
+
+def main():
+    usb = USB_HEADER.read_text(encoding="utf-8")
+    hds = HDS_SOURCE.read_text(encoding="utf-8")
+
+    tare = block_after(usb, 'if (inputString.startsWith("tare"))')
+    if "requestRemoteTare();" not in tare:
+        raise AssertionError("USB text tare does not request a remote tare")
+    if "b_menu || b_calibration || b_showChargingUI" not in tare:
+        raise AssertionError("USB text tare lost non-weighing button behavior")
+
+    timer = block_after(usb, 'if (inputString.startsWith("set"))')
+    if "toggleTimer();" not in timer:
+        raise AssertionError("USB text set does not toggle the timer")
+    if "b_menu || b_calibration || b_showChargingUI" not in timer:
+        raise AssertionError("USB text set lost non-weighing button behavior")
+
+    if "usbCallbacks.toggleTimer = scaleTimer;" not in hds:
+        raise AssertionError("USB timer callback is not wired")
+
+    print("USB text action contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Route normal USB text `tare` through the existing remote-tare mailbox.
- Route normal USB text `set` to the timer toggle callback.
- Retain button-press behavior in menu, calibration, and charging UI contexts.

# Root Cause

The USB text dispatcher still called physical button-press handlers after those handlers were changed to start asynchronous finger sampling. A serial command has no matching physical weight pulse or release sequence, so sampling timed out and neither tare nor timer behavior occurred.

# Scope

The change updates the two USB text actions, wires one timer callback, and adds one focused source contract. Binary Decent commands, physical finger recognition, menu actions, calibration actions, charging wake behavior, and other USB text commands are unchanged.

# Safety / Reliability Impact

Explicit serial commands no longer depend on load-cell transients. Tare reuses the synchronized `requestRemoteTare()` path already shared by BLE binary and WebSocket commands, and timer control remains on the main loop task.

# Compatibility

The command names remain `tare` and `set`. In menu, calibration, and charging UI contexts they continue to invoke the existing button-press handlers. Native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_usb_text_actions_contract.py` requires normal text tare to call `requestRemoteTare()`, normal text set to call the wired timer callback, and both commands to preserve non-weighing button behavior. The old implementation fails the action assertions.

# Verification

- `python tools/test_usb_text_actions_contract.py` - passed: `USB text action contract tests passed`.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed after rebasing onto current `origin/main`.
- `git diff --cached --check` - passed.

# Hardware Verification

Not run. No physical ESP32-S3, USB serial client, scale, tare, timer, menu, calibration, or charging UI was exercised.

# Evidence

Both text commands previously entered `startPressSampling()`. Action recognition requires a release and post-release weight samples, while the press phase expires after two seconds without a physical release. The rebased standard build passed.

# Documentation Impact

`docs/AI_PROTOCOL_NOTES.md` was reviewed. It already requires remote tare paths to converge on `requestRemoteTare()`, so no duplicate documentation was added.

# Risks and Mitigations

USB command delivery and physical action effects were not exercised on hardware. The change reuses existing runtime functions rather than introducing a second tare or timer implementation.

# Related Work

No matching existing GitHub issue or pull request was found during read-only searches.
