### PR TITLE
Default custom builds to the ESP32-S3 release feature set

### DIFF
--- a/docs/custom-build/catalog.json
+++ b/docs/custom-build/catalog.json
@@ -8,7 +8,8 @@
       "name": "WiFi",
       "description": "Wireless networking with inline configuration support.",
       "tooltip": "Provides WiFi and a minimal setup server for network and device-name configuration.",
-      "requires": []
+      "requires": [],
+      "default": true
     },
     {
       "id": "mdns",
@@ -17,7 +18,8 @@
       "tooltip": "Advertises the scale on the local network using multicast DNS. WiFi is included automatically.",
       "requires": [
         "wifi"
-      ]
+      ],
+      "default": true
     },
     {
       "id": "webserver",
@@ -26,7 +28,8 @@
       "tooltip": "Adds the embedded HTTP server for web settings, APIs, and approved web plugins.",
       "requires": [
         "wifi"
-      ]
+      ],
+      "default": true
     },
     {
       "id": "websocket",
@@ -36,14 +39,16 @@
       "requires": [
         "wifi",
         "webserver"
-      ]
+      ],
+      "default": true
     },
     {
       "id": "littlefs",
       "name": "Runtime LittleFS files",
       "description": "Bundle files in the runtime flash filesystem.",
       "tooltip": "Adds runtime assets such as HTML, configuration, or plugin resources to LittleFS.",
-      "requires": []
+      "requires": [],
+      "default": true
     },
     {
       "id": "elegant-ota",
@@ -53,7 +58,8 @@
       "requires": [
         "wifi",
         "webserver"
-      ]
+      ],
+      "default": true
     },
     {
       "id": "pull-ota",
@@ -96,7 +102,8 @@
       "recommends": {
         "features": [],
         "plugins": []
-      }
+      },
+      "default": true
     },
     {
       "id": "grind-by-weight",

--- a/tools/configure_custom_build.py
+++ b/tools/configure_custom_build.py
@@ -71,8 +71,9 @@ FEATURE_PRESENTATION = {
         "Internal compile gate selected by the Grind by weight plugin.",
     ),
 }
-DEFAULT_FEATURES = {"pull-ota"}
 HIDDEN_FEATURES = {"grinder"}
+DEFAULT_FEATURES = set(FEATURES) - HIDDEN_FEATURES
+DEFAULT_PLUGINS = {"default-web-apps"}
 CONFIG_KEYS = {"firmware_ref", "features", "plugins"}
 PLUGIN_KEYS = {
     "schema", "id", "name", "description", "tooltip", "version",
@@ -289,11 +290,14 @@ def buildBrowserCatalog():
         "features": features,
         "plugins": [
             {
-                key: manifest[key]
-                for key in (
-                    "id", "name", "description", "tooltip", "version",
-                    "firmware_refs", "requires", "depends_on", "conflicts", "recommends",
-                )
+                **{
+                    key: manifest[key]
+                    for key in (
+                        "id", "name", "description", "tooltip", "version",
+                        "firmware_refs", "requires", "depends_on", "conflicts", "recommends",
+                    )
+                },
+                **({"default": True} if manifest["id"] in DEFAULT_PLUGINS else {}),
             }
             for manifest, _, _ in plugins.values()
         ],

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -174,6 +174,12 @@ def main():
         "--service-catalog-output docs/custom-build/service-catalog.json"
     )
     assert serviceCatalog == customBuild.buildServiceCatalog()
+    assert {
+        feature["id"] for feature in generatedCatalog["features"] if feature.get("default")
+    } == set(customBuild.FEATURES) - customBuild.HIDDEN_FEATURES
+    assert [
+        plugin["id"] for plugin in generatedCatalog["plugins"] if plugin.get("default")
+    ] == ["default-web-apps"]
     pageRoot = customBuild.ROOT / "docs" / "custom-build"
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- select every visible ESP32-S3 release feature by default
- select the Default web apps plugin by default
- make Reset defaults restore that same release-equivalent selection

## Verification
- `python tools/test_plugin_catalog.py`
- `python tools/test_custom_build_execution.py`
- `node --check docs/custom-build/app.js`
- verified initial and reset selections in the browser
