### PR TITLE
fix(power): defer soft-wake state transition

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -180,7 +180,6 @@ struct BleDecentCommandSink {
 
   void softSleepOff() {
     bool wasSoftSleep = b_softSleep;
-    b_softSleep = false;
     b_u8g2Sleep = false;
     if (wasSoftSleep) {
       remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);

--- a/include/ble.h
+++ b/include/ble.h
@@ -180,7 +180,6 @@ struct BleDecentCommandSink {
 
   void softSleepOff() {
     bool wasSoftSleep = b_softSleep;
-    b_u8g2Sleep = false;
     if (wasSoftSleep) {
       remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
     } else {

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -480,7 +480,6 @@ bool handleWebsocketControlCommand(AsyncWebSocketClient *client, String command,
     if (action == "off" || action == "wake") {
       Serial.println("Websocket soft sleep off detected.");
       bool wasSoftSleep = b_softSleep;
-      b_softSleep = false;
       b_u8g2Sleep = false;
       if (wasSoftSleep) {
         wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -480,7 +480,6 @@ bool handleWebsocketControlCommand(AsyncWebSocketClient *client, String command,
     if (action == "off" || action == "wake") {
       Serial.println("Websocket soft sleep off detected.");
       bool wasSoftSleep = b_softSleep;
-      b_u8g2Sleep = false;
       if (wasSoftSleep) {
         wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
       } else {

--- a/tools/test_soft_sleep_ads_wake.py
+++ b/tools/test_soft_sleep_ads_wake.py
@@ -97,12 +97,14 @@ def main():
         ble_soft_off,
         [
             "bool wasSoftSleep = b_softSleep;",
-            "b_softSleep = false;",
+            "b_u8g2Sleep = false;",
             "if (wasSoftSleep)",
             "remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
             "remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
         ],
     )
+    if "b_softSleep = false;" in ble_soft_off:
+        raise AssertionError("BLE wake publishes awake state before rail restore")
 
     ble_disconnect_display = method_body(BLE_HEADER, "restoreDisplayAfterBleDisconnect")
     assert_ordered(
@@ -117,16 +119,22 @@ def main():
         raise AssertionError("all BLE disconnect callbacks must preserve soft sleep")
 
     ws_handler = read(WEBSOCKET_HEADER)
+    ws_wake_start = ws_handler.index('if (action == "off" || action == "wake")')
+    ws_wake_end = ws_handler.index('sendWebsocketStatus(client, "ok");', ws_wake_start)
+    ws_wake = ws_handler[ws_wake_start:ws_wake_end]
     assert_ordered(
-        ws_handler,
+        ws_wake,
         [
             'if (action == "off" || action == "wake")',
             "bool wasSoftSleep = b_softSleep;",
+            "b_u8g2Sleep = false;",
             "if (wasSoftSleep)",
             "wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
             "wsReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
         ],
     )
+    if "b_softSleep = false;" in ws_wake:
+        raise AssertionError("WebSocket wake publishes awake state before rail restore")
 
     ws_pending = method_body(WEBSOCKET_HEADER, "processWsPendingCmds")
     assert_ordered(ws_pending, ['wakeScaleFromSoftSleep("remote soft wake")'])

--- a/tools/test_soft_sleep_ads_wake.py
+++ b/tools/test_soft_sleep_ads_wake.py
@@ -97,14 +97,13 @@ def main():
         ble_soft_off,
         [
             "bool wasSoftSleep = b_softSleep;",
-            "b_u8g2Sleep = false;",
             "if (wasSoftSleep)",
             "remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
             "remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
         ],
     )
-    if "b_softSleep = false;" in ble_soft_off:
-        raise AssertionError("BLE wake publishes awake state before rail restore")
+    if "b_softSleep = false;" in ble_soft_off or "b_u8g2Sleep = false;" in ble_soft_off:
+        raise AssertionError("BLE wake publishes state before main-loop recovery")
 
     ble_disconnect_display = method_body(BLE_HEADER, "restoreDisplayAfterBleDisconnect")
     assert_ordered(
@@ -127,14 +126,13 @@ def main():
         [
             'if (action == "off" || action == "wake")',
             "bool wasSoftSleep = b_softSleep;",
-            "b_u8g2Sleep = false;",
             "if (wasSoftSleep)",
             "wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
             "wsReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
         ],
     )
-    if "b_softSleep = false;" in ws_wake:
-        raise AssertionError("WebSocket wake publishes awake state before rail restore")
+    if "b_softSleep = false;" in ws_wake or "b_u8g2Sleep = false;" in ws_wake:
+        raise AssertionError("WebSocket wake publishes state before main-loop recovery")
 
     ws_pending = method_body(WEBSOCKET_HEADER, "processWsPendingCmds")
     assert_ordered(ws_pending, ['wakeScaleFromSoftSleep("remote soft wake")'])


### PR DESCRIPTION
# Summary

- Keep `b_softSleep` and `b_u8g2Sleep` unchanged until the main loop has restored the power rails, ADC state, and OLED.
- Preserve idempotent duplicate wake behavior for BLE and WebSocket clients.
- Reuse the existing synchronized pending-command path without adding state.

# Root Cause

BLE and WebSocket callbacks cleared `b_softSleep` and `b_u8g2Sleep` before queuing `WSP_SLEEP_OFF`. If a normal wake arrived after `loop()` had already drained pending commands, the same loop pass could observe the scale as awake and run `pureScale()`, battery acquisition, or OLED rendering before the next pass restored the switched rails. The split state also allowed an immediate WebSocket acknowledgement to report `display_on: true` while `soft_sleep: true`.

# Scope

The change removes the premature sleep and display state assignments from the BLE and WebSocket wake handlers and strengthens the existing soft-sleep contract. USB and button wake paths already execute `wakeScaleFromSoftSleep()` directly from the main loop and are unchanged.

# Safety / Reliability Impact

Main-loop hardware work remains suppressed until `wakeScaleFromSoftSleep()` completes the rail, ADS1232, and OLED recovery sequence. Remote status remains internally consistent while that recovery is pending. No hardware calls are moved into BLE or AsyncTCP callbacks.

# Compatibility

Duplicate wake commands while already awake still restore only the display and do not reset ADC output. A WebSocket wake acknowledgement now retains the current sleep and display state until the main loop completes the deferred wake; a settled status query remains unchanged. No BLE packet or command format changes. The standard `esp32s3` build passes; native, grinder, and custom environments were intentionally not run.

# Regression Coverage

`tools/test_soft_sleep_ads_wake.py` rejects any BLE or WebSocket wake handler that clears `b_softSleep` or `b_u8g2Sleep` before the main-loop pending wake. It continues to require the shared hardware recovery helper and the existing idempotent display-only path.

# Verification

- `python tools/test_soft_sleep_ads_wake.py` - failed before the implementation change and passed after it.
- `python tools/test_ble_subscription_contract.py` - passed.
- `pio run -e esp32s3` with project-local `PLATFORMIO_CORE_DIR` - passed.
- `git diff origin/main...HEAD --check` - passed.

# Hardware Verification

Not run. No physical BLE/WebSocket soft-sleep cycle, rail timing, ADC recovery, OLED rendering, or weight-stream resumption was exercised.

# Evidence

Before the fix, the focused contract failed because the callbacks published wake state before main-loop recovery. After removing the premature sleep and display assignments, both focused contracts passed. The rebased standard build passed.

# Documentation Impact

No authoritative documentation change was needed. `docs/AI_GPIO_NOTES.md`, `docs/AI_FIRMWARE_NOTES.md`, and `docs/AI_PROTOCOL_NOTES.md` were reviewed.

# Risks and Mitigations

Physical timing was not tested. The implementation removes unsynchronized early publication and leaves the established main-loop recovery path and duplicate-wake routing intact.

# Related Work

PR #83 made duplicate remote wake commands idempotent but retained the premature cross-task state transition.
