### PR TITLE
perf(memory): reduce permanent RAM use

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -135,6 +135,7 @@ jobs:
         run: >-
           python tools/build_custom_firmware.py
           --config .pio.nosync/plugin-ci.json
+          --source-commit "${{ github.sha }}"
           --verify-plugin-environment "esp32s3-$PLUGIN_ID"
 
   build:

--- a/docs/custom-build/service-catalog.json
+++ b/docs/custom-build/service-catalog.json
@@ -74,7 +74,7 @@
       "conflicts": [],
       "patches": {
         "main": {
-          "sha256": "32c1e4f31e7ff3240d73617e1c3e7824885abf1eccee53d341536971242edce4"
+          "sha256": "43c35d610c68839baf2d9882a73307a2bdcf43eeb26e56e94d031d8691c394dd"
         }
       },
       "assets": []

--- a/include/finger_detection.h
+++ b/include/finger_detection.h
@@ -10,6 +10,7 @@
 void sendWebsocketButton(int buttonNumber, int buttonShortPress);
 #endif
 #define TOTAL_SAMPLES 50           // Total samples per button
+static_assert(TOTAL_SAMPLES < 255);
 bool b_fingerDetectionSerialOutput = false;
 
 #define CIRCLE_POST_RELEASE_DURATION 500      // Circle button post-release sampling duration(ms)
