### PR TITLE
Use weekly custom-build limits

### DIFF
--- a/cloudflare/custom-build-worker/src/worker.mjs
+++ b/cloudflare/custom-build-worker/src/worker.mjs
@@ -14,8 +14,11 @@ const binaries = ["firmware.bin", "bootloader.bin", "partitions.bin", "littlefs.
 const buildStates = new Set(["building", "ready", "failed"]);
 const maxEntryBytes = 4 * 1024 * 1024;
 const maxApiBytes = 4096;
-const clientBuildsPerDay = 3;
-const globalBuildsPerDay = 20;
+const dayMs = 86400000;
+const weekMs = 7 * dayMs;
+const utcWeekOffsetMs = 3 * dayMs;
+const clientBuildsPerWeek = 21;
+const globalBuildsPerWeek = 140;
 const maxAttempts = 2;
 const buildLeaseMs = 2 * 60 * 60 * 1000;
 
@@ -25,6 +28,11 @@ class ApiError extends Error {
     this.status = status;
     this.code = code;
   }
+}
+
+function utcWeekWindow(now) {
+  const week = Math.floor((now + utcWeekOffsetMs) / weekMs);
+  return {week, expiresAt: (week + 1) * weekMs - utcWeekOffsetMs};
 }
 
 function route(pathname, prefix) {
@@ -568,8 +576,7 @@ export class BuildCoordinator {
     }
     const build = await request.json();
     const now = Date.now();
-    const day = new Date(now).toISOString().slice(0, 10);
-    const rateExpiresAt = Date.parse(`${day}T00:00:00.000Z`) + 86400000;
+    const rateWindow = utcWeekWindow(now);
     const reservation = await this.state.storage.transaction(async transaction => {
       const recordKey = `build:${hash}`;
       const [current, storedPending] = await Promise.all([
@@ -599,11 +606,16 @@ export class BuildCoordinator {
         return {record: effectiveCurrent, terminal: true};
       }
       const storedRates = await transaction.get("rates");
-      const rates = storedRates?.day === day ? storedRates : {
-        day, global: 0, clients: {}, expires_at: rateExpiresAt,
+      const rates = storedRates?.week === rateWindow.week ? storedRates : {
+        week: rateWindow.week, global: 0, clients: {}, expires_at: rateWindow.expiresAt,
       };
       const clientCount = rates.clients[build.clientKey] || 0;
-      if (clientCount >= clientBuildsPerDay || rates.global >= globalBuildsPerDay) return {rateLimited: true};
+      if (clientCount >= clientBuildsPerWeek || rates.global >= globalBuildsPerWeek) {
+        return {
+          rateLimited: true,
+          retryAfter: Math.max(1, Math.ceil((rates.expires_at - now) / 1000)),
+        };
+      }
       const attemptId = crypto.randomUUID();
       const leaseExpiresAt = now + buildLeaseMs;
       const record = {
@@ -622,7 +634,7 @@ export class BuildCoordinator {
         [recordKey]: record,
         pending,
         rates: {
-          day,
+          week: rateWindow.week,
           global: rates.global + 1,
           clients: {...rates.clients, [build.clientKey]: clientCount + 1},
           expires_at: rates.expires_at,
@@ -631,7 +643,10 @@ export class BuildCoordinator {
       return {record, dispatch: true};
     });
     if (reservation.rateLimited) {
-      return Response.json({error: "rate_limited"}, {status: 429, headers: {"Retry-After": "86400"}});
+      return Response.json(
+        {error: "rate_limited"},
+        {status: 429, headers: {"Retry-After": String(reservation.retryAfter)}},
+      );
     }
     if (reservation.terminal) return Response.json(reservation.record, {status: 409});
     if (!reservation.dispatch) return Response.json(reservation.record);

--- a/cloudflare/custom-build-worker/test/worker.test.mjs
+++ b/cloudflare/custom-build-worker/test/worker.test.mjs
@@ -141,7 +141,7 @@ test("publishes immutable cache entries and deduplicates public builds", async (
         partition_schema: {path: "partitions/default.csv", sha256: "2".repeat(64)},
       },
     },
-    features: {wifi: [], mdns: [], webserver: [], littlefs: []},
+    features: {wifi: [], mdns: [], webserver: [], littlefs: [], "elegant-ota": []},
     plugins: {
       "asset-sort": {
         version: "1.0.0",
@@ -356,10 +356,41 @@ test("publishes immutable cache entries and deduplicates public builds", async (
       retryable: false,
       updated_at: (await env.COORDINATOR.coordinator.state.storage.get(`build:${retryHash}`)).updated_at,
     });
+    const burstFeatures = ["wifi", "mdns", "webserver", "littlefs", "elegant-ota"];
+    const burstSelections = Array.from({length: 31}, (_, index) =>
+      burstFeatures.filter((_, bit) => (index + 1) & (1 << bit)),
+    ).filter(features => ![["mdns"], ["webserver"]].some(skip =>
+      skip.length === features.length && skip.every((feature, index) => feature === features[index]),
+    ));
+    for (const features of burstSelections.slice(0, 18)) {
+      assert.equal((await api(env, "/api/v1/build", "POST", {
+        firmware_ref: "main", features, plugins: [],
+      })).status, 202);
+    }
     const limited = await api(env, "/api/v1/build", "POST", {
       firmware_ref: "main", features: ["webserver"], plugins: [],
     });
     assert.equal(limited.status, 429);
+    assert.ok(Number(limited.headers.get("Retry-After")) <= 7 * 24 * 60 * 60);
+    const rates = await env.COORDINATOR.coordinator.state.storage.get("rates");
+    assert.equal(rates.global, 21);
+    assert.deepEqual(Object.values(rates.clients), [21]);
+    assert.equal(Object.hasOwn(rates, "day"), false);
+    assert.equal(new Date(rates.expires_at).getUTCDay(), 1);
+    assert.equal(new Date(rates.expires_at).toISOString().slice(11), "00:00:00.000Z");
+    await env.COORDINATOR.coordinator.state.storage.put("rates", {
+      ...rates, global: 140, clients: {},
+    });
+    const globallyLimited = await api(env, "/api/v1/build", "POST", {
+      firmware_ref: "main", features: ["webserver"], plugins: [],
+    });
+    assert.equal(globallyLimited.status, 429);
+    await env.COORDINATOR.coordinator.state.storage.put("rates", {
+      ...rates, week: rates.week - 1, global: 140, clients: {},
+    });
+    assert.equal((await api(env, "/api/v1/build", "POST", {
+      firmware_ref: "main", features: ["webserver"], plugins: [],
+    })).status, 202);
 
     const rejectedOrigin = await worker.fetch(new Request("https://example.test/api/v1/status", {
       method: "POST",

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -143,7 +143,7 @@
       failed: result.retryable ? "The build did not complete. One retry is available." :
         "The build did not complete after two attempts.",
       unavailable: "The build service is currently unavailable.",
-      "rate-limited": "The daily build limit has been reached. Existing cached builds remain available.",
+      "rate-limited": "The weekly build limit has been reached. Existing cached builds remain available.",
       checking: "Checking the build cache."
     };
     buildState.className = `ready state-${result.state}`;
@@ -340,7 +340,7 @@
       if (error.name === "AbortError" || generation !== selectionGeneration) return;
       if (error.status === 429) {
         setStatus({state: "rate-limited"}, generation);
-        showToast("Daily build limit reached");
+        showToast("Weekly build limit reached");
       } else if (error.result?.state === "failed") {
         setStatus(error.result, generation);
         showToast("Retry limit reached");

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -123,6 +123,6 @@
     <span id="toast-message">Command copied</span>
   </div>
 
-  <script src="app.js?v=6"></script>
+  <script src="app.js?v=7"></script>
 </body>
 </html>

--- a/docs/custom-build/plan_4_phase.md
+++ b/docs/custom-build/plan_4_phase.md
@@ -20,7 +20,7 @@ The Phase 4 API, Durable Object coordinator, trusted service catalog, exact sour
 
 The GitHub App installation currently covers the organization because the installer is not the organization owner. Restricting it to `decentespresso/openscale` remains the target least-privilege configuration. The Worker still fixes dispatches to `decentespresso/openscale`; the wider installation is documented security hardening, not a functional deployment blocker.
 
-The initial server limits are three new builds per client per day, twenty new builds globally per day, and two attempts per combination. Duplicate requests do not consume another build slot. Client rate-limit hashes expire after 24 hours, while GitHub controls runner concurrency.
+The server limits are twenty-one new builds per client per UTC week, one hundred forty new builds globally per UTC week, and two attempts per combination. Duplicate requests do not consume another build slot. Client rate-limit hashes expire at the next Monday 00:00 UTC, while GitHub controls runner concurrency.
 
 Each attempt has a two-hour lease and a UUID fencing token. The Durable Object alarm marks an expired `queued` or `building` attempt as failed, and late callbacks from an older attempt are rejected. Status responses include `attempts`, `max_attempts`, and `retryable`; a build request after the second failure returns HTTP 409.
 
@@ -50,7 +50,7 @@ Cloudflare Worker
 2. Resolve and restrict the allowed firmware ref server-side.
 3. Return status and downloads immediately for an existing cache entry.
 4. Deduplicate concurrent requests for the same combination.
-5. Enforce per-client and global daily limits.
+5. Enforce per-client and global weekly limits.
 6. Trigger GitHub with a minimally privileged server-side GitHub App or installation token.
 7. Never expose GitHub credentials through the browser, logs, or artifacts.
 8. Provide the simple states `missing`, `queued`, `building`, `ready`, and `failed`.

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -183,7 +183,7 @@ def main():
     pageRoot = customBuild.ROOT / "docs" / "custom-build"
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
-    assert 'src="app.js?v=6"' in indexPage
+    assert 'src="app.js?v=7"' in indexPage
     assert 'href="styles.css?v=6"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage
@@ -192,6 +192,8 @@ def main():
     assert "catalog.features.filter(item => !item.hidden)" in appScript
     assert "Usually ready in about 5 minutes" in appScript
     assert "error.status === 429" in appScript
+    assert "weekly build limit" in appScript.lower()
+    assert "daily build limit" not in appScript.lower()
     assert "state.requested = new Set(plugin.recommends.features)" in appScript
     assert '`${ref.replace(/^v/, "")} (stable)`' in appScript
     grinderFeature = next(feature for feature in generatedCatalog["features"] if feature["id"] == "grinder")


### PR DESCRIPTION
## Summary
- replace the 3-per-client daily limit with 21 per UTC week
- replace the 20-build global daily limit with 140 per UTC week
- reset counters Monday at 00:00 UTC and return the exact retry delay
- update the configurator copy and deployment documentation

## Verification
- `node --test cloudflare/custom-build-worker/test/worker.test.mjs`
- `python tools/test_plugin_catalog.py`
- `python tools/test_custom_build_execution.py`
- `python tools/test_ai_docs_contract.py`
- `node --check docs/custom-build/app.js`

The Cloudflare Worker must be deployed after merge.
