### PR TITLE
fix(buttons): reject long finger presses

### DIFF
--- a/include/finger_detection.h
+++ b/include/finger_detection.h
@@ -145,6 +145,7 @@ bool isFingerPress(int button) {
   bool is_finger_press = has_significant_peak &&
                         has_good_recovery &&
                         has_good_recovery_ratio &&
+                        reasonable_press_time &&
                         reasonable_total_time;
 
   if (b_fingerDetectionSerialOutput) {

--- a/tools/test_finger_press_duration_contract.py
+++ b/tools/test_finger_press_duration_contract.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_HEADER = ROOT / "include" / "config.h"
+FINGER_HEADER = ROOT / "include" / "finger_detection.h"
+
+
+def define_value(text, name):
+    match = re.search(rf"^#define {name} (\d+)", text, re.MULTILINE)
+    if match is None:
+        raise AssertionError(f"missing define: {name}")
+    return int(match.group(1))
+
+
+def main():
+    config = CONFIG_HEADER.read_text(encoding="utf-8")
+    finger = FINGER_HEADER.read_text(encoding="utf-8")
+    long_press_delay = define_value(config, "LONGPRESS_DELAY")
+
+    for name in (
+        "CIRCLE_FINGER_PRESS_MAX_PRESS_TIME",
+        "SQUARE_FINGER_PRESS_MAX_PRESS_TIME",
+    ):
+        if define_value(finger, name) >= long_press_delay:
+            raise AssertionError(f"{name} overlaps the long-press threshold")
+
+    predicate = re.search(r"bool is_finger_press =([^;]+);", finger)
+    if predicate is None or "reasonable_press_time" not in predicate.group(1):
+        raise AssertionError("finger press classification ignores maximum press time")
+
+    print("finger press duration contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Apply the existing maximum press duration to finger-press classification.
- Keep normal short circle and square actions unchanged.
- Prevent a released long press from also queuing tare or timer work.

# Root Cause

`isFingerPress()` calculated `reasonable_press_time` from each button's 800 ms limit but omitted it from the final predicate. AceButton classifies a long press at 900 ms, so a normal long press whose load-cell sampling remains active through release could still satisfy the peak and recovery checks and run the short action.

# Scope

The change adds the already-computed duration guard to the existing classifier and adds one focused source contract. Button thresholds, AceButton configuration, load-cell sampling, long-press behavior, menu behavior, and protocol messages are unchanged.

# Safety / Reliability Impact

Long presses no longer fall through to short-press tare or timer actions after release. Short presses at or below the configured 800 ms limit retain the existing classifier.

# Compatibility

No BLE, USB, WebSocket, storage, or hardware interface changes. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_finger_press_duration_contract.py` verifies that both finger maximum durations remain below the AceButton long-press threshold and that the final classification predicate includes `reasonable_press_time`.

# Verification

- `python tools/test_finger_press_duration_contract.py` - failed before the implementation change and passed after it.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical button timing, load-cell pulse, tare, or timer behavior was exercised.

# Evidence

Before the fix, the focused contract failed with `finger press classification ignores maximum press time`. After adding the existing duration boolean to the predicate, the contract passes. The rebased standard build passed.

# Documentation Impact

No authoritative documentation change was needed. `docs/AI_FIRMWARE_NOTES.md` was reviewed for button and main-loop ownership.

# Risks and Mitigations

Physical timing was not tested. The implementation uses the existing per-button limits and changes one predicate term, minimizing the behavioral surface.

# Related Work

No matching GitHub issue or pull request was identified.
