### PR TITLE
fix(ota): suspend local input during updates

### DIFF
--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -221,6 +221,7 @@ public:
 
   void processUsbRxBuffer(bool allowTimeout) {
     while (usbRxLen > 0) {
+      if (b_ota) return;
       bool timedOut = allowTimeout && usbRxTimedOut();
 
       if (usbRxBuffer[0] == 0x03) {
@@ -236,7 +237,6 @@ public:
 
         onWrite(usbRxBuffer, frameLen);
         consumeUsbRxBytes(frameLen);
-        if (b_ota) return;
         continue;
       }
 

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -236,6 +236,7 @@ public:
 
         onWrite(usbRxBuffer, frameLen);
         consumeUsbRxBytes(frameLen);
+        if (b_ota) return;
         continue;
       }
 

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1480,23 +1480,25 @@ void loop() {
   } else {
     power_off(15);
   }
-  if (Serial.available()) {
-    uint8_t data[32];
-    size_t len = 0;
-    while (Serial.available() && len < sizeof(data)) {
-      data[len++] = Serial.read();
+  if (!b_ota) {
+    if (Serial.available()) {
+      uint8_t data[32];
+      size_t len = 0;
+      while (Serial.available() && len < sizeof(data)) {
+        data[len++] = Serial.read();
+      }
+      usbCallbacks.onStream(data, len);
     }
-    usbCallbacks.onStream(data, len);
-  }
-  usbCallbacks.poll();
+    usbCallbacks.poll();
 
-  if (!buttonChecksSuppressedUntilRelease()
+    if (!buttonChecksSuppressedUntilRelease()
 #if HDS_ENABLE_GRINDER
-      && !handleGrinderMenuChord()
+        && !handleGrinderMenuChord()
 #endif
-  ) {
-    buttonCircle.check();
-    buttonSquare.check();
+    ) {
+      buttonCircle.check();
+      buttonSquare.check();
+    }
   }
 #ifdef BUZZER
   buzzer.check();

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1480,25 +1480,26 @@ void loop() {
   } else {
     power_off(15);
   }
+  if (!b_ota && Serial.available()) {
+    uint8_t data[32];
+    size_t len = 0;
+    while (Serial.available() && len < sizeof(data)) {
+      data[len++] = Serial.read();
+    }
+    usbCallbacks.onStream(data, len);
+  }
   if (!b_ota) {
-    if (Serial.available()) {
-      uint8_t data[32];
-      size_t len = 0;
-      while (Serial.available() && len < sizeof(data)) {
-        data[len++] = Serial.read();
-      }
-      usbCallbacks.onStream(data, len);
-    }
     usbCallbacks.poll();
+  }
 
-    if (!buttonChecksSuppressedUntilRelease()
+  if (!b_ota
+      && !buttonChecksSuppressedUntilRelease()
 #if HDS_ENABLE_GRINDER
-        && !handleGrinderMenuChord()
+      && !handleGrinderMenuChord()
 #endif
-    ) {
-      buttonCircle.check();
-      buttonSquare.check();
-    }
+  ) {
+    buttonCircle.check();
+    buttonSquare.check();
   }
 #ifdef BUZZER
   buzzer.check();

--- a/tools/test_ota_input_isolation_contract.py
+++ b/tools/test_ota_input_isolation_contract.py
@@ -80,12 +80,9 @@ def main():
 
     usb = USB_HEADER.read_text(encoding="utf-8")
     usb_buffer = extract_block(usb, "void processUsbRxBuffer(bool allowTimeout) {")
-    if (
-        "onWrite(usbRxBuffer, frameLen);\n"
-        "        consumeUsbRxBytes(frameLen);\n"
-        "        if (b_ota) return;"
-    ) not in usb_buffer:
-        raise AssertionError("USB parser continues after an OTA command")
+    parser_loop = extract_block(usb_buffer, "while (usbRxLen > 0) {")
+    if parser_loop.index("if (b_ota) return;") > parser_loop.index("bool timedOut"):
+        raise AssertionError("USB parser checks OTA state after starting command dispatch")
 
     print("OTA input isolation contract tests passed")
 

--- a/tools/test_ota_input_isolation_contract.py
+++ b/tools/test_ota_input_isolation_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HDS_SOURCE = ROOT / "src" / "hds.ino"
+USB_HEADER = ROOT / "include" / "usbcomm.h"
 
 
 def extract_block(source, opener):
@@ -33,20 +34,36 @@ def main():
     loop_end = contents.index("void chargingOLED(", loop_start)
     loop = contents[loop_start:loop_end]
 
-    normal_input = extract_block(loop, "if (!b_ota) {")
+    serial_input = extract_block(loop, "if (!b_ota && Serial.available()) {")
     require_all(
-        normal_input,
+        serial_input,
         [
-            "Serial.available()",
             "usbCallbacks.onStream(data, len);",
+        ],
+        "serial input gate",
+    )
+    poll_input = extract_block(loop, "if (!b_ota) {")
+    require_all(
+        poll_input,
+        [
             "usbCallbacks.poll();",
+        ],
+        "USB timeout gate",
+    )
+    button_input = extract_block(
+        loop,
+        "if (!b_ota\n      && !buttonChecksSuppressedUntilRelease()",
+    )
+    require_all(
+        button_input,
+        [
             "buttonCircle.check();",
             "buttonSquare.check();",
         ],
-        "normal input gate",
+        "button input gate",
     )
 
-    gate_at = loop.index("if (!b_ota) {")
+    gate_at = loop.index("if (!b_ota && Serial.available()) {")
     if loop.index("processWsPendingCmds();") >= gate_at:
         raise AssertionError("pending reset routing must run during OTA")
     if loop.index("power_off(15);") >= gate_at:
@@ -60,6 +77,15 @@ def main():
     )
     if loop.index("checkBattery();") >= loop.index("if (b_ota) {"):
         raise AssertionError("charging-state refresh must run before OTA servicing")
+
+    usb = USB_HEADER.read_text(encoding="utf-8")
+    usb_buffer = extract_block(usb, "void processUsbRxBuffer(bool allowTimeout) {")
+    if (
+        "onWrite(usbRxBuffer, frameLen);\n"
+        "        consumeUsbRxBytes(frameLen);\n"
+        "        if (b_ota) return;"
+    ) not in usb_buffer:
+        raise AssertionError("USB parser continues after an OTA command")
 
     print("OTA input isolation contract tests passed")
 

--- a/tools/test_ota_input_isolation_contract.py
+++ b/tools/test_ota_input_isolation_contract.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HDS_SOURCE = ROOT / "src" / "hds.ino"
+
+
+def extract_block(source, opener):
+    start = source.find(opener)
+    if start < 0:
+        raise AssertionError(f"hds.ino missing {opener}")
+    brace = source.find("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"hds.ino has unterminated block {opener}")
+
+
+def require_all(source, markers, context):
+    for marker in markers:
+        if marker not in source:
+            raise AssertionError(f"{context} missing {marker}")
+
+
+def main():
+    contents = HDS_SOURCE.read_text(encoding="utf-8")
+    loop_start = contents.index("void loop() {")
+    loop_end = contents.index("void chargingOLED(", loop_start)
+    loop = contents[loop_start:loop_end]
+
+    normal_input = extract_block(loop, "if (!b_ota) {")
+    require_all(
+        normal_input,
+        [
+            "Serial.available()",
+            "usbCallbacks.onStream(data, len);",
+            "usbCallbacks.poll();",
+            "buttonCircle.check();",
+            "buttonSquare.check();",
+        ],
+        "normal input gate",
+    )
+
+    gate_at = loop.index("if (!b_ota) {")
+    if loop.index("processWsPendingCmds();") >= gate_at:
+        raise AssertionError("pending reset routing must run during OTA")
+    if loop.index("power_off(15);") >= gate_at:
+        raise AssertionError("low-battery and inactivity handling must precede input gating")
+
+    ota_service = extract_block(loop, "if (b_ota) {")
+    require_all(
+        ota_service,
+        ["ElegantOTA.loop();", "processOtaDisplayUpdate();", "return;"],
+        "OTA service gate",
+    )
+    if loop.index("checkBattery();") >= loop.index("if (b_ota) {"):
+        raise AssertionError("charging-state refresh must run before OTA servicing")
+
+    print("OTA input isolation contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

- Suspend USB command parsing and AceButton dispatch while OTA is active.
- Leave pull OTA's direct picker controls as the sole button owner during its workflow.
- Preserve pending reset routing, power monitoring, charging-state refresh, and ElegantOTA servicing.

# Root Cause

`pullOtaUpdateTask()` polls Circle and Square directly while the main loop continues calling both AceButton instances. Normal release-picker taps can therefore also enter the regular double-click handlers. With no BLE client and the menu already closed, those handlers set `b_powerOff`, allowing the next loop pass to enter deep sleep during the OTA workflow. USB commands were processed in the same pre-OTA section and could invoke unrelated normal actions concurrently.

# Scope

The change gates normal USB and AceButton processing on the existing `b_ota` state, rechecks that state between dispatch stages, and stops the USB frame loop when an OTA command activates it. Pull-OTA button polling, pending WebSocket command dispatch, low-battery and inactivity handling, charging-state refresh, and the existing OTA service return remain unchanged.

# Safety / Reliability Impact

The main loop no longer interprets pull-OTA selection gestures as normal tare, timer, menu, or shutdown gestures. It also stops executing USB actions while update state owns the device lifecycle.

# Compatibility

No button mapping, USB packet, manifest, NVS, filesystem, or OTA protocol changes. Normal input resumes when `b_ota` clears. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_ota_input_isolation_contract.py` requires separate OTA checks around serial reads, buffered USB polling, and both AceButton checks. It also requires the USB frame loop to stop after an OTA command while preserving pending reset routing, power handling, charging-state refresh, ElegantOTA servicing, and the OTA display update.

# Verification

- `python tools/test_ota_input_isolation_contract.py` - failed before the implementation change and passed after it.
- `python tools/test_ota_reboot_routing_contract.py` - passed.
- `python tools/test_pull_ota_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical release selection, USB traffic during OTA, firmware write, power-loss injection, or rollback was exercised.

# Evidence

Before the fix, the focused contract failed because the main loop had no non-OTA input gate. Review of the combined state also found that an OTA command could activate the flag inside an already-entered USB pass, so the gate was split at each dispatch boundary and the parser now stops with remaining bytes buffered. All three OTA contracts pass. The rebased standard build passed.

# Documentation Impact

No authoritative documentation change was needed. `docs/AI_OTA_NOTES.md` and `docs/AI_DISPLAY_NOTES.md` were reviewed for OTA lifecycle and input ownership constraints.

# Risks and Mitigations

Physical timing was not tested. The implementation reuses the existing volatile OTA state and changes no task, queue, hardware, or protocol ownership beyond suppressing the competing main-loop input calls.

# Related Work

Merged PR #11 moved ElegantOTA servicing behind `b_ota` but did not isolate input and predates the pull-OTA release picker.
