### PR TITLE
fix(usb): construct text from its known length

### DIFF
--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -284,11 +284,7 @@ public:
     Serial.println(" ");
 
     if (data[0] != 0x03) {
-      String input;
-      input.reserve(len);
-      for (size_t i = 0; i < len; i++) {
-        input += (char)data[i];
-      }
+      String input((const char *)data, len);
       handleStringCommand(input);
       return;
     }

--- a/tools/test_usb_text_buffer_contract.py
+++ b/tools/test_usb_text_buffer_contract.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+USB_HEADER = ROOT / "include" / "usbcomm.h"
+
+
+def main():
+    usb = USB_HEADER.read_text(encoding="utf-8")
+    text_path = usb[usb.index("if (data[0] != 0x03)"):]
+    text_path = text_path[:text_path.index("UsbDecentCommandSink sink;")]
+
+    if "String input((const char *)data, len);" not in text_path:
+        raise AssertionError("USB text does not use the known-length String constructor")
+    if "input.reserve(len)" in text_path or "input +=" in text_path:
+        raise AssertionError("USB text is accumulated byte by byte")
+
+    print("USB text buffer contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Construct USB text directly from the receive buffer and its known length.
- Remove the per-byte mutable append loop.
- Protect the bounded construction path with a focused contract.

# Root Cause

`MyUsbCallbacks::onWrite()` already receives a pointer and exact byte count, but it reserved an empty `String` and appended each byte individually. The standard Arduino core has a length-aware constructor for this case.

# Scope

The firmware change replaces five lines with one constructor call. USB buffering, text/binary separation, timeout behavior, command parsing, maximum frame length, and binary protocol handling are unchanged.

# Safety / Reliability Impact

The USB receive path performs one bounded copy rather than repeated `String` mutations. This removes avoidable heap work without adding state, allocations beyond the resulting `String`, or dependencies.

# Compatibility

All `len` bytes are still copied before `trim()` and command dispatch. Embedded terminators, delimiters, and the 160-byte receive bound are handled by the existing downstream behavior. Native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_usb_text_buffer_contract.py` requires the known-length constructor and rejects the previous reserve-and-append pattern in the text branch.

# Verification

- `python tools/test_usb_text_buffer_contract.py` - passed: `USB text buffer contract tests passed`.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed after rebasing onto current `origin/main`.
- `git diff --cached --check` - passed.

# Hardware Verification

Not run. No physical ESP32-S3 or USB serial stream was exercised.

# Evidence

The pinned core declares `String(const char *cstr, unsigned int length)` in `WString.h`, and the receive buffer is bounded at 160 bytes. The rebased standard build passed.

# Documentation Impact

`docs/AI_PROTOCOL_NOTES.md` was reviewed. The repository hard rule already rejects byte-by-byte `String` accumulation from known-length buffers, so no duplicate documentation was added.

# Risks and Mitigations

USB delivery was not exercised on hardware. The replacement uses the standard constructor provided by the exact pinned firmware core and preserves the explicit input length.

# Related Work

No matching existing GitHub issue or pull request was found during read-only searches.
