### PR TITLE
Restart automatically after WiFi menu changes

### DIFF
--- a/docs/custom-build/service-catalog.json
+++ b/docs/custom-build/service-catalog.json
@@ -74,7 +74,7 @@
       "conflicts": [],
       "patches": {
         "main": {
-          "sha256": "43c35d610c68839baf2d9882a73307a2bdcf43eeb26e56e94d031d8691c394dd"
+          "sha256": "315403d91c5082628f3afc85523178a16d6f23897b2a864a64b12301ed6343c0"
         }
       },
       "assets": []

--- a/include/decent_protocol.h
+++ b/include/decent_protocol.h
@@ -300,7 +300,7 @@ static inline void startDecentCalibration(uint8_t mode, const char *transport) {
   if (mode == 0x00) {
     Serial.print("Manual Calibration via ");
     Serial.println(transport);
-    b_menu = false;
+    leaveMenu();
     i_cal_weight = 0;
     i_button_cal_status = 1;
     i_calibration = 0;
@@ -308,7 +308,7 @@ static inline void startDecentCalibration(uint8_t mode, const char *transport) {
   } else if (mode == 0x01) {
     Serial.print("Smart Calibration via ");
     Serial.println(transport);
-    b_menu = false;
+    leaveMenu();
     i_cal_weight = 0;
     i_button_cal_status = 1;
     i_calibration = 1;
@@ -320,7 +320,7 @@ static inline void handleDecentMenuCommand(const uint8_t *data) {
   if (data[2] == 0x00) {
     if (data[3] == 0x00) {
       Serial.println("Hide menu");
-      b_menu = false;
+      leaveMenu();
     } else if (data[3] == 0x01) {
       Serial.println("Show menu");
       b_menu = true;
@@ -336,7 +336,7 @@ static inline void handleDecentMenuCommand(const uint8_t *data) {
       Serial.println("Show about info");
       b_debug = false;
       b_about = true;
-      b_menu = false;
+      leaveMenu();
     }
   } else if (data[2] == 0x02) {
     if (data[3] == 0x00) {
@@ -346,7 +346,7 @@ static inline void handleDecentMenuCommand(const uint8_t *data) {
       Serial.println("Show debug info");
       b_about = false;
       b_debug = true;
-      b_menu = false;
+      leaveMenu();
     }
   }
 }

--- a/include/menu.h
+++ b/include/menu.h
@@ -257,7 +257,7 @@ void exitMenu() {
 #if HDS_ENABLE_GRINDER
   grinderResumeAfterMenu();
 #endif
-  b_menu = false;
+  leaveMenu();
 #if HDS_ENABLE_GRINDER
   b_grinderMenuDirectEntry = false;
 #endif
@@ -266,10 +266,6 @@ void exitMenu() {
   currentIndex = 0;
   currentSelection = currentMenu[currentIndex];
   t_menuExitTime = millis();
-  if (b_menuRestartRequired) {
-    b_menuRestartRequired = false;
-    remoteQueueResetAt(millis());
-  }
 }
 
 #ifdef BUZZER
@@ -310,7 +306,7 @@ void toggleWifiOn() {
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_WIFI_BOOT, true);
-  b_menuRestartRequired = true;
+  markMenuRestartRequired();
   Serial.printf("%s\n", actionMessage);
 }
 
@@ -334,7 +330,7 @@ void toggleWifiOff() {
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_WIFI_BOOT, false);
-  b_menuRestartRequired = true;
+  markMenuRestartRequired();
   Serial.printf("%s\n", actionMessage);
 }
 
@@ -452,7 +448,7 @@ void resetWifi() {
   actionMessage2 = "Restart on exit";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
-  b_menuRestartRequired = true;
+  markMenuRestartRequired();
 }
 #endif
 
@@ -869,7 +865,7 @@ void grinderZeroRangeMenu() {
 #endif
 
 void calibrate() {
-  b_menu = false;
+  leaveMenu();
   b_calibration = true;
   i_calibration = 0;
 }
@@ -1481,7 +1477,7 @@ void wifiUpdate() {
   buzzer.off();
 #endif
   pullOtaUpdate();
-  b_menu = false;
+  leaveMenu();
 }
 #endif
 
@@ -1586,7 +1582,7 @@ void enableDebug() {
 #endif
   delay(1000);
   b_debug = true;
-  b_menu = false;
+  leaveMenu();
 }
 
 void calibrateVoltage() {

--- a/include/menu.h
+++ b/include/menu.h
@@ -266,6 +266,10 @@ void exitMenu() {
   currentIndex = 0;
   currentSelection = currentMenu[currentIndex];
   t_menuExitTime = millis();
+  if (b_menuRestartRequired) {
+    b_menuRestartRequired = false;
+    remoteQueueResetAt(millis());
+  }
 }
 
 #ifdef BUZZER
@@ -302,10 +306,11 @@ void toggleWifiOn() {
   }
 #endif
   actionMessage = "WiFi Enabled";
-  actionMessage2 = "Restart scale";
+  actionMessage2 = "Restart on exit";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_WIFI_BOOT, true);
+  b_menuRestartRequired = true;
   Serial.printf("%s\n", actionMessage);
 }
 
@@ -325,10 +330,11 @@ void toggleWifiOff() {
 #endif
   b_wifiOnBoot = false;
   actionMessage = "WiFi Disabled";
-  actionMessage2 = "Restart scale";
+  actionMessage2 = "Restart on exit";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_WIFI_BOOT, false);
+  b_menuRestartRequired = true;
   Serial.printf("%s\n", actionMessage);
 }
 
@@ -443,9 +449,10 @@ void showStatus() {
 void resetWifi() {
   saveCredentials("", "");
   actionMessage = "WiFi Reset";
-  actionMessage2 = "Restart scale";
+  actionMessage2 = "Restart on exit";
   t_actionMessage = millis();
   t_actionMessageDelay = 1000;
+  b_menuRestartRequired = true;
 }
 #endif
 

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -367,6 +367,7 @@ bool b_extraction = false;  //萃取模式标识
 int b_mode = 0;             //0 = pourover; 1 = espresso;
 
 bool b_menu = false;
+bool b_menuRestartRequired = false;
 unsigned long t_menuExitTime = 0;
 // Timestamp recording when the menu exit process started
 // Used to implement a protection period preventing unintended operations

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -367,8 +367,25 @@ bool b_extraction = false;  //萃取模式标识
 int b_mode = 0;             //0 = pourover; 1 = espresso;
 
 bool b_menu = false;
-bool b_menuRestartRequired = false;
+volatile bool b_menuRestartRequired = false;
 unsigned long t_menuExitTime = 0;
+
+inline void markMenuRestartRequired() {
+  portENTER_CRITICAL(&wsPendingMux);
+  b_menuRestartRequired = true;
+  portEXIT_CRITICAL(&wsPendingMux);
+}
+
+inline void leaveMenu() {
+  b_menu = false;
+  portENTER_CRITICAL(&wsPendingMux);
+  const bool restartRequired = b_menuRestartRequired;
+  b_menuRestartRequired = false;
+  portEXIT_CRITICAL(&wsPendingMux);
+  if (restartRequired) {
+    remoteQueueResetAt(millis());
+  }
+}
 // Timestamp recording when the menu exit process started
 // Used to implement a protection period preventing unintended operations
 

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -403,7 +403,7 @@ public:
     }
 
     if (inputString.startsWith("cal0")) {
-      b_menu = false;
+      leaveMenu();
       i_cal_weight = 0;
       i_button_cal_status = 1;
       b_calibration = true;
@@ -411,7 +411,7 @@ public:
     }
 
     if (inputString.startsWith("cal1")) {
-      b_menu = false;
+      leaveMenu();
       i_cal_weight = 0;
       i_button_cal_status = 1;
       b_calibration = true;

--- a/plugins/pressensor/patches/main.patch
+++ b/plugins/pressensor/patches/main.patch
@@ -252,7 +252,7 @@ index 8c02f2e..a036e87 100644
 +#endif
 +
  void calibrate() {
-   b_menu = false;
+   leaveMenu();
    b_calibration = true;
 @@ -1656,6 +1806,11 @@ void selectMenu() {
        b_grinderMenuDirectEntry = false;

--- a/tools/test_ota_reboot_routing_contract.py
+++ b/tools/test_ota_reboot_routing_contract.py
@@ -10,6 +10,7 @@ HDS_SOURCE = ROOT / "src" / "hds.ino"
 WEBSOCKET_HEADER = ROOT / "include" / "websocket.h"
 PARAMETER_HEADER = ROOT / "include" / "parameter.h"
 BLE_HEADER = ROOT / "include" / "ble.h"
+MENU_HEADER = ROOT / "include" / "menu.h"
 
 WSP_DISPLAY_ON = 1 << 0
 WSP_DISPLAY_OFF = 1 << 1
@@ -195,6 +196,17 @@ def main():
     assert_contains(PARAMETER_HEADER, "inline void remoteQueueOtaResetAt(unsigned long resetAt)")
     assert_contains(PARAMETER_HEADER, "std::mutex otaDispatchMutex;")
     assert_contains(BLE_HEADER, "remoteQueuePending(WSP_RESET);")
+    assert_contains(PARAMETER_HEADER, "bool b_menuRestartRequired = false;")
+    assert_contains(
+        MENU_HEADER,
+        "if (b_menuRestartRequired) {\n"
+        "    b_menuRestartRequired = false;\n"
+        "    remoteQueueResetAt(millis());\n"
+        "  }",
+    )
+    menu_contents = MENU_HEADER.read_text(encoding="utf-8")
+    if menu_contents.count("b_menuRestartRequired = true;") != 3:
+        raise AssertionError("menu.h expected three restart-requiring WiFi actions")
 
     websocket = WEBSOCKET_HEADER.read_text(encoding="utf-8")
     dispatcher_start = websocket.index("void processWsPendingCmds() {")

--- a/tools/test_ota_reboot_routing_contract.py
+++ b/tools/test_ota_reboot_routing_contract.py
@@ -196,17 +196,37 @@ def main():
     assert_contains(PARAMETER_HEADER, "inline void remoteQueueOtaResetAt(unsigned long resetAt)")
     assert_contains(PARAMETER_HEADER, "std::mutex otaDispatchMutex;")
     assert_contains(BLE_HEADER, "remoteQueuePending(WSP_RESET);")
-    assert_contains(PARAMETER_HEADER, "bool b_menuRestartRequired = false;")
+    assert_contains(PARAMETER_HEADER, "volatile bool b_menuRestartRequired = false;")
     assert_contains(
-        MENU_HEADER,
-        "if (b_menuRestartRequired) {\n"
-        "    b_menuRestartRequired = false;\n"
-        "    remoteQueueResetAt(millis());\n"
-        "  }",
+        PARAMETER_HEADER,
+        "inline void markMenuRestartRequired() {\n"
+        "  portENTER_CRITICAL(&wsPendingMux);\n"
+        "  b_menuRestartRequired = true;\n"
+        "  portEXIT_CRITICAL(&wsPendingMux);\n"
+        "}",
     )
+    assert_contains(
+        PARAMETER_HEADER,
+        "inline void leaveMenu() {\n"
+        "  b_menu = false;\n"
+        "  portENTER_CRITICAL(&wsPendingMux);\n"
+        "  const bool restartRequired = b_menuRestartRequired;\n"
+        "  b_menuRestartRequired = false;\n"
+        "  portEXIT_CRITICAL(&wsPendingMux);\n"
+        "  if (restartRequired) {\n"
+        "    remoteQueueResetAt(millis());\n"
+        "  }\n"
+        "}",
+    )
+    assert_contains(MENU_HEADER, "void calibrate() {\n  leaveMenu();")
+    assert_contains(MENU_HEADER, "pullOtaUpdate();\n  leaveMenu();")
+    assert_contains(MENU_HEADER, "b_debug = true;\n  leaveMenu();")
     menu_contents = MENU_HEADER.read_text(encoding="utf-8")
-    if menu_contents.count("b_menuRestartRequired = true;") != 3:
+    if menu_contents.count("markMenuRestartRequired();") != 3:
         raise AssertionError("menu.h expected three restart-requiring WiFi actions")
+    for path in [*ROOT.glob("include/*.h"), *ROOT.glob("src/*.ino"), *ROOT.glob("src/*.cpp")]:
+        if path != PARAMETER_HEADER:
+            assert_not_contains(path, "b_menu = false;")
 
     websocket = WEBSOCKET_HEADER.read_text(encoding="utf-8")
     dispatcher_start = websocket.index("void processWsPendingCmds() {")


### PR DESCRIPTION
## Summary

- mark WiFi enable, disable, and credential reset as restart-requiring menu actions
- queue the existing main-loop reboot path when leaving the HDS menu
- update the OLED message and extend the reboot routing contract

## Tests

- `pio run -e esp32s3`
- `python tools/test_ota_reboot_routing_contract.py`
- `python tools/test_grinder_feature_flag_contract.py`

## Known baseline issue

- `python tools/test_grinder_tcp_contract.py` fails on current `main` because `src/hds.ino` lacks the expected `if (!buttonChecksSuppressedUntilRelease()` string; this PR does not change that path.