### PR TITLE
fix(power): stamp battery samples at acquisition

### DIFF
--- a/include/power.h
+++ b/include/power.h
@@ -333,6 +333,7 @@ void updateBattery(int batteryPin){
     float correctedVoltage = batteryVoltage * f_batteryCalibrationFactor;
     f_batteryVoltage = correctedVoltage;
   }
+  t_batteryRefresh = millis();
 }
 
 float getUsbVoltage(int usbPin) {

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1517,7 +1517,6 @@ void loop() {
 #endif  //DEBUG
     if (millis() - t_batteryRefresh > i_batteryRefreshTareInterval){
       updateBattery(BATTERY_PIN);
-      t_batteryRefresh = millis();
     }
     checkBattery();
     if (b_ota) {

--- a/tools/test_battery_refresh_timestamp_contract.py
+++ b/tools/test_battery_refresh_timestamp_contract.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POWER_HEADER = ROOT / "include" / "power.h"
+HDS_SOURCE = ROOT / "src" / "hds.ino"
+
+
+def function_body(text, signature):
+    start = text.index(signature)
+    opening = text.index("{", start)
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def main():
+    power = POWER_HEADER.read_text(encoding="utf-8")
+    hds = HDS_SOURCE.read_text(encoding="utf-8")
+    update = function_body(power, "void updateBattery(int batteryPin)")
+
+    if "t_batteryRefresh = millis();" not in update:
+        raise AssertionError("battery acquisition does not mark its sample fresh")
+    if "t_batteryRefresh = millis();" in function_body(hds, "void loop()"):
+        raise AssertionError("battery freshness is owned by a caller instead of acquisition")
+
+    print("battery refresh timestamp contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Stamp battery freshness whenever a voltage sample is acquired.
- Let the startup sample participate in controlled low-battery shutdown.
- Remove duplicate timestamp ownership from the periodic loop caller.

# Root Cause

`setup()` takes an initial battery reading, but `t_batteryRefresh` was updated only by the 30-second refresh block in `loop()`. `shut_down_low_battery()` rejects samples while that timestamp is zero, so an ordinarily depleted battery could be repeatedly confirmed after startup without entering controlled shutdown until the periodic refresh ran.

# Scope

The change moves the existing timestamp assignment into `updateBattery()` and removes it from the periodic caller. ADC selection, voltage conversion, thresholds, debounce counts, display behavior, and deep-sleep sequencing are unchanged.

# Safety / Reliability Impact

Startup and low-voltage confirmation reads now carry the same freshness marker as periodic reads. This allows the existing controlled low-battery path to run from the first valid startup sample instead of waiting up to 30 seconds.

# Compatibility

No protocol, storage, GPIO, threshold, or hardware interface changes. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_battery_refresh_timestamp_contract.py` requires `updateBattery()` to own the freshness timestamp and rejects a caller-side assignment in `loop()`.

# Verification

- `python tools/test_battery_refresh_timestamp_contract.py` - failed before the implementation change and passed after it.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No depleted battery, ADC voltage, OLED warning, BLE notification, or deep-sleep transition was exercised.

# Evidence

Before the fix, the focused contract failed with `battery acquisition does not mark its sample fresh`. After moving the timestamp into the acquisition function, the contract passes. The rebased standard build passed.

# Documentation Impact

No authoritative documentation change was needed. `docs/AI_FIRMWARE_NOTES.md` and `docs/AI_GPIO_NOTES.md` were reviewed for battery, main-loop, and power ownership.

# Risks and Mitigations

Physical low-voltage behavior was not tested. The implementation reuses the existing timestamp and changes only where it is assigned.

# Related Work

PR-009 fixes fresh-sample debounce in the same power path. The candidates are independently useful and have no ordering dependency. No matching GitHub issue or pull request was identified.
