### PR TITLE
Fix WiFi-only custom build setup page

### DIFF
--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -41,6 +41,7 @@ Do not add an environment merely because it exists. Changes limited to ADS1232 b
 - `tools/build_custom_firmware.py` resolves an allowed firmware ref to an exact commit, builds it in a temporary checkout, applies approved patches in plugin-ID order, and publishes firmware, LittleFS, dependency, and provenance artifacts only after the full build succeeds.
 - `tools/build_custom_firmware.py --verify-plugin-environment esp32s3-<plugin-id>` applies one patch plugin in an isolated checkout, runs its matching contract scripts, and builds its dedicated validation environment without publishing artifacts.
 - Custom feature lists are exact. An empty list builds BLE/USB-only firmware; Pull OTA is enabled only when `pull-ota` is selected.
+- WiFi retains the web server so a build requested with only `wifi` serves the inline network and device-name setup page without LittleFS.
 - `HDS_FEATURE_LITTLEFS` controls runtime filesystem mounting and web assets. Pull OTA retains its staged `littlefs.bin` transaction independently of that runtime feature.
 - `check_platform_freshness.py` compares the explicit pioarduino pin with the latest stable release as an advisory pre-build check. It never fails offline builds; set `HDS_SKIP_PLATFORM_CHECK=1` only when the check should be skipped deliberately.
 - `.gitattributes` enforces LF line endings repo-wide.

--- a/docs/custom-build/catalog.json
+++ b/docs/custom-build/catalog.json
@@ -6,9 +6,11 @@
     {
       "id": "wifi",
       "name": "WiFi",
-      "description": "Wireless networking support for connected features.",
-      "tooltip": "Provides the WiFi stack used by OTA updates, discovery, web tools, and connected plugins.",
-      "requires": []
+      "description": "Wireless networking with inline configuration support.",
+      "tooltip": "Provides WiFi and the embedded web server used to configure the network and device name.",
+      "requires": [
+        "webserver"
+      ]
     },
     {
       "id": "mdns",

--- a/docs/custom-build/service-catalog.json
+++ b/docs/custom-build/service-catalog.json
@@ -9,7 +9,9 @@
     "sha256": "ab2f33c14eb855054613fd3a4ba85457ae281c6f371c25931ccc763bc79cb0e2"
   },
   "features": {
-    "wifi": [],
+    "wifi": [
+      "webserver"
+    ],
     "mdns": [
       "wifi"
     ],

--- a/tools/configure_custom_build.py
+++ b/tools/configure_custom_build.py
@@ -15,7 +15,7 @@ ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 PATH_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 FIRMWARE_REFS = ("main",)
 FEATURES = {
-    "wifi": ("HDS_FEATURE_WIFI", ()),
+    "wifi": ("HDS_FEATURE_WIFI", ("webserver",)),
     "mdns": ("HDS_FEATURE_MDNS", ("wifi",)),
     "webserver": ("HDS_FEATURE_WEBSERVER", ("wifi",)),
     "websocket": ("HDS_FEATURE_WEBSOCKET", ("wifi", "webserver")),
@@ -27,8 +27,8 @@ FEATURES = {
 FEATURE_PRESENTATION = {
     "wifi": (
         "WiFi",
-        "Wireless networking support for connected features.",
-        "Provides the WiFi stack used by OTA updates, discovery, web tools, and connected plugins.",
+        "Wireless networking with inline configuration support.",
+        "Provides WiFi and the embedded web server used to configure the network and device name.",
     ),
     "mdns": (
         "mDNS",

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -172,13 +172,13 @@ def main():
             resolvedFeature = customBuild.resolveConfiguration(writeConfig(root, [feature], []))
             assert set(dependencies).issubset(resolvedFeature["features"])
         wifi = customBuild.resolveConfiguration(writeConfig(root, ["wifi"], []))
-        assert wifi["features"] == ["wifi"]
+        assert wifi["features"] == ["webserver", "wifi"]
         noFeatures = customBuild.resolveConfiguration(writeConfig(root, [], []))
         assert noFeatures["features"] == []
         pullOnly = customBuild.resolveConfiguration(writeConfig(root, ["pull-ota"], []))
         assert {"pull-ota", "wifi"}.issubset(pullOnly["features"])
         assert "littlefs" not in pullOnly["features"]
-        assert "webserver" not in pullOnly["features"]
+        assert "webserver" in pullOnly["features"]
         assertRejected(lambda: customBuild.resolveConfiguration(writeConfig(root, [], ["../bad"])))
         resolved = customBuild.resolveConfiguration(writeConfig(root, [], ["hello-web"]))
         assert "littlefs" in resolved["features"]


### PR DESCRIPTION
## Summary
- retain the web server whenever WiFi is selected
- keep LittleFS disabled for a WiFi-only custom build
- update generated catalogs, documentation, and feature-resolution coverage

## Verification
- `python tools/test_plugin_catalog.py`
- `python tools/test_custom_build_execution.py`
- `python tools/test_ai_docs_contract.py`
- `pio run -e esp32s3-custom` with `features: ["wifi"]`
