### PR TITLE
fix(ble): queue voltage responses

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -29,6 +29,8 @@ void sendBleVoltage();
 void sendBleLedResponse();
 void sendAdsDebugInfoBLE();
 void queueBleStatusResponse();
+void queueBleVoltageResponse();
+void processBleVoltageResponse();
 static bool bleHasLiveClient();
 void buildAdsDebugPacket(byte data[41]);
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
@@ -39,6 +41,7 @@ volatile uint16_t connId = 0xFFFF;
 void resetBleFff4StateLocked(uint16_t subscriptionHandle) {
   bleFff4SubscriptionHandle = subscriptionHandle;
   bleStatusResponsesPending = 0;
+  bleVoltageResponsesPending = 0;
   bleStatusRequestAt = 0;
   bleNotifyFailureLogged = false;
 }
@@ -240,7 +243,7 @@ struct BleDecentCommandSink {
 #endif
 
   void sendVoltage() {
-    sendBleVoltage();
+    queueBleVoltageResponse();
   }
 
   void adsDebug(uint8_t mode) {
@@ -392,6 +395,23 @@ static bool bleCanNotifyCurrent() {
     && pReadCharacteristic != nullptr
     && bleHasLiveClient()
     && subscribed;
+}
+
+void queueBleVoltageResponse() {
+  portENTER_CRITICAL(&bleFff4Mux);
+  if (bleVoltageResponsesPending != UINT16_MAX) bleVoltageResponsesPending = bleVoltageResponsesPending + 1;
+  portEXIT_CRITICAL(&bleFff4Mux);
+}
+
+void processBleVoltageResponse() {
+  bool sendVoltage = false;
+  portENTER_CRITICAL(&bleFff4Mux);
+  if (bleVoltageResponsesPending > 0) {
+    bleVoltageResponsesPending = bleVoltageResponsesPending - 1;
+    sendVoltage = true;
+  }
+  portEXIT_CRITICAL(&bleFff4Mux);
+  if (sendVoltage) sendBleVoltage();
 }
 
 void queueBleStatusResponse() {

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -14,6 +14,7 @@ Preferences settingsPreferences;
 volatile bool b_ble_enabled = false;
 volatile uint16_t bleFff4SubscriptionHandle = 0xFFFF;
 volatile uint16_t bleStatusResponsesPending = 0;
+volatile uint16_t bleVoltageResponsesPending = 0;
 volatile unsigned long bleStatusRequestAt = 0;
 volatile bool bleNotifyFailureLogged = false;
 volatile uint32_t bleFff4ConnectionGeneration = 0;

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1447,6 +1447,7 @@ void setManualStableValue(float value) {
 void loop() {
   processWsPendingCmds();
   processBleStatusResponse();
+  processBleVoltageResponse();
 
   if (b_powerOff){
     shut_down_now_nobeep();

--- a/tools/test_ble_voltage_mailbox_contract.py
+++ b/tools/test_ble_voltage_mailbox_contract.py
@@ -1,0 +1,75 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BLE_HEADER = ROOT / "include" / "ble.h"
+PARAMETER_HEADER = ROOT / "include" / "parameter.h"
+HDS_SOURCE = ROOT / "src" / "hds.ino"
+
+
+def function_body(text, name):
+    match = re.search(rf"\b\w+\s+{re.escape(name)}\([^;{{}}]*\)\s*{{", text)
+    if match is None:
+        raise AssertionError(f"missing function: {name}")
+    opening = text.index("{", match.start())
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated function: {name}")
+
+
+def assert_contains(text, *snippets):
+    for snippet in snippets:
+        if snippet not in text:
+            raise AssertionError(f"missing snippet: {snippet}")
+
+
+def main():
+    ble = BLE_HEADER.read_text(encoding="utf-8")
+    parameter = PARAMETER_HEADER.read_text(encoding="utf-8")
+    hds = HDS_SOURCE.read_text(encoding="utf-8")
+
+    assert_contains(parameter, "volatile uint16_t bleVoltageResponsesPending = 0;")
+    assert_contains(function_body(ble, "resetBleFff4StateLocked"), "bleVoltageResponsesPending = 0;")
+
+    sink = function_body(ble, "sendVoltage")
+    assert_contains(sink, "queueBleVoltageResponse();")
+    if "sendBleVoltage();" in sink:
+        raise AssertionError("BLE callback sends the voltage notification directly")
+
+    queue = function_body(ble, "queueBleVoltageResponse")
+    assert_contains(
+        queue,
+        "portENTER_CRITICAL(&bleFff4Mux)",
+        "bleVoltageResponsesPending != UINT16_MAX",
+        "bleVoltageResponsesPending = bleVoltageResponsesPending + 1",
+        "portEXIT_CRITICAL(&bleFff4Mux)",
+    )
+
+    process = function_body(ble, "processBleVoltageResponse")
+    assert_contains(
+        process,
+        "portENTER_CRITICAL(&bleFff4Mux)",
+        "bleVoltageResponsesPending = bleVoltageResponsesPending - 1",
+        "portEXIT_CRITICAL(&bleFff4Mux)",
+        "sendBleVoltage();",
+    )
+    if process.index("portEXIT_CRITICAL(&bleFff4Mux)") > process.index("sendBleVoltage();"):
+        raise AssertionError("voltage notification runs while holding the mailbox lock")
+
+    loop = function_body(hds, "loop")
+    assert_contains(loop, "processBleVoltageResponse();")
+    if loop.index("processBleVoltageResponse();") > loop.index("sendBleWeight();"):
+        raise AssertionError("voltage response is not drained before periodic notifications")
+
+    print("BLE voltage mailbox contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Queue BLE voltage replies from the NimBLE write callback.
- Drain voltage replies from the main loop before periodic notifications.
- Clear pending replies when the FFF4 connection state resets.

# Root Cause

`BleDecentCommandSink::sendVoltage()` called `sendBleVoltage()` directly from NimBLE `onWrite`, while weight, debug, status, button, and power notifications use the main loop. The shared FFF4 characteristic therefore had no firmware-level serialization across each `setValue()` and `notify()` pair, so an ordinary voltage request could overlap another notification and lose or replace the intended payload.

# Scope

The change adds one bounded voltage-response counter protected by the existing `bleFff4Mux`, redirects the voltage sink to that mailbox, clears it with the existing connection state, and drains one response per loop pass. Packet bytes, command dispatch, subscription gating, status-response timeout behavior, and other BLE commands are unchanged.

# Safety / Reliability Impact

Voltage responses now share the main-loop execution context with all routine FFF4 notifications. The callback performs only a short critical-section counter update and no characteristic delivery.

# Compatibility

The Decent `0x22` command and seven-byte voltage response are unchanged. Unsubscribed or disconnected delivery still fails through the existing `bleCanNotifyCurrent()` gate. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_ble_voltage_mailbox_contract.py` requires callback deferral, bounded synchronized queueing, connection reset, unlocked main-loop delivery, and placement before periodic weight notification. `tools/test_ble_subscription_contract.py` continues to verify the shared FFF4 subscription gate and status mailbox.

# Verification

- `python tools/test_ble_voltage_mailbox_contract.py` - failed before the implementation change and passed after it.
- `python tools/test_ble_subscription_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No BLE client, concurrent voltage/weight traffic, disconnect timing, or notification capture was exercised.

# Evidence

Before the fix, the focused contract failed because `bleVoltageResponsesPending` and its mailbox did not exist. After deferring delivery to `loop()`, both BLE contracts pass. The rebased standard build passed.

# Documentation Impact

No authoritative documentation change was needed. `docs/AI_FIRMWARE_NOTES.md` and `docs/AI_PROTOCOL_NOTES.md` were reviewed for task ownership and FFF4 response behavior.

# Risks and Mitigations

Physical BLE timing was not tested. The queue saturates instead of wrapping, resets with the active connection, drains one reply per loop pass, and reuses the existing subscription gate.

# Related Work

GitHub PR #112 introduced the synchronized FFF4 subscription state and deferred status-response mailbox but left voltage replies in the callback.
