### PR TITLE
fix(ota): wake for async updates

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -173,18 +173,11 @@ struct BleDecentCommandSink {
   }
 
   void softSleepOn() {
-    b_softSleep = true;
-    b_u8g2Sleep = true;
     remoteReplacePending(WSP_SLEEP_ON, WSP_SLEEP_OFF);
   }
 
   void softSleepOff() {
-    bool wasSoftSleep = b_softSleep;
-    if (wasSoftSleep) {
-      remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
-    } else {
-      remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
-    }
+    remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON | WSP_DISPLAY_OFF);
   }
 
   void timerStart() {

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -114,7 +114,6 @@ bool b_debug = false;
 
 unsigned long t_batteryIcon = 0;
 bool b_showBatteryIcon = true;
-// volatile: now also written from the AsyncTCP task (WS soft-sleep command).
 volatile bool b_softSleep = false;
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
 bool b_gyroEnabled = true;

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -169,7 +169,12 @@ void processWsPendingCmds() {
   if (mask & WSP_LOWPWR_ON)   { u8g2.setContrast(0); }
   if (mask & WSP_LOWPWR_OFF)  { u8g2.setContrast(255); }
   if (mask & WSP_SLEEP_OFF) {
-    wakeScaleFromSoftSleep("remote soft wake");
+    if (b_softSleep) {
+      wakeScaleFromSoftSleep("remote soft wake");
+    } else {
+      u8g2.setPowerSave(0);
+      b_u8g2Sleep = false;
+    }
   }
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
   if ((mask & WSP_BLE_GYRO) && !(mask & WSP_SLEEP_ON) && !b_softSleep) {
@@ -177,6 +182,8 @@ void processWsPendingCmds() {
   }
 #endif
   if (mask & WSP_SLEEP_ON) {
+    b_softSleep = true;
+    b_u8g2Sleep = true;
     u8g2.setPowerSave(1);
     digitalWrite(PWR_CTRL, LOW);
     digitalWrite(ACC_PWR_CTRL, LOW);
@@ -471,20 +478,13 @@ bool handleWebsocketControlCommand(AsyncWebSocketClient *client, String command,
   if (command == "sleep" || command == "soft_sleep") {
     if (action == "on") {
       Serial.println("Websocket soft sleep on detected.");
-      b_softSleep = true;
-      b_u8g2Sleep = true;
       wsReplacePending(WSP_SLEEP_ON, WSP_SLEEP_OFF);
       sendWebsocketStatus(client, "ok");
       return true;
     }
     if (action == "off" || action == "wake") {
       Serial.println("Websocket soft sleep off detected.");
-      bool wasSoftSleep = b_softSleep;
-      if (wasSoftSleep) {
-        wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);
-      } else {
-        wsReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);
-      }
+      wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON | WSP_DISPLAY_OFF);
       sendWebsocketStatus(client, "ok");
       return true;
     }

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1506,6 +1506,9 @@ void loop() {
   buzzer.check();
 #endif
 
+  if (b_ota && b_softSleep) {
+    wakeScaleFromSoftSleep("OTA wake");
+  }
   if (!b_softSleep) {
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
     if (b_gyroEnabled) {

--- a/tools/test_ota_reboot_routing_contract.py
+++ b/tools/test_ota_reboot_routing_contract.py
@@ -33,7 +33,29 @@ def assert_before(path, first, second):
         raise AssertionError(f"{path.name} must place {first} before {second}")
 
 
+def assert_pending_sleep_ota_interleaving():
+    pending_sleep = True
+    soft_sleep = False
+    rails_on = True
+    ota_active = True
+
+    if ota_active and soft_sleep:
+        soft_sleep = False
+        rails_on = True
+    if pending_sleep:
+        pending_sleep = False
+        soft_sleep = True
+        rails_on = False
+    if ota_active and soft_sleep:
+        soft_sleep = False
+        rails_on = True
+
+    if pending_sleep or soft_sleep or not rails_on:
+        raise AssertionError("OTA wake leaves applied soft sleep or powered-off rails")
+
+
 def main():
+    assert_pending_sleep_ota_interleaving()
     hds = HDS_SOURCE.read_text(encoding="utf-8")
     loop = hds[hds.index("void loop() {"):hds.index("void chargingOLED(")]
     if "if (b_ota || bleHasLiveClient()" not in loop:
@@ -41,6 +63,8 @@ def main():
     ota_wake = 'if (b_ota && b_softSleep) {\n    wakeScaleFromSoftSleep("OTA wake");'
     if ota_wake not in loop:
         raise AssertionError("active OTA does not wake soft-sleep hardware")
+    if loop.index("processWsPendingCmds();") > loop.index(ota_wake):
+        raise AssertionError("pending sleep must be applied before OTA wake")
     if loop.index(ota_wake) > loop.index("if (!b_softSleep)"):
         raise AssertionError("OTA wake runs after the sleeping-loop gate")
 

--- a/tools/test_ota_reboot_routing_contract.py
+++ b/tools/test_ota_reboot_routing_contract.py
@@ -38,6 +38,11 @@ def main():
     loop = hds[hds.index("void loop() {"):hds.index("void chargingOLED(")]
     if "if (b_ota || bleHasLiveClient()" not in loop:
         raise AssertionError("OTA does not suspend the auto-sleep countdown")
+    ota_wake = 'if (b_ota && b_softSleep) {\n    wakeScaleFromSoftSleep("OTA wake");'
+    if ota_wake not in loop:
+        raise AssertionError("active OTA does not wake soft-sleep hardware")
+    if loop.index(ota_wake) > loop.index("if (!b_softSleep)"):
+        raise AssertionError("OTA wake runs after the sleeping-loop gate")
 
     # ElegantOTA's own auto-reboot bypasses reset()'s mDNS withdrawal; the
     # restart must be queued through the main-loop reset mechanism instead.

--- a/tools/test_soft_sleep_ads_wake.py
+++ b/tools/test_soft_sleep_ads_wake.py
@@ -92,14 +92,16 @@ def main():
         ],
     )
 
+    ble_soft_on = method_body(BLE_HEADER, "softSleepOn")
+    if "b_softSleep = true;" in ble_soft_on or "b_u8g2Sleep = true;" in ble_soft_on:
+        raise AssertionError("BLE sleep publishes state before main-loop rail shutdown")
+    assert_ordered(ble_soft_on, ["remoteReplacePending(WSP_SLEEP_ON, WSP_SLEEP_OFF);"])
+
     ble_soft_off = method_body(BLE_HEADER, "softSleepOff")
     assert_ordered(
         ble_soft_off,
         [
-            "bool wasSoftSleep = b_softSleep;",
-            "if (wasSoftSleep)",
-            "remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
-            "remoteReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
+            "remoteReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON | WSP_DISPLAY_OFF);",
         ],
     )
     if "b_softSleep = false;" in ble_soft_off or "b_u8g2Sleep = false;" in ble_soft_off:
@@ -121,14 +123,17 @@ def main():
     ws_wake_start = ws_handler.index('if (action == "off" || action == "wake")')
     ws_wake_end = ws_handler.index('sendWebsocketStatus(client, "ok");', ws_wake_start)
     ws_wake = ws_handler[ws_wake_start:ws_wake_end]
+    ws_sleep_start = ws_handler.index('if (action == "on")', ws_handler.index('if (command == "sleep"'))
+    ws_sleep_end = ws_handler.index('sendWebsocketStatus(client, "ok");', ws_sleep_start)
+    ws_sleep = ws_handler[ws_sleep_start:ws_sleep_end]
+    if "b_softSleep = true;" in ws_sleep or "b_u8g2Sleep = true;" in ws_sleep:
+        raise AssertionError("WebSocket sleep publishes state before main-loop rail shutdown")
+    assert_ordered(ws_sleep, ["wsReplacePending(WSP_SLEEP_ON, WSP_SLEEP_OFF);"])
     assert_ordered(
         ws_wake,
         [
             'if (action == "off" || action == "wake")',
-            "bool wasSoftSleep = b_softSleep;",
-            "if (wasSoftSleep)",
-            "wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON);",
-            "wsReplacePending(WSP_DISPLAY_ON, WSP_DISPLAY_OFF);",
+            "wsReplacePending(WSP_SLEEP_OFF, WSP_SLEEP_ON | WSP_DISPLAY_OFF);",
         ],
     )
     if "b_softSleep = false;" in ws_wake or "b_u8g2Sleep = false;" in ws_wake:
@@ -139,8 +144,28 @@ def main():
     sleep_off_index = ws_pending.index("if (mask & WSP_SLEEP_OFF)")
     sleep_on_index = ws_pending.index("if (mask & WSP_SLEEP_ON)")
     sleep_off_body = ws_pending[sleep_off_index:sleep_on_index]
+    assert_ordered(
+        sleep_off_body,
+        [
+            "if (b_softSleep)",
+            'wakeScaleFromSoftSleep("remote soft wake")',
+            "u8g2.setPowerSave(0);",
+            "b_u8g2Sleep = false;",
+        ],
+    )
     if "digitalWrite(PWR_CTRL, HIGH);" in sleep_off_body:
         raise AssertionError("remote soft wake must use wakeScaleFromSoftSleep")
+    sleep_on_body = ws_pending[sleep_on_index:]
+    assert_ordered(
+        sleep_on_body,
+        [
+            "b_softSleep = true;",
+            "b_u8g2Sleep = true;",
+            "u8g2.setPowerSave(1);",
+            "digitalWrite(PWR_CTRL, LOW);",
+            "digitalWrite(ACC_PWR_CTRL, LOW);",
+        ],
+    )
 
     print("soft sleep ADS wake tests passed")
 


### PR DESCRIPTION
# Summary

- Wake soft-sleep hardware from the main loop whenever OTA becomes active.
- Make `b_softSleep` describe applied rail state rather than an asynchronous sleep request.
- Queue BLE and WebSocket sleep intent until the main loop performs the hardware transition.
- Keep all rail, ADC, and OLED work out of AsyncTCP and BLE callbacks.

# Root Cause

WiFi remains active during soft sleep, so ElegantOTA can start from the asynchronous HTTP task while `b_softSleep` is true. OTA servicing is inside the awake-only loop section; without a main-loop wake, failure handling cannot clear `b_ota` and the scale can remain stuck in update mode.

The original wake guard also raced with pending remote sleep. BLE and WebSocket callbacks published `b_softSleep = true` before `WSP_SLEEP_ON` actually powered the rails down. OTA could clear that requested state, after which the still-pending command powered the rails down without restoring `b_softSleep`, leaving the software state and hardware state inconsistent.

# Implementation

- `processWsPendingCmds()` now publishes soft-sleep state beside the actual rail shutdown.
- BLE and WebSocket callbacks only replace the pending sleep command.
- A wake request atomically replaces pending sleep/display-off intent and is interpreted against applied state in the main loop.
- `processWsPendingCmds()` runs before the OTA wake guard, so a pending sleep is applied and immediately recovered in the same loop pass when OTA is active.

# Safety / Reliability Impact

Async callbacks still perform no OLED, SPI, I2C, rail, or ADC work. The main loop remains the sole owner of remote sleep hardware transitions, and OTA servicing always reaches a powered, internally consistent state.

# Compatibility

No HTTP endpoint, manifest, BLE, USB, WebSocket, storage, or reboot wire contract changes. Starting ElegantOTA while soft asleep now wakes the scale and display. Native, grinder, custom, and hardware targets were intentionally not run.

# Regression Coverage

- `tools/test_ota_reboot_routing_contract.py` exercises pending-sleep plus asynchronous OTA start and requires pending-command dispatch before OTA recovery.
- `tools/test_soft_sleep_ads_wake.py` requires callbacks to defer state publication, latest wake intent to replace pending sleep, and applied state to change beside rail shutdown.

# Verification

- `python tools/test_ota_reboot_routing_contract.py`
- `python tools/test_soft_sleep_ads_wake.py`
- `python tools/test_pull_ota_contract.py`
- `python tools/test_ota_input_isolation_contract.py`
- `python tools/test_charging_wake_contract.py`
- `python tools/test_ble_subscription_contract.py`
- `pio run -e esp32s3` with an isolated `PLATFORMIO_CORE_DIR`
- `git diff --check`

All passed. The ESP32-S3 build retains only the existing volatile-increment warnings in `src/wifi_setup.cpp`.

# Hardware Verification

Not run. No physical soft-sleep HTTP upload, induced failure, recovery, or reboot was exercised.
