### PR TITLE
fix(ota): keep updates awake

### DIFF
--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1464,7 +1464,7 @@ void loop() {
   else
     b_heartBeatIcon = false;
 #endif
-  if (bleHasLiveClient()
+  if (b_ota || bleHasLiveClient()
 #if HDS_FEATURE_WEBSOCKET
       || (b_wifiEnabled && websocket.count() > 0)
 #endif

--- a/tools/test_ota_reboot_routing_contract.py
+++ b/tools/test_ota_reboot_routing_contract.py
@@ -6,6 +6,7 @@ WIFI_OTA_HEADER = ROOT / "include" / "wifi_ota.h"
 PULL_OTA_HEADER = ROOT / "include" / "pull_ota.h"
 ROLLBACK_HEADER = ROOT / "include" / "ota_rollback.h"
 WIFI_SETUP_SOURCE = ROOT / "src" / "wifi_setup.cpp"
+HDS_SOURCE = ROOT / "src" / "hds.ino"
 
 
 def assert_contains(path, text):
@@ -33,6 +34,11 @@ def assert_before(path, first, second):
 
 
 def main():
+    hds = HDS_SOURCE.read_text(encoding="utf-8")
+    loop = hds[hds.index("void loop() {"):hds.index("void chargingOLED(")]
+    if "if (b_ota || bleHasLiveClient()" not in loop:
+        raise AssertionError("OTA does not suspend the auto-sleep countdown")
+
     # ElegantOTA's own auto-reboot bypasses reset()'s mDNS withdrawal; the
     # restart must be queued through the main-loop reset mechanism instead.
     assert_contains(WIFI_OTA_HEADER, "ElegantOTA.setAutoReboot(false)")


### PR DESCRIPTION
# Summary

- Treat active OTA work as keep-awake activity.
- Preserve low-battery monitoring while preventing inactivity sleep during flash writes.
- Leave normal idle, BLE, WebSocket, and grinder behavior unchanged.

# Root Cause

`loop()` evaluated the inactivity shutdown path before reaching its later `b_ota` early return. The keep-awake condition included live BLE and WebSocket clients but not the OTA state, so a USB-triggered or HTTP update started near the idle deadline could call `power_off(15)` and enter deep sleep while an update was active.

# Scope

The change adds `b_ota` to the existing main-loop keep-awake decision and extends the OTA lifecycle contract. OTA download, validation, rollback, low-battery shutdown, BLE/WebSocket behavior, grinder/custom environments, and filesystem contents are unchanged.

# Safety / Reliability Impact

Active ElegantOTA and pull-OTA operations continually refresh the inactivity timer. The existing `power_off(-1)` path still performs low-battery sampling and shutdown, so battery protection is not disabled.

# Compatibility

No protocol, manifest, NVS, filesystem, or user-interface contract changes. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_ota_reboot_routing_contract.py` now requires the OTA flag in the main-loop keep-awake condition. Before the implementation change it failed with `OTA does not suspend the auto-sleep countdown`; after the change it passes. `tools/test_pull_ota_contract.py` also passes for the surrounding update flow.

# Verification

- `python tools/test_ota_reboot_routing_contract.py` - failed before the implementation change and passed after it.
- `python tools/test_pull_ota_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical OTA, near-expiry inactivity timer, power-loss injection, or flash recovery was exercised.

# Evidence

Before the fix, the keep-awake branch began with `if (bleHasLiveClient()` while the OTA guard appeared later in the loop. It now begins with `if (b_ota || bleHasLiveClient()`, routing active updates through the existing timer-refresh path. The rebased standard build passed.

# Documentation Impact

No authoritative documentation change was needed; the existing OTA notes already require deterministic OTA and reboot lifecycle behavior.

# Risks and Mitigations

Physical timing was not tested. The implementation reuses the existing keep-awake branch and changes one condition, minimizing behavioral surface.

# Related Work

None identified.
