### PR TITLE
fix(power): debounce low battery with fresh samples

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -346,21 +346,23 @@ int i_lowBatteryCount = 0;
 int i_lowBatteryCountTotal = 0;
 void power_off(int min) {
   if (!b_is_charging) {
-    if (f_batteryVoltage < lowBatteryThreshold) {
-      updateBattery(BATTERY_PIN);
-    }
-    if (f_batteryVoltage > lowBatteryThreshold) {
-      i_lowBatteryCount = 0;
-    }
+    if (!b_softSleep) {
+      if (f_batteryVoltage < lowBatteryThreshold) {
+        updateBattery(BATTERY_PIN);
+      }
+      if (f_batteryVoltage > lowBatteryThreshold) {
+        i_lowBatteryCount = 0;
+      }
 
-    if (f_batteryVoltage < lowBatteryThreshold) {
-      i_lowBatteryCount++;
-      i_lowBatteryCountTotal++;
-    }
+      if (f_batteryVoltage < lowBatteryThreshold) {
+        i_lowBatteryCount++;
+        i_lowBatteryCountTotal++;
+      }
 
-    if (i_lowBatteryCount > 50) {
-      shut_down_low_battery(f_batteryVoltage);
-      return;
+      if (i_lowBatteryCount > 50) {
+        shut_down_low_battery(f_batteryVoltage);
+        return;
+      }
     }
 
     if (min == -1) {
@@ -399,21 +401,23 @@ void power_off_gyro(int sec) {
 
 void power_off(double sec) {
   if (!b_is_charging) {
-    if (f_batteryVoltage < lowBatteryThreshold) {
-      updateBattery(BATTERY_PIN);
-    }
-    if (f_batteryVoltage > lowBatteryThreshold) {
-      i_lowBatteryCount = 0;
-    }
+    if (!b_softSleep) {
+      if (f_batteryVoltage < lowBatteryThreshold) {
+        updateBattery(BATTERY_PIN);
+      }
+      if (f_batteryVoltage > lowBatteryThreshold) {
+        i_lowBatteryCount = 0;
+      }
 
-    if (f_batteryVoltage < lowBatteryThreshold) {
-      i_lowBatteryCount++;
-      i_lowBatteryCountTotal++;
-    }
+      if (f_batteryVoltage < lowBatteryThreshold) {
+        i_lowBatteryCount++;
+        i_lowBatteryCountTotal++;
+      }
 
-    if (i_lowBatteryCount > 50) {
-      shut_down_low_battery(f_batteryVoltage);
-      return;
+      if (i_lowBatteryCount > 50) {
+        shut_down_low_battery(f_batteryVoltage);
+        return;
+      }
     }
 
     if (sec == -1) {

--- a/include/power.h
+++ b/include/power.h
@@ -346,6 +346,9 @@ int i_lowBatteryCount = 0;
 int i_lowBatteryCountTotal = 0;
 void power_off(int min) {
   if (!b_is_charging) {
+    if (f_batteryVoltage < lowBatteryThreshold) {
+      updateBattery(BATTERY_PIN);
+    }
     if (f_batteryVoltage > lowBatteryThreshold) {
       i_lowBatteryCount = 0;
     }
@@ -396,6 +399,9 @@ void power_off_gyro(int sec) {
 
 void power_off(double sec) {
   if (!b_is_charging) {
+    if (f_batteryVoltage < lowBatteryThreshold) {
+      updateBattery(BATTERY_PIN);
+    }
     if (f_batteryVoltage > lowBatteryThreshold) {
       i_lowBatteryCount = 0;
     }

--- a/tools/test_low_battery_debounce_contract.py
+++ b/tools/test_low_battery_debounce_contract.py
@@ -5,8 +5,8 @@ ROOT = Path(__file__).resolve().parents[1]
 POWER_HEADER = ROOT / "include" / "power.h"
 
 
-def function_body(text, signature):
-    start = text.index(signature)
+def block_body(text, marker):
+    start = text.index(marker)
     opening = text.index("{", start)
     depth = 0
     for index in range(opening, len(text)):
@@ -16,23 +16,28 @@ def function_body(text, signature):
             depth -= 1
             if depth == 0:
                 return text[opening + 1:index]
-    raise AssertionError(f"unterminated function: {signature}")
+    raise AssertionError(f"unterminated block: {marker}")
 
 
 def assert_fresh_low_samples(body, signature):
-    refresh = body.index("updateBattery(BATTERY_PIN);")
-    increment = body.index("i_lowBatteryCount++;")
+    awake = block_body(body, "if (!b_softSleep)")
+    refresh = awake.index("updateBattery(BATTERY_PIN);")
+    increment = awake.index("i_lowBatteryCount++;")
     if refresh > increment:
         raise AssertionError(f"{signature} counts a cached low-battery sample")
-    refresh_guard = body.rfind("if (f_batteryVoltage < lowBatteryThreshold)", 0, refresh)
+    refresh_guard = awake.rfind("if (f_batteryVoltage < lowBatteryThreshold)", 0, refresh)
     if refresh_guard < 0:
         raise AssertionError(f"{signature} refreshes without a low-battery guard")
+    if "shut_down_low_battery(f_batteryVoltage);" not in awake:
+        raise AssertionError(f"{signature} can shut down from a sleeping cached sample")
+    if "t_power_off" in awake:
+        raise AssertionError(f"{signature} pauses the inactivity timer during soft sleep")
 
 
 def main():
     power = POWER_HEADER.read_text(encoding="utf-8")
     for signature in ("void power_off(int min)", "void power_off(double sec)"):
-        assert_fresh_low_samples(function_body(power, signature), signature)
+        assert_fresh_low_samples(block_body(power, signature), signature)
 
     print("low-battery debounce contract tests passed")
 

--- a/tools/test_low_battery_debounce_contract.py
+++ b/tools/test_low_battery_debounce_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POWER_HEADER = ROOT / "include" / "power.h"
+
+
+def function_body(text, signature):
+    start = text.index(signature)
+    opening = text.index("{", start)
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def assert_fresh_low_samples(body, signature):
+    refresh = body.index("updateBattery(BATTERY_PIN);")
+    increment = body.index("i_lowBatteryCount++;")
+    if refresh > increment:
+        raise AssertionError(f"{signature} counts a cached low-battery sample")
+    refresh_guard = body.rfind("if (f_batteryVoltage < lowBatteryThreshold)", 0, refresh)
+    if refresh_guard < 0:
+        raise AssertionError(f"{signature} refreshes without a low-battery guard")
+
+
+def main():
+    power = POWER_HEADER.read_text(encoding="utf-8")
+    for signature in ("void power_off(int min)", "void power_off(double sec)"):
+        assert_fresh_low_samples(function_body(power, signature), signature)
+
+    print("low-battery debounce contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Refresh the battery voltage while confirming a cached low reading.
- Count actual consecutive ADC results rather than repeated loop checks of one value.
- Preserve the 30-second sampling cadence whenever the cached voltage is healthy.
- Pause battery confirmation while soft sleep has the main sensor rail switched off.

# Root Cause

Battery acquisition was moved out of `power_off()` and into a 30-second cache to reduce routine ADC work. The existing low-battery counter stayed in `power_off()` and still incremented every loop, so one cached low result was counted more than 50 times and triggered deep sleep without fresh confirmation.

The initial confirmation fix also exposed that `power_off()` runs before the loop's soft-sleep gate. On the standard V8.1 configuration, a cached low value could therefore start I2C ADS1115 reads after `PWR_CTRL` switched the main rail off.

# Scope

Both `power_off()` overloads now refresh only when the cached value is below the existing threshold and the scale is awake. Low-battery counting pauses in soft sleep, while the existing inactivity timer continues to run. Thresholds, counter limit, ADC conversion, charging behavior, regular sampling interval, notification behavior, and shutdown teardown are unchanged.

# Safety / Reliability Impact

A transient low reading must remain low across the existing 50-sample confirmation burst before shutdown. Healthy operation keeps the existing cached read path, and soft sleep performs no battery I2C work against the switched-off sensor rail.

# Compatibility

The low-battery threshold remains 3.2 V and shutdown still occurs after more than 50 consecutive low results. The change restores distinct readings behind that count. Native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_low_battery_debounce_contract.py` checks both overloads, requires a guarded `updateBattery(BATTERY_PIN)` before the low-battery counter increment, and keeps acquisition, counting, and low-battery shutdown inside the awake-only block without moving the inactivity timer into it. The old cached-only implementation and the unguarded confirmation implementation fail this contract.

# Verification

- `python tools/test_low_battery_debounce_contract.py` - passed: `low-battery debounce contract tests passed`.
- `python tools/test_soft_sleep_ads_wake.py` - passed.
- `python tools/test_charging_wake_contract.py` - passed.
- `python tools/test_ota_reboot_routing_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed after rebasing onto current `origin/main`.
- `git diff --cached --check` - passed.

# Hardware Verification

Not run. No physical ESP32-S3, ADS1115, battery transient, charger transition, or deep-sleep event was exercised.

# Evidence

The cache change in commit `cc13cd5f5150c6454db32880aaedb4d9925d33b6` replaced direct ADC reads with `f_batteryVoltage` but retained per-loop counter increments. Standard V8.1 defines `ADS1115ADC`, while documented soft sleep lowers `PWR_CTRL`; the follow-up guard prevents that I2C acquisition until wake. The rebased standard build passed.

# Documentation Impact

`docs/AI_GPIO_NOTES.md` and the battery history were reviewed. No threshold or board-pin documentation changed.

# Risks and Mitigations

The duration and analog behavior of the confirmation burst were not measured on hardware. The fix restores distinct-sample semantics, activates extra reads only after the existing cached threshold is crossed, and resumes a paused confirmation after wake.

# Related Work

No matching existing GitHub issue or pull request was found during read-only searches.