@@ -34,11 +35,9 @@ enum SamplingPhase {
 
 struct PressSample {
   float weight;
-  unsigned long timestamp;
-  bool is_release_point;
 };
 
-static_assert(sizeof(PressSample) == 12);
+static_assert(sizeof(PressSample) == 4);
 
 struct ButtonPressData {
   PressSample samples[TOTAL_SAMPLES];
@@ -47,6 +46,7 @@ struct ButtonPressData {
   unsigned long press_start_time;
   unsigned long release_time;
   unsigned long last_sample_real_time;
+  uint8_t release_index;
   bool is_active;
 };
 
@@ -98,27 +98,26 @@ bool isFingerPress(int button) {
     return isQuickTap(button);
   }
 
-  int release_index = -1;
+  int release_index = data->release_index;
   float start_weight = data->samples[0].weight;
   float peak_weight = start_weight;
   int peak_index = 0;
 
   for (int i = 0; i < data->sample_index; i++) {
-    if (data->samples[i].is_release_point) {
-      release_index = i;
-    }
     if (data->samples[i].weight > peak_weight) {
       peak_weight = data->samples[i].weight;
       peak_index = i;
     }
   }
 
-  if (release_index < 0) release_index = data->sample_index - 1;
+  if (release_index >= data->sample_index) release_index = data->sample_index - 1;
 
   float final_weight = data->samples[data->sample_index-1].weight;
 
-  unsigned long press_duration = data->samples[release_index].timestamp;
-  unsigned long total_duration = data->samples[data->sample_index-1].timestamp;
+  const unsigned long press_sample_time = data->release_index < data->sample_index ? data->release_time : data->last_sample_real_time;
+  const unsigned long final_sample_time = data->release_index == data->sample_index - 1 ? data->release_time : data->last_sample_real_time;
+  unsigned long press_duration = press_sample_time - data->press_start_time;
+  unsigned long total_duration = final_sample_time - data->press_start_time;
 
   float peak_change = peak_weight - start_weight;
   float net_change = final_weight - start_weight;
@@ -264,28 +263,28 @@ void analyzeCompletePressData(int button) {
     Serial.println(String(70, '='));
   }
 
-  int release_index = -1;
+  int release_index = data->release_index;
   float start_weight = data->samples[0].weight;
   float peak_weight = start_weight;
   int peak_index = 0;
 
   for (int i = 0; i < data->sample_index; i++) {
-    if (data->samples[i].is_release_point) {
-      release_index = i;
-    }
     if (data->samples[i].weight > peak_weight) {
       peak_weight = data->samples[i].weight;
       peak_index = i;
     }
   }
 
-  if (release_index < 0) release_index = data->sample_index - 1;
+  if (release_index >= data->sample_index) release_index = data->sample_index - 1;
 
   float final_weight = data->samples[data->sample_index-1].weight;
 
+  const unsigned long press_sample_time = data->release_index < data->sample_index ? data->release_time : data->last_sample_real_time;
+  const unsigned long final_sample_time = data->release_index == data->sample_index - 1 ? data->release_time : data->last_sample_real_time;
+  const unsigned long total_duration_ms = final_sample_time - data->press_start_time;
   float avg_interval = 0;
   if (data->sample_index > 1) {
-    avg_interval = data->samples[data->sample_index-1].timestamp / (float)(data->sample_index-1);
+    avg_interval = total_duration_ms / (float)(data->sample_index-1);
   }
 
   if (b_fingerDetectionSerialOutput) {
@@ -298,8 +297,8 @@ void analyzeCompletePressData(int button) {
     Serial.println("\n--- KEY METRICS ---");
   }
 
-  float press_duration = data->samples[release_index].timestamp;
-  float total_duration = data->samples[data->sample_index-1].timestamp;
+  float press_duration = press_sample_time - data->press_start_time;
+  float total_duration = total_duration_ms;
   float recovery_duration = total_duration - press_duration;
 
   float press_increase = peak_weight - start_weight;
@@ -359,12 +358,11 @@ void startPressSampling(int button) {
   data->sample_index = 0;
   data->press_start_time = millis();
   data->last_sample_real_time = data->press_start_time;
+  data->release_index = TOTAL_SAMPLES;
   data->is_active = true;
 
   if (data->sample_index < TOTAL_SAMPLES) {
     data->samples[data->sample_index].weight = f_current_raw_value;
-    data->samples[data->sample_index].timestamp = 0;
-    data->samples[data->sample_index].is_release_point = false;
     data->sample_index++;
   }
   if (b_fingerDetectionSerialOutput) {
@@ -384,9 +382,8 @@ void onButtonReleased(int button) {
   data->current_phase = PHASE_RECOVERING;
 
   if (data->sample_index < TOTAL_SAMPLES) {
+    data->release_index = data->sample_index;
     data->samples[data->sample_index].weight = f_current_raw_value;
-    data->samples[data->sample_index].timestamp = data->release_time - data->press_start_time;
-    data->samples[data->sample_index].is_release_point = true;
     data->sample_index++;
   }
   if (b_fingerDetectionSerialOutput) {
@@ -438,8 +435,6 @@ void updatePressSampling() {
       float current_weight = f_current_raw_value;
 
       data->samples[data->sample_index].weight = current_weight;
-      data->samples[data->sample_index].timestamp = current_time - data->press_start_time;
-      data->samples[data->sample_index].is_release_point = false;
 
       data->sample_index++;
       data->last_sample_real_time = current_time;

--- a/include/finger_detection.h
+++ b/include/finger_detection.h
@@ -35,9 +35,10 @@ enum SamplingPhase {
 struct PressSample {
   float weight;
   unsigned long timestamp;
-  SamplingPhase phase;
   bool is_release_point;
 };
+
+static_assert(sizeof(PressSample) == 12);
 
 struct ButtonPressData {
   PressSample samples[TOTAL_SAMPLES];
@@ -45,8 +46,6 @@ struct ButtonPressData {
   SamplingPhase current_phase;
   unsigned long press_start_time;
   unsigned long release_time;
-  float release_weight;
-  float last_sampled_weight;
   unsigned long last_sample_real_time;
   bool is_active;
 };
@@ -360,13 +359,11 @@ void startPressSampling(int button) {
   data->sample_index = 0;
   data->press_start_time = millis();
   data->last_sample_real_time = data->press_start_time;
-  data->last_sampled_weight = f_current_raw_value;
   data->is_active = true;
 
   if (data->sample_index < TOTAL_SAMPLES) {
     data->samples[data->sample_index].weight = f_current_raw_value;
     data->samples[data->sample_index].timestamp = 0;
-    data->samples[data->sample_index].phase = PHASE_PRESSING;
     data->samples[data->sample_index].is_release_point = false;
     data->sample_index++;
   }
@@ -384,13 +381,11 @@ void onButtonReleased(int button) {
   if (!data || data->current_phase != PHASE_PRESSING) return;
 
   data->release_time = millis();
-  data->release_weight = f_current_raw_value;
   data->current_phase = PHASE_RECOVERING;
 
   if (data->sample_index < TOTAL_SAMPLES) {
-    data->samples[data->sample_index].weight = data->release_weight;
+    data->samples[data->sample_index].weight = f_current_raw_value;
     data->samples[data->sample_index].timestamp = data->release_time - data->press_start_time;
-    data->samples[data->sample_index].phase = PHASE_RECOVERING;
     data->samples[data->sample_index].is_release_point = true;
     data->sample_index++;
   }
@@ -444,12 +439,10 @@ void updatePressSampling() {
 
       data->samples[data->sample_index].weight = current_weight;
       data->samples[data->sample_index].timestamp = current_time - data->press_start_time;
-      data->samples[data->sample_index].phase = data->current_phase;
       data->samples[data->sample_index].is_release_point = false;
 
       data->sample_index++;
       data->last_sample_real_time = current_time;
-      data->last_sampled_weight = current_weight;
     } else {
       if (b_fingerDetectionSerialOutput) {
         Serial.print(button == BUTTON_CIRCLE ? "Circle" : "Square");

--- a/include/menu.h
+++ b/include/menu.h
@@ -11,7 +11,7 @@
 #include "grinder_runtime.h"
 #endif
 #include <string.h>
-const char *weights[] = { "Exit", "50g", "100g", "200g", "500g", "1000g" };
+const char *const weights[] = { "Exit", "50g", "100g", "200g", "500g", "1000g" };
 const float weight_values[] = { 0.0, 50.0, 100.0, 200.0, 500.0, 1000.0 };
 bool b_showAbout = false;
 bool b_showLogo = false;
@@ -115,11 +115,11 @@ Menu menuGrinder = { "Grind by weight", NULL, NULL, NULL };
 Menu menuBuzzerBack = { "Back", NULL, NULL, &menuBuzzer };
 Menu menuBuzzerOn = { "Buzzer On", buzzerOn, NULL, &menuBuzzer };
 Menu menuBuzzerOff = { "Buzzer Off", buzzerOff, NULL, &menuBuzzer };
-Menu *buzzerMenu[] = { &menuBuzzerBack, &menuBuzzerOn, &menuBuzzerOff };
+Menu *const buzzerMenu[] = { &menuBuzzerBack, &menuBuzzerOn, &menuBuzzerOff };
 #endif
 Menu menuCalibrationBack = { "Back", NULL, NULL, &menuCalibration };
 Menu menuCalibrate = { "Calibrate", calibrate, NULL, &menuCalibration };
-Menu *calibrationMenu[] = { &menuCalibrationBack, &menuCalibrate };
+Menu *const calibrationMenu[] = { &menuCalibrationBack, &menuCalibrate };
 
 #if HDS_FEATURE_WIFI
 Menu menuWiFiUpdateBack = { "Back", NULL, NULL, &menuWifi };
@@ -131,7 +131,7 @@ Menu menuWiFiPullUpdateOption = { "WiFi Update", wifiUpdate, NULL, &menuWifi };
 #endif
 Menu menuWiFiResetOption = { "Reset WiFi", resetWifi, NULL, &menuWifi };
 
-Menu *wifiUpdateMenu[] = {
+Menu *const wifiUpdateMenu[] = {
   &menuWiFiUpdateBack,
   &menuWiFiOnOption,
   &menuWiFiOffOption,
@@ -146,19 +146,19 @@ Menu *wifiUpdateMenu[] = {
 Menu menuHeartbeatBack = { "Back", NULL, NULL, &menuHeartbeat };
 Menu menuHeartbeatOn = { "Heartbeat On", heartbeatOn, NULL, &menuHeartbeat };
 Menu menuHeartbeatOff = { "Heartbeat Off", heartbeatOff, NULL, &menuHeartbeat };
-Menu *heartbeatMenu[] = { &menuHeartbeatBack, &menuHeartbeatOn,
+Menu *const heartbeatMenu[] = { &menuHeartbeatBack, &menuHeartbeatOn,
                           &menuHeartbeatOff };
 
 Menu menuFlipScreenBack = { "Back", NULL, NULL, &menuFlipScreen };
 Menu menuFlipScreenOn = { "Flip On", flipScreenOn, NULL, &menuFlipScreen };
 Menu menuFlipScreenOff = { "Flip Off", flipScreenOff, NULL, &menuFlipScreen };
-Menu *flipScreenMenu[] = { &menuFlipScreenBack, &menuFlipScreenOn,
+Menu *const flipScreenMenu[] = { &menuFlipScreenBack, &menuFlipScreenOn,
                            &menuFlipScreenOff };
 
 Menu menuTimeOnTopBack = { "Back", NULL, NULL, &menuTimeOnTop };
 Menu menuTimeOnTopOn = { "Time On Top", timeOnTopOn, NULL, &menuTimeOnTop };
 Menu menuTimeOnTopOff = { "Weight On Top", timeOnTopOff, NULL, &menuTimeOnTop };
-Menu *timeOnTopMenu[] = { &menuTimeOnTopBack, &menuTimeOnTopOn,
+Menu *const timeOnTopMenu[] = { &menuTimeOnTopBack, &menuTimeOnTopOn,
                           &menuTimeOnTopOff };
 
 Menu menuBtnFuncWhileConnectedBack = { "Back", NULL, NULL,
@@ -168,19 +168,19 @@ Menu menuBtnFuncWhileConnectedOn = { "Enable Buttons", btnFuncWhileConnectedOn,
 Menu menuBtnFuncWhileConnectedOff = { "Disable Buttons",
                                       btnFuncWhileConnectedOff, NULL,
                                       &menuBtnFuncWhileConnected };
-Menu *btnFuncWhileConnectedMenu[] = { &menuBtnFuncWhileConnectedBack,
+Menu *const btnFuncWhileConnectedMenu[] = { &menuBtnFuncWhileConnectedBack,
                                       &menuBtnFuncWhileConnectedOn,
                                       &menuBtnFuncWhileConnectedOff };
 
 Menu menuAutoSleepBack = { "Back", NULL, NULL, &menuAutoSleep };
 Menu menuAutoSleepOn = { "Auto Sleep On", autoSleepOn, NULL, &menuAutoSleep };
 Menu menuAutoSleepOff = { "Auto Sleep Off", autoSleepOff, NULL, &menuAutoSleep };
-Menu *autoSleepMenu[] = { &menuAutoSleepBack, &menuAutoSleepOn, &menuAutoSleepOff };
+Menu *const autoSleepMenu[] = { &menuAutoSleepBack, &menuAutoSleepOn, &menuAutoSleepOff };
 
 Menu menuQuickBootBack = { "Back", NULL, NULL, &menuQuickBoot };
 Menu menuQuickBootOn = { "Quick Boot On", quickBootOn, NULL, &menuQuickBoot };
 Menu menuQuickBootOff = { "Quick Boot Off", quickBootOff, NULL, &menuQuickBoot };
-Menu *quickBootMenu[] = { &menuQuickBootBack, &menuQuickBootOn, &menuQuickBootOff };
+Menu *const quickBootMenu[] = { &menuQuickBootBack, &menuQuickBootOn, &menuQuickBootOff };
 
 Menu menuDriftCompBack = { "Back", NULL, NULL, &menuDriftComp };
 Menu menuDriftCompOff = { "Drift Comp Off", driftCompOff, NULL, &menuDriftComp };
@@ -188,7 +188,7 @@ Menu menuQuickBoot0050 = { "0.05g", driftComp0050, NULL, &menuDriftComp };
 Menu menuQuickBoot0075 = { "0.075g", driftComp0075, NULL, &menuDriftComp };
 Menu menuQuickBoot0100 = { "0.1g", driftComp0100, NULL, &menuDriftComp };
 Menu menuQuickBoot0200 = { "0.2g", driftComp0200, NULL, &menuDriftComp };
-Menu *driftCompMenu[] = { &menuDriftCompBack, &menuDriftCompOff, &menuQuickBoot0050, &menuQuickBoot0075, &menuQuickBoot0100, &menuQuickBoot0200 };
+Menu *const driftCompMenu[] = { &menuDriftCompBack, &menuDriftCompOff, &menuQuickBoot0050, &menuQuickBoot0075, &menuQuickBoot0100, &menuQuickBoot0200 };
 
 #if HDS_ENABLE_GRINDER
 Menu menuGrinderBack = { "Back", NULL, NULL, &menuGrinder };
@@ -198,11 +198,11 @@ Menu menuGrinderSelect = { "Select Plug", grinderSelectPlugMenu, NULL, &menuGrin
 Menu menuGrinderTarget = { "Target g", grinderTargetMenu, NULL, &menuGrinder };
 Menu menuGrinderSafety = { "Safety g", grinderSafetyMenu, NULL, &menuGrinder };
 Menu menuGrinderZero = { "Zero Range", grinderZeroRangeMenu, NULL, &menuGrinder };
-Menu *grinderMenu[] = { &menuGrinderBack, &menuGrinderOn, &menuGrinderOff, &menuGrinderSelect, &menuGrinderTarget, &menuGrinderSafety, &menuGrinderZero };
+Menu *const grinderMenu[] = { &menuGrinderBack, &menuGrinderOn, &menuGrinderOff, &menuGrinderSelect, &menuGrinderTarget, &menuGrinderSafety, &menuGrinderZero };
 #endif
 
 
-Menu *mainMenu[] = {
+Menu *const mainMenu[] = {
   &menuExit,
 #ifdef BUZZER
   &menuBuzzer,
@@ -218,7 +218,7 @@ Menu *mainMenu[] = {
   &menuGrinder,
 #endif
 };
-Menu **currentMenu = mainMenu;
+Menu *const *currentMenu = mainMenu;
 Menu *currentSelection = mainMenu[0];
 int currentMenuSize = getMenuSize(mainMenu);
 int currentIndex = 0;

--- a/include/menu.h
+++ b/include/menu.h
@@ -29,7 +29,7 @@ template<typename T> int getMenuSize(T &menu) {
 struct Menu {
   const char *name;
   void (*action)();
-  Menu *subMenu;
+  const Menu *subMenu;
   Menu *parentMenu;
 };
 
@@ -87,7 +87,7 @@ void wifi_init();
 #endif
 
 
-Menu menuExit = { "Exit", exitMenu, NULL, NULL };
+const Menu menuExit = { "Exit", exitMenu, NULL, NULL };
 #ifdef BUZZER
 Menu menuBuzzer = { "Buzzer", NULL, NULL, NULL };
 #endif
@@ -95,10 +95,10 @@ Menu menuCalibration = { "Calibration", NULL, NULL, NULL };
 #if HDS_FEATURE_WIFI
 Menu menuWifi = { "WiFi Settings", NULL, NULL, NULL };
 #endif
-Menu menuStatus = { "Status", showStatus, NULL, NULL };
-Menu menuAbout = { "About", showAbout, NULL, NULL };
-Menu menuLogo = { "Show Logo", showLogo, NULL, NULL };
-Menu menuFactory = { "Factory", NULL, NULL, NULL };
+const Menu menuStatus = { "Status", showStatus, NULL, NULL };
+const Menu menuAbout = { "About", showAbout, NULL, NULL };
+const Menu menuLogo = { "Show Logo", showLogo, NULL, NULL };
+const Menu menuFactory = { "Factory", NULL, NULL, NULL };
 Menu menuHeartbeat = { "Heartbeat", NULL, NULL, NULL };
 Menu menuFlipScreen = { "Flip Screen", NULL, NULL, NULL };
 Menu menuTimeOnTop = { "Time On Top", NULL, NULL, NULL };
@@ -112,26 +112,26 @@ Menu menuGrinder = { "Grind by weight", NULL, NULL, NULL };
 
 
 #ifdef BUZZER
-Menu menuBuzzerBack = { "Back", NULL, NULL, &menuBuzzer };
-Menu menuBuzzerOn = { "Buzzer On", buzzerOn, NULL, &menuBuzzer };
-Menu menuBuzzerOff = { "Buzzer Off", buzzerOff, NULL, &menuBuzzer };
-Menu *const buzzerMenu[] = { &menuBuzzerBack, &menuBuzzerOn, &menuBuzzerOff };
+const Menu menuBuzzerBack = { "Back", NULL, NULL, &menuBuzzer };
+const Menu menuBuzzerOn = { "Buzzer On", buzzerOn, NULL, &menuBuzzer };
+const Menu menuBuzzerOff = { "Buzzer Off", buzzerOff, NULL, &menuBuzzer };
+const Menu *const buzzerMenu[] = { &menuBuzzerBack, &menuBuzzerOn, &menuBuzzerOff };
 #endif
-Menu menuCalibrationBack = { "Back", NULL, NULL, &menuCalibration };
-Menu menuCalibrate = { "Calibrate", calibrate, NULL, &menuCalibration };
-Menu *const calibrationMenu[] = { &menuCalibrationBack, &menuCalibrate };
+const Menu menuCalibrationBack = { "Back", NULL, NULL, &menuCalibration };
+const Menu menuCalibrate = { "Calibrate", calibrate, NULL, &menuCalibration };
+const Menu *const calibrationMenu[] = { &menuCalibrationBack, &menuCalibrate };
 
 #if HDS_FEATURE_WIFI
-Menu menuWiFiUpdateBack = { "Back", NULL, NULL, &menuWifi };
-Menu menuWiFiOnOption = { "WiFi On", toggleWifiOn, NULL, &menuWifi };
-Menu menuWiFiOffOption = { "WiFi Off", toggleWifiOff, NULL, &menuWifi };
-Menu menuWiFiStatusOption = { "WiFi Status", showWifiStatus, NULL, &menuWifi };
+const Menu menuWiFiUpdateBack = { "Back", NULL, NULL, &menuWifi };
+const Menu menuWiFiOnOption = { "WiFi On", toggleWifiOn, NULL, &menuWifi };
+const Menu menuWiFiOffOption = { "WiFi Off", toggleWifiOff, NULL, &menuWifi };
+const Menu menuWiFiStatusOption = { "WiFi Status", showWifiStatus, NULL, &menuWifi };
 #if HDS_FEATURE_PULL_OTA
-Menu menuWiFiPullUpdateOption = { "WiFi Update", wifiUpdate, NULL, &menuWifi };
+const Menu menuWiFiPullUpdateOption = { "WiFi Update", wifiUpdate, NULL, &menuWifi };
 #endif
-Menu menuWiFiResetOption = { "Reset WiFi", resetWifi, NULL, &menuWifi };
+const Menu menuWiFiResetOption = { "Reset WiFi", resetWifi, NULL, &menuWifi };
 
-Menu *const wifiUpdateMenu[] = {
+const Menu *const wifiUpdateMenu[] = {
   &menuWiFiUpdateBack,
   &menuWiFiOnOption,
   &menuWiFiOffOption,
@@ -143,66 +143,66 @@ Menu *const wifiUpdateMenu[] = {
 };
 #endif
 
-Menu menuHeartbeatBack = { "Back", NULL, NULL, &menuHeartbeat };
-Menu menuHeartbeatOn = { "Heartbeat On", heartbeatOn, NULL, &menuHeartbeat };
-Menu menuHeartbeatOff = { "Heartbeat Off", heartbeatOff, NULL, &menuHeartbeat };
-Menu *const heartbeatMenu[] = { &menuHeartbeatBack, &menuHeartbeatOn,
+const Menu menuHeartbeatBack = { "Back", NULL, NULL, &menuHeartbeat };
+const Menu menuHeartbeatOn = { "Heartbeat On", heartbeatOn, NULL, &menuHeartbeat };
+const Menu menuHeartbeatOff = { "Heartbeat Off", heartbeatOff, NULL, &menuHeartbeat };
+const Menu *const heartbeatMenu[] = { &menuHeartbeatBack, &menuHeartbeatOn,
                           &menuHeartbeatOff };
 
-Menu menuFlipScreenBack = { "Back", NULL, NULL, &menuFlipScreen };
-Menu menuFlipScreenOn = { "Flip On", flipScreenOn, NULL, &menuFlipScreen };
-Menu menuFlipScreenOff = { "Flip Off", flipScreenOff, NULL, &menuFlipScreen };
-Menu *const flipScreenMenu[] = { &menuFlipScreenBack, &menuFlipScreenOn,
+const Menu menuFlipScreenBack = { "Back", NULL, NULL, &menuFlipScreen };
+const Menu menuFlipScreenOn = { "Flip On", flipScreenOn, NULL, &menuFlipScreen };
+const Menu menuFlipScreenOff = { "Flip Off", flipScreenOff, NULL, &menuFlipScreen };
+const Menu *const flipScreenMenu[] = { &menuFlipScreenBack, &menuFlipScreenOn,
                            &menuFlipScreenOff };
 
-Menu menuTimeOnTopBack = { "Back", NULL, NULL, &menuTimeOnTop };
-Menu menuTimeOnTopOn = { "Time On Top", timeOnTopOn, NULL, &menuTimeOnTop };
-Menu menuTimeOnTopOff = { "Weight On Top", timeOnTopOff, NULL, &menuTimeOnTop };
-Menu *const timeOnTopMenu[] = { &menuTimeOnTopBack, &menuTimeOnTopOn,
+const Menu menuTimeOnTopBack = { "Back", NULL, NULL, &menuTimeOnTop };
+const Menu menuTimeOnTopOn = { "Time On Top", timeOnTopOn, NULL, &menuTimeOnTop };
+const Menu menuTimeOnTopOff = { "Weight On Top", timeOnTopOff, NULL, &menuTimeOnTop };
+const Menu *const timeOnTopMenu[] = { &menuTimeOnTopBack, &menuTimeOnTopOn,
                           &menuTimeOnTopOff };
 
-Menu menuBtnFuncWhileConnectedBack = { "Back", NULL, NULL,
+const Menu menuBtnFuncWhileConnectedBack = { "Back", NULL, NULL,
                                        &menuBtnFuncWhileConnected };
-Menu menuBtnFuncWhileConnectedOn = { "Enable Buttons", btnFuncWhileConnectedOn,
+const Menu menuBtnFuncWhileConnectedOn = { "Enable Buttons", btnFuncWhileConnectedOn,
                                      NULL, &menuBtnFuncWhileConnected };
-Menu menuBtnFuncWhileConnectedOff = { "Disable Buttons",
-                                      btnFuncWhileConnectedOff, NULL,
-                                      &menuBtnFuncWhileConnected };
-Menu *const btnFuncWhileConnectedMenu[] = { &menuBtnFuncWhileConnectedBack,
-                                      &menuBtnFuncWhileConnectedOn,
-                                      &menuBtnFuncWhileConnectedOff };
+const Menu menuBtnFuncWhileConnectedOff = { "Disable Buttons",
+                                       btnFuncWhileConnectedOff, NULL,
+                                       &menuBtnFuncWhileConnected };
+const Menu *const btnFuncWhileConnectedMenu[] = { &menuBtnFuncWhileConnectedBack,
+                                       &menuBtnFuncWhileConnectedOn,
+                                       &menuBtnFuncWhileConnectedOff };
 
-Menu menuAutoSleepBack = { "Back", NULL, NULL, &menuAutoSleep };
-Menu menuAutoSleepOn = { "Auto Sleep On", autoSleepOn, NULL, &menuAutoSleep };
-Menu menuAutoSleepOff = { "Auto Sleep Off", autoSleepOff, NULL, &menuAutoSleep };
-Menu *const autoSleepMenu[] = { &menuAutoSleepBack, &menuAutoSleepOn, &menuAutoSleepOff };
+const Menu menuAutoSleepBack = { "Back", NULL, NULL, &menuAutoSleep };
+const Menu menuAutoSleepOn = { "Auto Sleep On", autoSleepOn, NULL, &menuAutoSleep };
+const Menu menuAutoSleepOff = { "Auto Sleep Off", autoSleepOff, NULL, &menuAutoSleep };
+const Menu *const autoSleepMenu[] = { &menuAutoSleepBack, &menuAutoSleepOn, &menuAutoSleepOff };
 
-Menu menuQuickBootBack = { "Back", NULL, NULL, &menuQuickBoot };
-Menu menuQuickBootOn = { "Quick Boot On", quickBootOn, NULL, &menuQuickBoot };
-Menu menuQuickBootOff = { "Quick Boot Off", quickBootOff, NULL, &menuQuickBoot };
-Menu *const quickBootMenu[] = { &menuQuickBootBack, &menuQuickBootOn, &menuQuickBootOff };
+const Menu menuQuickBootBack = { "Back", NULL, NULL, &menuQuickBoot };
+const Menu menuQuickBootOn = { "Quick Boot On", quickBootOn, NULL, &menuQuickBoot };
+const Menu menuQuickBootOff = { "Quick Boot Off", quickBootOff, NULL, &menuQuickBoot };
+const Menu *const quickBootMenu[] = { &menuQuickBootBack, &menuQuickBootOn, &menuQuickBootOff };
 
-Menu menuDriftCompBack = { "Back", NULL, NULL, &menuDriftComp };
-Menu menuDriftCompOff = { "Drift Comp Off", driftCompOff, NULL, &menuDriftComp };
-Menu menuQuickBoot0050 = { "0.05g", driftComp0050, NULL, &menuDriftComp };
-Menu menuQuickBoot0075 = { "0.075g", driftComp0075, NULL, &menuDriftComp };
-Menu menuQuickBoot0100 = { "0.1g", driftComp0100, NULL, &menuDriftComp };
-Menu menuQuickBoot0200 = { "0.2g", driftComp0200, NULL, &menuDriftComp };
-Menu *const driftCompMenu[] = { &menuDriftCompBack, &menuDriftCompOff, &menuQuickBoot0050, &menuQuickBoot0075, &menuQuickBoot0100, &menuQuickBoot0200 };
+const Menu menuDriftCompBack = { "Back", NULL, NULL, &menuDriftComp };
+const Menu menuDriftCompOff = { "Drift Comp Off", driftCompOff, NULL, &menuDriftComp };
+const Menu menuQuickBoot0050 = { "0.05g", driftComp0050, NULL, &menuDriftComp };
+const Menu menuQuickBoot0075 = { "0.075g", driftComp0075, NULL, &menuDriftComp };
+const Menu menuQuickBoot0100 = { "0.1g", driftComp0100, NULL, &menuDriftComp };
+const Menu menuQuickBoot0200 = { "0.2g", driftComp0200, NULL, &menuDriftComp };
+const Menu *const driftCompMenu[] = { &menuDriftCompBack, &menuDriftCompOff, &menuQuickBoot0050, &menuQuickBoot0075, &menuQuickBoot0100, &menuQuickBoot0200 };
 
 #if HDS_ENABLE_GRINDER
-Menu menuGrinderBack = { "Back", NULL, NULL, &menuGrinder };
-Menu menuGrinderOn = { "Enable", grinderOn, NULL, &menuGrinder };
-Menu menuGrinderOff = { "Disable", grinderOff, NULL, &menuGrinder };
-Menu menuGrinderSelect = { "Select Plug", grinderSelectPlugMenu, NULL, &menuGrinder };
-Menu menuGrinderTarget = { "Target g", grinderTargetMenu, NULL, &menuGrinder };
-Menu menuGrinderSafety = { "Safety g", grinderSafetyMenu, NULL, &menuGrinder };
-Menu menuGrinderZero = { "Zero Range", grinderZeroRangeMenu, NULL, &menuGrinder };
-Menu *const grinderMenu[] = { &menuGrinderBack, &menuGrinderOn, &menuGrinderOff, &menuGrinderSelect, &menuGrinderTarget, &menuGrinderSafety, &menuGrinderZero };
+const Menu menuGrinderBack = { "Back", NULL, NULL, &menuGrinder };
+const Menu menuGrinderOn = { "Enable", grinderOn, NULL, &menuGrinder };
+const Menu menuGrinderOff = { "Disable", grinderOff, NULL, &menuGrinder };
+const Menu menuGrinderSelect = { "Select Plug", grinderSelectPlugMenu, NULL, &menuGrinder };
+const Menu menuGrinderTarget = { "Target g", grinderTargetMenu, NULL, &menuGrinder };
+const Menu menuGrinderSafety = { "Safety g", grinderSafetyMenu, NULL, &menuGrinder };
+const Menu menuGrinderZero = { "Zero Range", grinderZeroRangeMenu, NULL, &menuGrinder };
+const Menu *const grinderMenu[] = { &menuGrinderBack, &menuGrinderOn, &menuGrinderOff, &menuGrinderSelect, &menuGrinderTarget, &menuGrinderSafety, &menuGrinderZero };
 #endif
 
 
-Menu *const mainMenu[] = {
+const Menu *const mainMenu[] = {
   &menuExit,
 #ifdef BUZZER
   &menuBuzzer,
@@ -218,8 +218,8 @@ Menu *const mainMenu[] = {
   &menuGrinder,
 #endif
 };
-Menu *const *currentMenu = mainMenu;
-Menu *currentSelection = mainMenu[0];
+const Menu *const *currentMenu = mainMenu;
+const Menu *currentSelection = mainMenu[0];
 int currentMenuSize = getMenuSize(mainMenu);
 int currentIndex = 0;
 const int linesPerPage =

--- a/include/menu.h
+++ b/include/menu.h
@@ -30,7 +30,7 @@ struct Menu {
   const char *name;
   void (*action)();
   const Menu *subMenu;
-  Menu *parentMenu;
+  const Menu *parentMenu;
 };
 
 void exitMenu();
@@ -86,28 +86,45 @@ void grinderZeroRangeMenu();
 void wifi_init();
 #endif
 
+extern const Menu menuCalibrationBack;
+extern const Menu menuHeartbeatBack;
+extern const Menu menuFlipScreenBack;
+extern const Menu menuTimeOnTopBack;
+extern const Menu menuBtnFuncWhileConnectedBack;
+extern const Menu menuAutoSleepBack;
+extern const Menu menuQuickBootBack;
+extern const Menu menuDriftCompBack;
+#ifdef BUZZER
+extern const Menu menuBuzzerBack;
+#endif
+#if HDS_FEATURE_WIFI
+extern const Menu menuWiFiUpdateBack;
+#endif
+#if HDS_ENABLE_GRINDER
+extern const Menu menuGrinderBack;
+#endif
 
 const Menu menuExit = { "Exit", exitMenu, NULL, NULL };
 #ifdef BUZZER
-Menu menuBuzzer = { "Buzzer", NULL, NULL, NULL };
+const Menu menuBuzzer = { "Buzzer", NULL, &menuBuzzerBack, NULL };
 #endif
-Menu menuCalibration = { "Calibration", NULL, NULL, NULL };
+const Menu menuCalibration = { "Calibration", NULL, &menuCalibrationBack, NULL };
 #if HDS_FEATURE_WIFI
-Menu menuWifi = { "WiFi Settings", NULL, NULL, NULL };
+const Menu menuWifi = { "WiFi Settings", NULL, &menuWiFiUpdateBack, NULL };
 #endif
 const Menu menuStatus = { "Status", showStatus, NULL, NULL };
 const Menu menuAbout = { "About", showAbout, NULL, NULL };
 const Menu menuLogo = { "Show Logo", showLogo, NULL, NULL };
 const Menu menuFactory = { "Factory", NULL, NULL, NULL };
-Menu menuHeartbeat = { "Heartbeat", NULL, NULL, NULL };
-Menu menuFlipScreen = { "Flip Screen", NULL, NULL, NULL };
-Menu menuTimeOnTop = { "Time On Top", NULL, NULL, NULL };
-Menu menuBtnFuncWhileConnected = { "Button with BLE", NULL, NULL, NULL };
-Menu menuAutoSleep = { "Auto Sleep", NULL, NULL, NULL };
-Menu menuQuickBoot = { "Quick Boot", NULL, NULL, NULL };
-Menu menuDriftComp = { "Drift Comp", NULL, NULL, NULL };
+const Menu menuHeartbeat = { "Heartbeat", NULL, &menuHeartbeatBack, NULL };
+const Menu menuFlipScreen = { "Flip Screen", NULL, &menuFlipScreenBack, NULL };
+const Menu menuTimeOnTop = { "Time On Top", NULL, &menuTimeOnTopBack, NULL };
+const Menu menuBtnFuncWhileConnected = { "Button with BLE", NULL, &menuBtnFuncWhileConnectedBack, NULL };
+const Menu menuAutoSleep = { "Auto Sleep", NULL, &menuAutoSleepBack, NULL };
+const Menu menuQuickBoot = { "Quick Boot", NULL, &menuQuickBootBack, NULL };
+const Menu menuDriftComp = { "Drift Comp", NULL, &menuDriftCompBack, NULL };
 #if HDS_ENABLE_GRINDER
-Menu menuGrinder = { "Grind by weight", NULL, NULL, NULL };
+const Menu menuGrinder = { "Grind by weight", NULL, &menuGrinderBack, NULL };
 #endif
 
 
@@ -226,26 +243,6 @@ const int linesPerPage =
   4;
 int currentPage = 0;
 int totalPages = currentMenuSize / linesPerPage + 1;
-
-void linkSubmenus() {
-#ifdef BUZZER
-  menuBuzzer.subMenu = buzzerMenu[0];
-#endif
-  menuCalibration.subMenu = calibrationMenu[0];
-#if HDS_FEATURE_WIFI
-  menuWifi.subMenu = wifiUpdateMenu[0];
-#endif
-  menuHeartbeat.subMenu = heartbeatMenu[0];
-  menuFlipScreen.subMenu = flipScreenMenu[0];
-  menuTimeOnTop.subMenu = timeOnTopMenu[0];
-  menuBtnFuncWhileConnected.subMenu = btnFuncWhileConnectedMenu[0];
-  menuAutoSleep.subMenu = autoSleepMenu[0];
-  menuQuickBoot.subMenu = quickBootMenu[0];
-  menuDriftComp.subMenu = driftCompMenu[0];
-#if HDS_ENABLE_GRINDER
-  menuGrinder.subMenu = grinderMenu[0];
-#endif
-}
 
 void exitMenu() {
   u8g2.setFont(FONT_M);

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -146,7 +146,6 @@ bool b_grinderMenuDirectEntry = false;
 float INPUTCOFFEEPOUROVER = 20.0;
 float INPUTCOFFEEESPRESSO = 20.0;
 float f_batteryCalibrationFactor = 0.66;
-String str_welcome = "welcome";
 float f_calibration_value = CALIBRATION_VALUE_DEFAULT;   //称重单元校准值
 bool b_calibrationInvalid = false;
 char c_calibrationStatus[32] = "ok";

--- a/plugins/pressensor/patches/main.patch
+++ b/plugins/pressensor/patches/main.patch
@@ -29,10 +29,10 @@ index 80187e8..d238c56 100644
  //文本对齐 AC居中 AR右对齐 AL左对齐 T为要显示的文本
  #define LCDWidth u8g2.getDisplayWidth()
 diff --git a/include/finger_detection.h b/include/finger_detection.h
-index c854ef6..99b02fd 100644
+index f751a85..5a6a5e8 100644
 --- a/include/finger_detection.h
 +++ b/include/finger_detection.h
-@@ -217,8 +217,17 @@ bool isFingerPress(int button) {
+@@ -216,8 +216,17 @@ bool isFingerPress(int button) {
            sendBleButton(2, 1);
          }
          if (!b_menu && !b_calibration && (!bleClientLive || b_btnFuncWhileConnected)) {
@@ -52,7 +52,7 @@ index c854ef6..99b02fd 100644
        }
      }
 diff --git a/include/menu.h b/include/menu.h
-index d002267..18840b3 100644
+index 8c02f2e..a036e87 100644
 --- a/include/menu.h
 +++ b/include/menu.h
 @@ -10,6 +10,9 @@
@@ -63,7 +63,7 @@ index d002267..18840b3 100644
 +#include "pressensor_runtime.h"
 +#endif
  #include <string.h>
- const char *weights[] = { "Exit", "50g", "100g", "200g", "500g", "1000g" };
+ const char *const weights[] = { "Exit", "50g", "100g", "200g", "500g", "1000g" };
  const float weight_values[] = { 0.0, 50.0, 100.0, 200.0, 500.0, 1000.0 };
 @@ -82,6 +85,14 @@ void grinderTargetMenu();
  void grinderSafetyMenu();
@@ -80,32 +80,44 @@ index d002267..18840b3 100644
  #if HDS_FEATURE_WIFI
  void wifi_init();
  #endif
-@@ -111,4 +122,7 @@
+@@ -103,6 +114,9 @@ extern const Menu menuWiFiUpdateBack;
+ #if HDS_ENABLE_GRINDER
+ extern const Menu menuGrinderBack;
  #endif
 +#if HDS_ENABLE_PRESSENSOR
-+Menu menuPressensor = { "Pressensor", NULL, NULL, NULL };
++extern const Menu menuPressensorBack;
++#endif
+ 
+ const Menu menuExit = { "Exit", exitMenu, NULL, NULL };
+ #ifdef BUZZER
+@@ -126,6 +140,9 @@ const Menu menuDriftComp = { "Drift Comp", NULL, &menuDriftCompBack, NULL };
+ #if HDS_ENABLE_GRINDER
+ const Menu menuGrinder = { "Grind by weight", NULL, &menuGrinderBack, NULL };
+ #endif
++#if HDS_ENABLE_PRESSENSOR
++const Menu menuPressensor = { "Pressensor", NULL, &menuPressensorBack, NULL };
 +#endif
  
  
  #ifdef BUZZER
-@@ -201,6 +215,16 @@ Menu menuGrinderZero = { "Zero Range", grinderZeroRangeMenu, NULL, &menuGrinder
- Menu *grinderMenu[] = { &menuGrinderBack, &menuGrinderOn, &menuGrinderOff, &menuGrinderSelect, &menuGrinderTarget, &menuGrinderSafety, &menuGrinderZero };
+@@ -218,6 +235,16 @@ const Menu menuGrinderZero = { "Zero Range", grinderZeroRangeMenu, NULL, &menuGr
+ const Menu *const grinderMenu[] = { &menuGrinderBack, &menuGrinderOn, &menuGrinderOff, &menuGrinderSelect, &menuGrinderTarget, &menuGrinderSafety, &menuGrinderZero };
  #endif
  
 +#if HDS_ENABLE_PRESSENSOR
-+Menu menuPressensorBack = { "Back", NULL, NULL, &menuPressensor };
-+Menu menuPressensorOn = { "Pressensor On", pressensorMenuOn, NULL, &menuPressensor };
-+Menu menuPressensorOff = { "Pressensor Off", pressensorMenuOff, NULL, &menuPressensor };
-+Menu menuPressensorSelect = { "Select Sensor", pressensorSelectSensorMenu, NULL, &menuPressensor };
-+Menu menuPressensorZero = { "Zero Sensor", pressensorZeroMenu, NULL, &menuPressensor };
-+Menu menuPressensorAutoStart = { "Auto Start", pressensorAutoStartToggle, NULL, &menuPressensor };
-+Menu menuPressensorAutoStop = { "Auto Stop", pressensorAutoStopToggle, NULL, &menuPressensor };
-+Menu *pressensorMenu[] = { &menuPressensorBack, &menuPressensorOn, &menuPressensorOff, &menuPressensorSelect, &menuPressensorZero, &menuPressensorAutoStart, &menuPressensorAutoStop };
++const Menu menuPressensorBack = { "Back", NULL, NULL, &menuPressensor };
++const Menu menuPressensorOn = { "Pressensor On", pressensorMenuOn, NULL, &menuPressensor };
++const Menu menuPressensorOff = { "Pressensor Off", pressensorMenuOff, NULL, &menuPressensor };
++const Menu menuPressensorSelect = { "Select Sensor", pressensorSelectSensorMenu, NULL, &menuPressensor };
++const Menu menuPressensorZero = { "Zero Sensor", pressensorZeroMenu, NULL, &menuPressensor };
++const Menu menuPressensorAutoStart = { "Auto Start", pressensorAutoStartToggle, NULL, &menuPressensor };
++const Menu menuPressensorAutoStop = { "Auto Stop", pressensorAutoStopToggle, NULL, &menuPressensor };
++const Menu *const pressensorMenu[] = { &menuPressensorBack, &menuPressensorOn, &menuPressensorOff, &menuPressensorSelect, &menuPressensorZero, &menuPressensorAutoStart, &menuPressensorAutoStop };
 +#endif
  
- Menu *mainMenu[] = {
+ const Menu *const mainMenu[] = {
    &menuExit,
-@@ -217,6 +241,9 @@ Menu *mainMenu[] = {
+@@ -234,6 +261,9 @@ const Menu *const mainMenu[] = {
  #if HDS_ENABLE_GRINDER
    &menuGrinder,
  #endif
@@ -113,19 +125,9 @@ index d002267..18840b3 100644
 +  &menuPressensor,
 +#endif
  };
- Menu **currentMenu = mainMenu;
- Menu *currentSelection = mainMenu[0];
-@@ -245,6 +272,9 @@ void linkSubmenus() {
- #if HDS_ENABLE_GRINDER
-   menuGrinder.subMenu = grinderMenu[0];
- #endif
-+#if HDS_ENABLE_PRESSENSOR
-+  menuPressensor.subMenu = pressensorMenu[0];
-+#endif
- }
- 
- void exitMenu() {
-@@ -864,6 +894,126 @@ void grinderZeroRangeMenu() {
+ const Menu *const *currentMenu = mainMenu;
+ const Menu *currentSelection = mainMenu[0];
+@@ -861,6 +891,126 @@ void grinderZeroRangeMenu() {
  }
  #endif
  
@@ -265,10 +267,10 @@ index d002267..18840b3 100644
      }
      currentIndex = 0;
 diff --git a/include/parameter.h b/include/parameter.h
-index c671664..5b540db 100644
+index 9defe9d..934ae5e 100644
 --- a/include/parameter.h
 +++ b/include/parameter.h
-@@ -233,6 +233,17 @@ extern GrinderRuntime grinderRuntime;
+@@ -243,6 +243,17 @@ extern GrinderRuntime grinderRuntime;
  portMUX_TYPE grinderMdnsMux = portMUX_INITIALIZER_UNLOCKED;
  GrinderMdnsCandidate * volatile grinderMdnsCandidateBuffer = nullptr;
  #endif
@@ -1359,7 +1361,7 @@ index 21fbdcb..623faf1 100644
  platform = native
  test_build_src = no
 diff --git a/src/hds.ino b/src/hds.ino
-index b93b7cd..d4f7809 100644
+index c473fa7..cac7fed 100644
 --- a/src/hds.ino
 +++ b/src/hds.ino
 @@ -22,6 +22,9 @@
@@ -1382,7 +1384,7 @@ index b93b7cd..d4f7809 100644
  
    b_quickBoot = storageGetBool(KEY_QUICK_BOOT, false);
    i_buttonBootDelay = b_quickBoot ? 0 : 500;
-@@ -1470,6 +1476,9 @@ void loop() {
+@@ -1478,6 +1484,9 @@ void loop() {
  #endif
  #if HDS_ENABLE_GRINDER
        || grinderRuntimeKeepsAwake()
@@ -1392,7 +1394,7 @@ index b93b7cd..d4f7809 100644
  #endif
    ) {
      power_off(-1);
-@@ -1535,6 +1544,9 @@ void loop() {
+@@ -1548,6 +1557,9 @@ void loop() {
  #endif
  #if HDS_ENABLE_GRINDER
        grinderRuntimeTick(f_displayedValue);
@@ -1402,7 +1404,7 @@ index b93b7cd..d4f7809 100644
  #endif
        showMenu();
      } else if (GPIO_power_on_with == BATTERY_CHARGING) {
-@@ -1645,7 +1657,16 @@ void loop() {
+@@ -1658,7 +1670,16 @@ void loop() {
            }
          }
          pureScale();
@@ -1419,7 +1421,7 @@ index b93b7cd..d4f7809 100644
  #if HDS_ENABLE_GRINDER
          grinderRuntimeTick(f_displayedValue);
  #endif
-@@ -1853,6 +1874,119 @@ void drawGrinder() {
+@@ -1866,6 +1887,119 @@ void drawGrinder() {
  }
  #endif
  

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -596,10 +596,6 @@ void setup() {
   u8g2.setContrast(255);
   u8g2.setFont(FONT_M);
   power_off(15);
-#ifdef WELCOME
-  str_welcome = storageGetString(KEY_WELCOME, String(WELCOME1));
-  str_welcome.trim();
-#endif
   b_screenFlipped = storageGetBool(KEY_SCREEN_FLIP, false);
   if (b_screenFlipped)
     u8g2.setDisplayRotation(U8G2_R0);
@@ -751,15 +747,23 @@ void setup() {
   Serial.println(digitalRead(BUTTON_CIRCLE));
 #endif
 
-  Serial.print("Welcome: ");
-  if (str_welcome.length() == 127)
-    Serial.print(WELCOME1);
-  else
-    Serial.print(str_welcome);
-  Serial.print("\t");
-  Serial.print(WELCOME2);
-  Serial.print("\t");
-  Serial.println(WELCOME3);
+  {
+#ifdef WELCOME
+    String welcome = storageGetString(KEY_WELCOME, String(WELCOME1));
+    welcome.trim();
+#else
+    String welcome = "welcome";
+#endif
+    Serial.print("Welcome: ");
+    if (welcome.length() == 127)
+      Serial.print(WELCOME1);
+    else
+      Serial.print(welcome);
+    Serial.print("\t");
+    Serial.print(WELCOME2);
+    Serial.print("\t");
+    Serial.println(WELCOME3);
+  }
   Serial.print("Info: ");
   Serial.print(LINE1);
   Serial.print("\t");

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -454,7 +454,6 @@ void setup() {
   releaseWakePinsFromRtcMode();
 #endif
   button_init();
-  linkSubmenus();
   pinMode(BATTERY_CHARGING, INPUT_PULLUP);
 #if defined(V7_4) || defined(V7_5) || defined(V8_0) || defined(V8_1)
   pinMode(USB_DET, INPUT_PULLUP);

--- a/tools/test_finger_detection_memory_contract.py
+++ b/tools/test_finger_detection_memory_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+HEADER = Path(__file__).resolve().parents[1] / "include" / "finger_detection.h"
+UINT32_MASK = (1 << 32) - 1
+
+
+def cached_timing(press_start, release_time, last_sample_time, release_index, sample_count):
+    press_sample_time = release_time if release_index < sample_count else last_sample_time
+    final_sample_time = release_time if release_index == sample_count - 1 else last_sample_time
+    return (
+        (press_sample_time - press_start) & UINT32_MASK,
+        (final_sample_time - press_start) & UINT32_MASK,
+    )
+
+
+def main():
+    source = HEADER.read_text(encoding="utf-8")
+    for required in (
+        "static_assert(TOTAL_SAMPLES < 255);",
+        "static_assert(sizeof(PressSample) == 4);",
+        "uint8_t release_index;",
+        "data->release_index = TOTAL_SAMPLES;",
+        "data->release_index = data->sample_index;",
+    ):
+        assert required in source
+    for removed in (".timestamp", ".is_release_point", "if (data->release_time >", "if (data->last_sample_real_time >"):
+        assert removed not in source
+
+    timing_expressions = (
+        "data->release_index < data->sample_index ? data->release_time : data->last_sample_real_time",
+        "data->release_index == data->sample_index - 1 ? data->release_time : data->last_sample_real_time",
+    )
+    for expression in timing_expressions:
+        assert source.count(expression) == 2
+    assert source.count("int peak_index = 0;") == 2
+    assert source.count("peak_index = i;") == 2
+    assert source.count("if (release_index >= data->sample_index)") == 2
+
+    scenarios = (
+        ((1000, 1200, 1500, 20, 30), (200, 500)),
+        ((1000, 1200, 1190, 20, 21), (200, 200)),
+        ((1000, 1600, 1490, 50, 50), (490, 490)),
+        ((0xFFFFFFF0, 0x10, 0x40, 3, 7), (32, 80)),
+    )
+    for inputs, expected in scenarios:
+        assert cached_timing(*inputs) == expected
+
+    print("finger detection memory contract tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_menu_memory_contract.py
+++ b/tools/test_menu_memory_contract.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MENU = ROOT / "include" / "menu.h"
+SKETCH = ROOT / "src" / "hds.ino"
+SUBMENU_LINKS = {
+    "menuAutoSleep": "menuAutoSleepBack",
+    "menuBtnFuncWhileConnected": "menuBtnFuncWhileConnectedBack",
+    "menuBuzzer": "menuBuzzerBack",
+    "menuCalibration": "menuCalibrationBack",
+    "menuDriftComp": "menuDriftCompBack",
+    "menuFlipScreen": "menuFlipScreenBack",
+    "menuGrinder": "menuGrinderBack",
+    "menuHeartbeat": "menuHeartbeatBack",
+    "menuQuickBoot": "menuQuickBootBack",
+    "menuTimeOnTop": "menuTimeOnTopBack",
+    "menuWifi": "menuWiFiUpdateBack",
+}
+
+
+def main():
+    menu = MENU.read_text(encoding="utf-8")
+    sketch = SKETCH.read_text(encoding="utf-8")
+    declarations = re.findall(
+        r"^const Menu (menu\w+) = \{(.*?)\};",
+        menu,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    links = {}
+    for name, initializer in declarations:
+        match = re.search(r",\s*(&menu\w+|NULL)\s*,\s*(?:&menu\w+|NULL)\s*$", initializer)
+        assert match is not None
+        if match.group(1) != "NULL":
+            links[name] = match.group(1)[1:]
+
+    assert links == SUBMENU_LINKS
+    assert "\nMenu menu" not in menu
+    assert re.search(r"^Menu \*const", menu, flags=re.MULTILINE) is None
+    assert "currentSelection->subMenu" in menu
+    assert "linkSubmenus" not in menu
+    assert "linkSubmenus" not in sketch
+
+    print("menu memory contract tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_plugin_ci_contract.py
+++ b/tools/test_plugin_ci_contract.py
@@ -32,6 +32,7 @@ def main():
     assert "tools/list_changed_patch_plugins.py" in customWorkflow
     assert "fromJSON(needs.detect_plugins.outputs.matrix)" in customWorkflow
     assert '--verify-plugin-environment "esp32s3-$PLUGIN_ID"' in customWorkflow
+    assert '--source-commit "${{ github.sha }}"' in customWorkflow
     assert "verify-pressensor:" not in customWorkflow
     assert "compile-matrix:" not in customWorkflow
     dispatchBuild = customWorkflow.split("\n  build:\n", 1)[1]

--- a/tools/test_welcome_memory_contract.py
+++ b/tools/test_welcome_memory_contract.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PARAMETER = (ROOT / "include" / "parameter.h").read_text(encoding="utf-8")
+SKETCH = (ROOT / "src" / "hds.ino").read_text(encoding="utf-8")
+
+
+assert "str_welcome" not in PARAMETER
+assert "str_welcome" not in SKETCH
+assert SKETCH.count("String welcome =") == 2
+assert "String welcome = storageGetString(KEY_WELCOME, String(WELCOME1));" in SKETCH
+assert "welcome.trim();" in SKETCH
+assert 'String welcome = "welcome";' in SKETCH
+assert "if (welcome.length() == 127)" in SKETCH
+assert "Serial.print(welcome);" in SKETCH
+
+print("welcome memory contract tests passed")


### PR DESCRIPTION
## Summary

Reduce permanent and boot-lifetime RAM use without changing scale behavior:

- compact finger-press sample state
- move immutable menu pointer tables and descriptors to flash
- initialize fixed menu links at compile time
- release stored welcome text after boot

## Memory

The five candidates remove 2,168 bytes of static RAM cumulatively:

| Section | Delta |
| --- | ---: |
| `.data` | -928 bytes |
| `.bss` | -1,240 bytes |
| Static RAM | -2,168 bytes |

Current-main combined build:

- RAM: 56,636 bytes
- `.data`: 24,114 bytes
- `.bss`: 32,520 bytes
- Flash: 1,646,193 bytes

## Verification

- clean `esp32s3` build: PASS
- `esp32s3-grinder` build: PASS
- finger-detection memory contract: PASS
- menu memory contract: PASS
- welcome memory contract: PASS
- storage-migration contract: PASS
- OTA reboot-routing contract: PASS
- firmware-only COM5 upload with esptool hash verification: PASS
- user smoke check: no problem observed

NVS was not erased and LittleFS was not uploaded.

## Known Main-Branch Test Issue

`tools/test_grinder_tcp_contract.py` has an existing exact-text assertion for `if (!buttonChecksSuppressedUntilRelease()`. Current main changed that condition to include the OTA guard on the preceding line, so this assertion fails independently of this PR; the grinder firmware build itself passes.