### PR TITLE
fix(power): notify BLE before low-battery sleep

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -273,8 +273,8 @@ void shut_down_low_battery(float voltage) {
       b_power_off = 1;
       updateEspnow(1);
     }
-    sendBlePowerOff(3);
 #endif
+    sendBlePowerOff(3);
 #if HDS_FEATURE_WEBSOCKET
     sendWebsocketPowerOff(3);
 #endif

--- a/tools/test_low_battery_notification_contract.py
+++ b/tools/test_low_battery_notification_contract.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POWER_HEADER = ROOT / "include" / "power.h"
+
+
+def function_body(text, name):
+    start = text.index(f"void {name}(")
+    opening = text.index("{", start)
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated function: {name}")
+
+
+def main():
+    power = POWER_HEADER.read_text(encoding="utf-8")
+    shutdown = function_body(power, "shut_down_low_battery")
+    espnow_start = shutdown.index("#ifdef ESPNOW")
+    espnow_end = shutdown.index("#endif", espnow_start)
+    ble_notification = shutdown.index("sendBlePowerOff(3);")
+
+    if ble_notification < espnow_end:
+        raise AssertionError("BLE low-battery notification depends on ESPNOW")
+
+    print("low-battery notification contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Send the existing BLE low-battery power-off packet independently of ESP-NOW.
- Leave ESP-NOW and WebSocket notifications under their existing feature gates.
- Protect the preprocessor boundary with a focused contract.

# Root Cause

`sendBlePowerOff(3)` was nested inside `#ifdef ESPNOW`. The standard `esp32s3` build does not define ESP-NOW, so preprocessing removed the BLE notification even though BLE remained enabled and the firmware still entered low-battery deep sleep.

# Scope

The firmware change moves one existing call across one preprocessor boundary. Packet content, BLE subscription checks, low-battery thresholds, shutdown timing, ESP-NOW behavior, WebSocket behavior, and deep-sleep teardown are unchanged.

# Safety / Reliability Impact

A subscribed BLE client can receive the existing low-battery reason before the device sleeps. The shared BLE notification gate still makes the call a no-op when no eligible client is present.

# Compatibility

The packet format and reason code remain unchanged. This restores intended behavior for the standard `esp32s3` build without enabling ESP-NOW. Native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_low_battery_notification_contract.py` extracts `shut_down_low_battery()` and requires `sendBlePowerOff(3)` to appear after the ESP-NOW guard. The old source fails this assertion.

# Verification

- `python tools/test_low_battery_notification_contract.py` - passed: `low-battery notification contract tests passed`.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed after rebasing onto current `origin/main`.
- `git diff --cached --check` - passed.

# Hardware Verification

Not run. No physical ESP32-S3, low-battery transition, BLE subscription, notification delivery, or deep sleep was exercised.

# Evidence

`platformio.ini` does not add `ESPNOW` to the standard environment. Before the change, the preprocessor therefore removed the BLE call. The rebased standard build passed.

# Documentation Impact

`docs/AI_PROTOCOL_NOTES.md` and `docs/AI_GPIO_NOTES.md` were reviewed. No authoritative behavior text needed changing.

# Risks and Mitigations

Delivery before deep sleep was not measured on hardware. The code retains the existing one-second delay and the existing `bleCanNotifyCurrent()` eligibility guard.

# Related Work

No matching existing GitHub issue or pull request was found during read-only searches.
