### PR TITLE
chore: update ADS1232 dependency

### DIFF
--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -14,6 +14,16 @@ pio run -e esp32s3 -t uploadfs --upload-port <port>
 
 Firmware-only flashing does not update `web_apps/`. Flash LittleFS when the on-device web UI matters.
 
+## Environment Selection
+
+Build only the environments affected by the change:
+
+- Use `esp32s3` for changes limited to core firmware, weighing, or ADS communication, including an ADS1232 dependency-pin update.
+- Add `esp32s3-grinder` only for grinder-specific code, feature flags, or build configuration.
+- Add `esp32s3-custom` only for custom-build composition, patches, generated inputs, or shared feature-selection changes.
+
+Do not add an environment merely because it exists. Changes limited to ADS1232 behavior or its dependency pin do not require the grinder or custom environments; those environments do not alter the weighing or ADS communication path.
+
 ## PlatformIO Details
 
 - `platformio.ini` uses `.pio.nosync` as the workspace directory.

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,7 +65,7 @@ lib_compat_mode = strict
 lib_deps =
   bblanchon/ArduinoJson @ 7.4.3
   bxparks/AceButton @ 1.10.1
-  https://github.com/decentespresso/ADS1232_ADC.git#24cd10d3037c878f751a057377303598a00f977e
+  https://github.com/decentespresso/ADS1232_ADC.git#a5a0b5cd9ba5a44860f3ea623d48a5c008f93c4b
   robtillaart/StopWatch @ 0.3.6
   adafruit/Adafruit ADS1X15 @ 2.6.2
   adafruit/Adafruit BusIO @ 1.17.4


### PR DESCRIPTION
## Summary

- update the pinned ADS1232_ADC revision from `24cd10d3037c878f751a057377303598a00f977e` to `a5a0b5cd9ba5a44860f3ea623d48a5c008f93c4b`
- consume merged ADS1232_ADC PRs [#9](https://github.com/decentespresso/ADS1232_ADC/pull/9), [#12](https://github.com/decentespresso/ADS1232_ADC/pull/12), and [#13](https://github.com/decentespresso/ADS1232_ADC/pull/13)

## Verification

- `python tools/test_ai_docs_contract.py`
- `pio run -e esp32s3`
- `pio run -e esp32s3-grinder`
- `pio run -e esp32s3-custom`

PlatformIO resolved `ADS1232_ADC @ 1.0.0+sha.a5a0b5c`.

Physical OpenScale boot, wake, recovery, and weight validation have not been run with this new pin.