### PR TITLE
fix(ota): wake before pull update

### DIFF
--- a/include/menu.h
+++ b/include/menu.h
@@ -1470,6 +1470,9 @@ void calibration(int input) {
 
 #if HDS_FEATURE_PULL_OTA
 void wifiUpdate() {
+  if (b_softSleep) {
+    wakeScaleFromSoftSleep("WiFi OTA wake");
+  }
 #ifdef BUZZER
   buzzer.off();
 #endif

--- a/tools/test_soft_sleep_ads_wake.py
+++ b/tools/test_soft_sleep_ads_wake.py
@@ -8,6 +8,7 @@ PARAMETER_HEADER = ROOT / "include" / "parameter.h"
 BLE_HEADER = ROOT / "include" / "ble.h"
 USBCOMM_HEADER = ROOT / "include" / "usbcomm.h"
 WEBSOCKET_HEADER = ROOT / "include" / "websocket.h"
+MENU_HEADER = ROOT / "include" / "menu.h"
 
 
 def read(path):
@@ -16,7 +17,7 @@ def read(path):
 
 def method_body(path, name):
     text = read(path)
-    match = re.search(rf"\b\w+\s+{re.escape(name)}\(", text)
+    match = re.search(rf"\b\w+\s+{re.escape(name)}\([^)]*\)\s*\{{", text)
     if match is None:
         raise AssertionError(f"method not found: {name}")
     opening = text.index("{", match.start())
@@ -80,6 +81,16 @@ def main():
     )
     if "digitalWrite(PWR_CTRL, HIGH);" in usb_soft_off:
         raise AssertionError("USB soft wake must use wakeScaleFromSoftSleep")
+
+    wifi_update = method_body(MENU_HEADER, "wifiUpdate")
+    assert_ordered(
+        wifi_update,
+        [
+            "if (b_softSleep)",
+            'wakeScaleFromSoftSleep("WiFi OTA wake")',
+            "pullOtaUpdate();",
+        ],
+    )
 
     ble_soft_off = method_body(BLE_HEADER, "softSleepOff")
     assert_ordered(


### PR DESCRIPTION
# Summary

- Wake the scale through the existing soft-sleep recovery path before starting pull OTA.
- Restore the power rails, ADC, and OLED before the updater renders or requests local confirmation.
- Keep BLE, USB, and menu OTA entry points routed through one shared guard.

# Root Cause

The shared `wifiUpdate()` entry point started the pull-OTA task without checking `b_softSleep`. BLE and USB remain available during soft sleep, so an ordinary client can send Decent command `0x1B` after placing the scale to sleep. The task then renders its release picker while the OLED and peripheral rails remain off, leaving the user unable to see the selection and confirmation prompts.

# Scope

The change adds one soft-sleep guard to `wifiUpdate()` and extends the existing soft-sleep contract. It does not change the Decent command, OTA task, picker controls, manifest validation, storage, or reboot flow.

# Safety / Reliability Impact

Pull OTA no longer performs OLED and ADC-related wake work while their switched rails remain off. All existing OTA callers use the established main-loop-safe `wakeScaleFromSoftSleep()` path before the task starts.

# Compatibility

No packet, command, menu, manifest, NVS, filesystem, or release-selection behavior changes. Awake updates are unchanged. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_soft_sleep_ads_wake.py` now requires the shared OTA entry point to call `wakeScaleFromSoftSleep()` before `pullOtaUpdate()`. The assertion failed before the firmware change and passes after it.

# Verification

- `python tools/test_soft_sleep_ads_wake.py` - failed before the implementation change and passed after it.
- `python tools/test_pull_ota_contract.py` - passed.
- `python tools/test_ota_reboot_routing_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical soft-sleep, BLE/USB update request, OLED prompt, firmware write, or rollback was exercised.

# Evidence

Before the fix, the focused contract failed with `missing ordered snippet: if (b_softSleep)`. After the shared wake guard was added, all three focused contracts passed. The rebased standard build passed; only the existing volatile increment warnings in `src/wifi_setup.cpp` remain.

# Documentation Impact

No authoritative documentation change was needed. `docs/AI_OTA_NOTES.md`, `docs/AI_GPIO_NOTES.md`, and `docs/AI_PROTOCOL_NOTES.md` were reviewed.

# Risks and Mitigations

Physical timing was not tested. The change reuses the already-tested soft-wake helper rather than duplicating rail, display, or ADC initialization.

# Related Work

Merged pull-OTA work in PR #87 introduced the picker but contains no soft-sleep wake guard.
