### PR TITLE
perf: reduce idle housekeeping work

### DIFF
--- a/include/ble.h
+++ b/include/ble.h
@@ -414,6 +414,7 @@ void queueBleStatusResponse() {
 }
 
 void processBleStatusResponse() {
+  if (bleStatusResponsesPending == 0) return;
   const unsigned long now = millis();
   bool sendStatus = false;
   bool disconnectCurrent = false;

--- a/include/menu.h
+++ b/include/menu.h
@@ -3,6 +3,7 @@
 
 #include "esp32-hal.h"
 #include "parameter.h"
+#include "timing.h"
 #if HDS_FEATURE_WIFI
 #include "mdns_name.h"
 #include "wifi_setup.h"
@@ -22,6 +23,27 @@ String actionMessage = "Default";
 String actionMessage2 = "Default";
 unsigned long t_actionMessage = 0;
 int t_actionMessageDelay = 1000;
+constexpr unsigned long MENU_SAFETY_REFRESH_INTERVAL_MS = 100;
+bool menuFrameDirty = true;
+bool menuFrameShowsActionMessage = false;
+unsigned long lastMenuFrameRender = 0;
+
+inline void invalidateMenuFrame() {
+  menuFrameDirty = true;
+}
+
+inline bool menuFrameNeedsRender(unsigned long now) {
+  const bool actionMessageVisible = now - t_actionMessage < t_actionMessageDelay;
+  return menuFrameDirty
+      || hdsIntervalElapsed(now, lastMenuFrameRender, MENU_SAFETY_REFRESH_INTERVAL_MS)
+      || (menuFrameShowsActionMessage && !actionMessageVisible);
+}
+
+inline void menuActionMessageChanged() {
+  t_actionMessage = millis();
+  invalidateMenuFrame();
+}
+
 template<typename T> int getMenuSize(T &menu) {
   return sizeof(menu) / sizeof(menu[0]);
 }
@@ -245,6 +267,7 @@ int currentPage = 0;
 int totalPages = currentMenuSize / linesPerPage + 1;
 
 void exitMenu() {
+  invalidateMenuFrame();
   u8g2.setFont(FONT_M);
   u8g2.firstPage();
   do {
@@ -275,7 +298,7 @@ void buzzerOn() {
     buzzer.beep(1, BUZZER_DURATION);
   }
   actionMessage = "Buzzer on";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutInt(KEY_BEEP, b_beep);
   Serial.println("Buzzer On stored in NVS.");
@@ -284,7 +307,7 @@ void buzzerOn() {
 void buzzerOff() {
   b_beep = false;
   actionMessage = "Buzzer off";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutInt(KEY_BEEP, b_beep);
   Serial.println("Buzzer off stored in NVS.");
@@ -303,7 +326,7 @@ void toggleWifiOn() {
 #endif
   actionMessage = "WiFi Enabled";
   actionMessage2 = "Restart on exit";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_WIFI_BOOT, true);
   markMenuRestartRequired();
@@ -318,7 +341,7 @@ void toggleWifiOff() {
     grinderSaveSettings();
     actionMessage = "Grind by weight";
     actionMessage2 = "Needs WiFi";
-    t_actionMessage = millis();
+    menuActionMessageChanged();
     t_actionMessageDelay = 1500;
     Serial.println("WiFi Off deferred until Grind by weight is disabled.");
     return;
@@ -327,7 +350,7 @@ void toggleWifiOff() {
   b_wifiOnBoot = false;
   actionMessage = "WiFi Disabled";
   actionMessage2 = "Restart on exit";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_WIFI_BOOT, false);
   markMenuRestartRequired();
@@ -446,7 +469,7 @@ void resetWifi() {
   saveCredentials("", "");
   actionMessage = "WiFi Reset";
   actionMessage2 = "Restart on exit";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   markMenuRestartRequired();
 }
@@ -455,7 +478,7 @@ void resetWifi() {
 void heartbeatOn() {
   b_requireHeartBeat = true;
   actionMessage = "Heartbeat On";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_HEARTBEAT, b_requireHeartBeat);
   Serial.println("Heartbeat detection...On");
@@ -464,7 +487,7 @@ void heartbeatOn() {
 void heartbeatOff() {
   b_requireHeartBeat = false;
   actionMessage = "Heartbeat Off";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_HEARTBEAT, b_requireHeartBeat);
   Serial.println("Heartbeat detection...Off");
@@ -473,7 +496,7 @@ void heartbeatOff() {
 void flipScreenOn() {
   b_screenFlipped = true;
   actionMessage = "Flip On";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_SCREEN_FLIP, b_screenFlipped);
   u8g2.setDisplayRotation(U8G2_R0);
@@ -483,7 +506,7 @@ void flipScreenOn() {
 void flipScreenOff() {
   b_screenFlipped = false;
   actionMessage = "Flip Off";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_SCREEN_FLIP, b_screenFlipped);
   u8g2.setDisplayRotation(U8G2_R2);
@@ -493,7 +516,7 @@ void flipScreenOff() {
 void timeOnTopOn() {
   b_timeOnTop = true;
   actionMessage = "Time On Top";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_TIME_ON_TOP, b_timeOnTop);
   Serial.println("Time On Top");
@@ -502,7 +525,7 @@ void timeOnTopOn() {
 void timeOnTopOff() {
   b_timeOnTop = false;
   actionMessage = "Weight On Top";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_TIME_ON_TOP, b_timeOnTop);
   Serial.println("Weight On Top");
@@ -511,7 +534,7 @@ void timeOnTopOff() {
 void btnFuncWhileConnectedOn() {
   b_btnFuncWhileConnected = true;
   actionMessage = "BLE Btns On";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_BTN_CONN, b_btnFuncWhileConnected);
   Serial.println("BLE Btns On");
@@ -520,7 +543,7 @@ void btnFuncWhileConnectedOn() {
 void btnFuncWhileConnectedOff() {
   b_btnFuncWhileConnected = false;
   actionMessage = "BLE Btns Off";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_BTN_CONN, b_btnFuncWhileConnected);
   Serial.println("BLE Btns Off");
@@ -529,7 +552,7 @@ void btnFuncWhileConnectedOff() {
 void autoSleepOn() {
   b_autoSleep = true;
   actionMessage = "Autosleep On";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_AUTO_SLEEP, b_autoSleep);
   Serial.println("Autosleep on stored in NVS.");
@@ -538,7 +561,7 @@ void autoSleepOn() {
 void autoSleepOff() {
   b_autoSleep = false;
   actionMessage = "Autosleep Off";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_AUTO_SLEEP, b_autoSleep);
   Serial.println("Autosleep off stored in NVS.");
@@ -547,7 +570,7 @@ void autoSleepOff() {
 void quickBootOn() {
   b_quickBoot = true;
   actionMessage = "Quick Boot On";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_QUICK_BOOT, b_quickBoot);
   Serial.println("Quick boot on stored in NVS.");
@@ -556,7 +579,7 @@ void quickBootOn() {
 void quickBootOff() {
   b_quickBoot = false;
   actionMessage = "Quick Boot Off";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_QUICK_BOOT, b_quickBoot);
   Serial.println("Quick boot off stored in NVS.");
@@ -565,7 +588,7 @@ void quickBootOff() {
 void driftCompOff() {
   f_maxDriftCompensation = 0.0;
   actionMessage = "Drift Comp Off";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
   Serial.println("Drift Comp Off stored in NVS.");
@@ -574,7 +597,7 @@ void driftCompOff() {
 void driftComp0050() {
   f_maxDriftCompensation = 0.05;
   actionMessage = "Drift Comp 0.05g";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
   Serial.println("Drift Comp 0.05g stored in NVS.");
@@ -583,7 +606,7 @@ void driftComp0050() {
 void driftComp0075() {
   f_maxDriftCompensation = 0.075;
   actionMessage = "Drift Comp 0.075g";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
   Serial.println("Drift Comp 0.075g stored in NVS.");
@@ -592,7 +615,7 @@ void driftComp0075() {
 void driftComp0100() {
   f_maxDriftCompensation = 0.1;
   actionMessage = "Drift Comp 0.1g";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
   Serial.println("Drift Comp 0.1g stored in NVS.");
@@ -601,7 +624,7 @@ void driftComp0100() {
 void driftComp0200() {
   f_maxDriftCompensation = 0.2;
   actionMessage = "Drift Comp 0.2g";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   storagePutFloat(KEY_DRIFT_MAX, f_maxDriftCompensation);
   Serial.println("Drift Comp 0.2g stored in NVS.");
@@ -611,7 +634,7 @@ void driftComp0200() {
 void grinderSetActionMessage(const char *line1, const char *line2 = nullptr) {
   actionMessage = line1;
   actionMessage2 = line2 == nullptr ? "Default" : line2;
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1500;
 }
 
@@ -928,6 +951,7 @@ void calibrationFinish(bool returnToMenu) {
   calibrationRestoreSampleWindow();
   if (returnToMenu) {
     b_menu = true;
+    invalidateMenuFrame();
   }
 }
 
@@ -1587,7 +1611,7 @@ void enableDebug() {
 
 void calibrateVoltage() {
   actionMessage = "Calibrate 4.2v";
-  t_actionMessage = millis();
+  menuActionMessageChanged();
   t_actionMessageDelay = 1000;
   const int numReadings = 50;
   long adcSum = 0;
@@ -1613,11 +1637,13 @@ void calibrateVoltage() {
 void navigateMenu(int direction) {
   currentIndex = (currentIndex + direction + currentMenuSize) % currentMenuSize;
   currentSelection = currentMenu[currentIndex];
+  invalidateMenuFrame();
   Serial.print("currentIndex ");
   Serial.println(currentIndex);
 }
 
 void selectMenu() {
+  invalidateMenuFrame();
   if (currentSelection->subMenu) {
 #ifdef BUZZER
     if (currentSelection == &menuBuzzer) {
@@ -1680,6 +1706,9 @@ void selectMenu() {
 }
 
 void showMenu() {
+  const unsigned long now = millis();
+  if (!menuFrameNeedsRender(now)) return;
+  const bool actionMessageVisible = now - t_actionMessage < t_actionMessageDelay;
   if (b_screenFlipped)
     u8g2.setDisplayRotation(U8G2_R0);
   else
@@ -1688,7 +1717,7 @@ void showMenu() {
   u8g2.setFont(FONT_S);
   u8g2.firstPage();
   do {
-    if (millis() - t_actionMessage < t_actionMessageDelay) {
+    if (actionMessageVisible) {
       u8g2.setFont(FONT_M);
       if (AC(actionMessage.c_str()) < 0)
         u8g2.setFont(FONT_S);
@@ -1720,6 +1749,9 @@ void showMenu() {
       }
     }
   } while (u8g2.nextPage());
+  lastMenuFrameRender = now;
+  menuFrameShowsActionMessage = actionMessageVisible;
+  menuFrameDirty = false;
 }
 
 #endif

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -2,6 +2,7 @@
 #define PARAMETER_H
 //declaration
 #include <Arduino.h>
+#include <atomic>
 #include <Preferences.h>
 #include <math.h>
 #include <mutex>
@@ -38,6 +39,11 @@ const unsigned long WEBSOCKET_DEFAULT_NOTIFY_INTERVAL_MS = WEBSOCKET_2HZ_NOTIFY_
 volatile unsigned long weightWebsocketNotifyInterval = WEBSOCKET_DEFAULT_NOTIFY_INTERVAL_MS;
 volatile bool b_websocketEventsEnabled = false;
 volatile bool b_websocketLowPowerEnabled = false;
+std::atomic<uint8_t> g_websocketClientCount{0};
+
+inline bool websocketHasClients() {
+  return g_websocketClientCount.load(std::memory_order_relaxed) > 0;
+}
 
 // Snapshot of the stopWatch state, refreshed once per main-loop iteration. The
 // WS status frame is built on the AsyncTCP task (response to {"command":"status"}

--- a/include/timing.h
+++ b/include/timing.h
@@ -1,0 +1,10 @@
+#ifndef HDS_TIMING_H
+#define HDS_TIMING_H
+
+inline bool hdsIntervalElapsed(unsigned long now,
+                                unsigned long last,
+                                unsigned long interval) {
+  return now - last >= interval;
+}
+
+#endif

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -176,7 +176,7 @@ void startWebServer() {
         return;
       }
 #if HDS_FEATURE_WEBSOCKET
-      if (websocket.count() > 0) {
+      if (websocketHasClients()) {
         static int tokens = HTTP_STREAMING_BURST;
         static unsigned long lastRefill = 0;
         static unsigned long lastPageLoadBoost = 0;

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -140,6 +140,7 @@ inline void wsReplacePending(uint32_t setBits, uint32_t clearBits) {
 }
 
 void processWsPendingCmds() {
+  if (wsPendingMask == 0) return;
   portENTER_CRITICAL(&wsPendingMux);
   uint32_t mask = b_ota ? (wsPendingMask & WSP_OTA_RESET) : wsPendingMask;
   uint8_t samplesInUse = pendingSamplesInUse;
@@ -297,7 +298,7 @@ static inline bool wsClientHeapOk() {
 }
 
 void sendWebsocketButton(int buttonNumber, int buttonShortPress) {
-  if (!b_wifiEnabled || !b_websocketEventsEnabled || websocket.count() == 0) return;
+  if (!b_wifiEnabled || !b_websocketEventsEnabled || !websocketHasClients()) return;
   if (!wsBroadcastHeapOk()) return;
   websocket.printfAll("{\"type\":\"button\",\"button\":\"%s\",\"button_number\":%d,\"press\":\"%s\",\"press_code\":%d,\"ms\":%lu}",
                       websocketButtonName(buttonNumber),
@@ -308,7 +309,7 @@ void sendWebsocketButton(int buttonNumber, int buttonShortPress) {
 }
 
 void sendWebsocketPowerOff(int i_reason) {
-  if (!b_wifiEnabled || !b_websocketEventsEnabled || websocket.count() == 0) return;
+  if (!b_wifiEnabled || !b_websocketEventsEnabled || !websocketHasClients()) return;
   if (!wsBroadcastHeapOk()) return;
   websocket.printfAll("{\"type\":\"power\",\"event\":\"power_off\",\"reason\":\"%s\",\"reason_code\":%d,\"ms\":%lu}",
                       websocketPowerOffReason(i_reason),
@@ -374,7 +375,7 @@ void sendWebsocketStatus(AsyncWebSocketClient *client, const char *status) {
 }
 
 void sendWebsocketWeightAll(float grams, unsigned long ms) {
-  if (!b_wifiEnabled || websocket.count() == 0) return;
+  if (!b_wifiEnabled || !websocketHasClients()) return;
   if (!wsBroadcastHeapOk()) return;
   char message[96];
   int messageLength = snprintf(message, sizeof(message),
@@ -676,12 +677,15 @@ void setupWebsocketEvents() {
                       AsyncWebSocket *server, AsyncWebSocketClient *client,
                       AwsEventType type, void *arg, uint8_t *data, size_t len) {
     if (type == WS_EVT_CONNECT) {
+      server->cleanupClients(4);
+      g_websocketClientCount.store(server->count(), std::memory_order_relaxed);
       Serial.printf("Client %u connected\n", client->id());
       client->setCloseClientOnQueueFull(false);
       client->client()->setAckTimeout(30000);
     } else if (type == WS_EVT_DISCONNECT) {
       Serial.printf("Client %u disconnected\n", client->id());
-      if (server->count() == 0) {
+      g_websocketClientCount.store(server->count(), std::memory_order_relaxed);
+      if (!websocketHasClients()) {
         weightWebsocketNotifyInterval = WEBSOCKET_DEFAULT_NOTIFY_INTERVAL_MS;
         b_websocketEventsEnabled = false;
       }

--- a/include/websocket.h
+++ b/include/websocket.h
@@ -678,6 +678,9 @@ void setupWebsocketEvents() {
                       AwsEventType type, void *arg, uint8_t *data, size_t len) {
     if (type == WS_EVT_CONNECT) {
       server->cleanupClients(4);
+      if (server->count() > 4) {
+        client->close();
+      }
       g_websocketClientCount.store(server->count(), std::memory_order_relaxed);
       Serial.printf("Client %u connected\n", client->id());
       client->setCloseClientOnQueueFull(false);

--- a/include/wifi_setup.h
+++ b/include/wifi_setup.h
@@ -18,6 +18,8 @@ bool saveDeviceNameForRestart(const char *name, char *stored, size_t storedSize)
 
 void wifiSupervise();
 
+constexpr unsigned long WIFI_SUPERVISE_INTERVAL_MS = 250;
+
 extern volatile bool b_wifiEnabled;
 
 extern const char *wifiPrefsKey;

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -34,12 +34,15 @@
 #include "ble.h"
 #include "usbcomm.h"
 #include "finger_detection.h"
+#include "timing.h"
 
 #if HDS_ENABLE_GRINDER
 #ifndef GRINDER_MENU_CHORD_HOLD_MS
 #define GRINDER_MENU_CHORD_HOLD_MS 500
 #endif
 #endif
+
+constexpr unsigned long BUTTON_POLL_INTERVAL_MS = 2;
 
 bool anyScaleButtonPressed() {
   return digitalRead(BUTTON_CIRCLE) == LOW || digitalRead(BUTTON_SQUARE) == LOW;
@@ -344,6 +347,7 @@ bool handleGrinderMenuChord() {
     return true;
   }
   b_menu = true;
+  invalidateMenuFrame();
   b_grinderMenuDirectEntry = true;
   b_buttonChordSuppressUntilRelease = true;
   currentMenu = grinderMenu;
@@ -376,14 +380,14 @@ void button_init() {
 void _wifi_init(void *args) {
   b_wifiEnabled = true;
   setupWifi();
+#if HDS_FEATURE_WEBSOCKET
+  setupWebsocketEvents();
+#endif
 #if HDS_FEATURE_WEBSERVER
   startWebServer();
 #endif
 #if HDS_FEATURE_ELEGANT_OTA
   wifiOta();
-#endif
-#if HDS_FEATURE_WEBSOCKET
-  setupWebsocketEvents();
 #endif
   vTaskDelete(NULL);
 }
@@ -733,6 +737,7 @@ void setup() {
 #endif
   if (digitalRead(BUTTON_CIRCLE) == LOW && digitalRead(BUTTON_SQUARE) == LOW) {
     b_menu = true;
+    invalidateMenuFrame();
     b_buttonChordSuppressUntilRelease = true;
 #if HDS_ENABLE_GRINDER
     b_grinderMenuDirectEntry = false;
@@ -1476,7 +1481,7 @@ void loop() {
 #endif
   if (b_ota || bleHasLiveClient()
 #if HDS_FEATURE_WEBSOCKET
-      || (b_wifiEnabled && websocket.count() > 0)
+      || (b_wifiEnabled && websocketHasClients())
 #endif
 #if HDS_ENABLE_GRINDER
       || grinderRuntimeKeepsAwake()
@@ -1504,8 +1509,12 @@ void loop() {
       && !handleGrinderMenuChord()
 #endif
   ) {
-    buttonCircle.check();
-    buttonSquare.check();
+    static unsigned long lastButtonPoll = 0;
+    if (hdsIntervalElapsed(now, lastButtonPoll, BUTTON_POLL_INTERVAL_MS)) {
+      lastButtonPoll = now;
+      buttonCircle.check();
+      buttonSquare.check();
+    }
   }
 #ifdef BUZZER
   buzzer.check();
@@ -1597,9 +1606,6 @@ void loop() {
           wifiSupervise();
 #if !HDS_FEATURE_WEBSERVER
           wifiConfigServerPoll();
-#endif
-#if HDS_FEATURE_WEBSOCKET
-          websocket.cleanupClients(4);
 #endif
 #if HDS_FEATURE_ELEGANT_OTA
           ElegantOTA.loop();

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1510,8 +1510,9 @@ void loop() {
 #endif
   ) {
     static unsigned long lastButtonPoll = 0;
-    if (hdsIntervalElapsed(now, lastButtonPoll, BUTTON_POLL_INTERVAL_MS)) {
-      lastButtonPoll = now;
+    const unsigned long buttonNow = millis();
+    if (hdsIntervalElapsed(buttonNow, lastButtonPoll, BUTTON_POLL_INTERVAL_MS)) {
+      lastButtonPoll = buttonNow;
       buttonCircle.check();
       buttonSquare.check();
     }

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -6,7 +6,9 @@
 #include "esp32-hal.h"
 #include "esp_system.h"  // esp_restart() for the heap watchdog
 #include "mdns_name.h"
+#include "timing.h"
 #include <Arduino.h>
+#include "wifi_setup.h"
 #if HDS_FEATURE_MDNS
 #include <ESPmDNS.h>
 #endif
@@ -240,6 +242,7 @@ void setupWifi() {
 }
 
 void wifiSupervise() {
+  static unsigned long lastRun = 0;
   static unsigned long lastLog = 0;
   static unsigned long downSince = 0;
   static unsigned long lastAttempt = 0;
@@ -247,6 +250,10 @@ void wifiSupervise() {
   static unsigned long lowHeapSince = 0;
   static unsigned long lastDeferLog = 0;
   unsigned long now = millis();
+  if (!hdsIntervalElapsed(now, lastRun, WIFI_SUPERVISE_INTERVAL_MS)) {
+    return;
+  }
+  lastRun = now;
   bool up = WiFi.status() == WL_CONNECTED;
 
 #if HDS_FEATURE_MDNS

--- a/tools/test_idle_optimizations_contract.py
+++ b/tools/test_idle_optimizations_contract.py
@@ -44,6 +44,31 @@ class ClientCount:
         self.count = actual_count
 
 
+class WebSocketChurnModel:
+    CONNECTED = "connected"
+    DISCONNECTING = "disconnecting"
+
+    def __init__(self):
+        self.clients = []
+
+    def connected_count(self):
+        return sum(state == self.CONNECTED for state in self.clients)
+
+    def cleanup_clients(self, maximum):
+        if self.connected_count() > maximum:
+            if self.clients[0] == self.CONNECTED:
+                self.clients[0] = self.DISCONNECTING
+
+    def connect(self, maximum):
+        self.clients.append(self.CONNECTED)
+        self.cleanup_clients(maximum)
+        if self.connected_count() > maximum:
+            self.clients[-1] = self.DISCONNECTING
+
+    def remove_disconnecting(self):
+        self.clients = [state for state in self.clients if state != self.DISCONNECTING]
+
+
 class IdleOptimizationContractTests(unittest.TestCase):
     def test_websocket_client_cache_and_cleanup_contract(self):
         self.assertIn("std::atomic<uint8_t> g_websocketClientCount{0};", PARAMETER)
@@ -51,9 +76,12 @@ class IdleOptimizationContractTests(unittest.TestCase):
         self.assertIn("inline bool websocketHasClients()", PARAMETER)
         connect = WEBSOCKET[WEBSOCKET.index("if (type == WS_EVT_CONNECT)"):]
         self.assertIn("server->cleanupClients(4);", connect)
+        self.assertIn("if (server->count() > 4)", connect)
+        self.assertIn("client->close();", connect)
         self.assertIn("g_websocketClientCount.store(server->count(), std::memory_order_relaxed);", connect)
+        self.assertLess(connect.index("client->close();"), connect.index("g_websocketClientCount.store"))
         self.assertEqual(WEBSOCKET.count("server->cleanupClients(4);"), 1)
-        self.assertEqual(WEBSOCKET.count("server->count()"), 2)
+        self.assertEqual(WEBSOCKET.count("server->count()"), 3)
         loop = function_body(HDS, "loop")
         self.assertNotIn("websocket.count()", loop)
         self.assertNotIn("cleanupClients", loop)
@@ -65,6 +93,17 @@ class IdleOptimizationContractTests(unittest.TestCase):
         self.assertEqual(cache.count, 1)
         cache.disconnect(0)
         self.assertEqual(cache.count, 0)
+
+        churn = WebSocketChurnModel()
+        for _ in range(4):
+            churn.connect(4)
+        churn.connect(4)
+        self.assertEqual(churn.connected_count(), 4)
+        churn.connect(4)
+        self.assertEqual(churn.connected_count(), 4)
+        self.assertEqual(churn.clients.count(WebSocketChurnModel.DISCONNECTING), 2)
+        churn.remove_disconnecting()
+        self.assertEqual(churn.connected_count(), 4)
 
     def test_wifi_cadence_and_rollover_contract(self):
         self.assertIn("WIFI_SUPERVISE_INTERVAL_MS = 250", WIFI_HEADER)
@@ -101,11 +140,14 @@ class IdleOptimizationContractTests(unittest.TestCase):
     def test_button_poll_cadence_contract(self):
         self.assertIn("BUTTON_POLL_INTERVAL_MS = 2", HDS)
         loop = function_body(HDS, "loop")
-        gate = "hdsIntervalElapsed(now, lastButtonPoll, BUTTON_POLL_INTERVAL_MS)"
+        gate = "hdsIntervalElapsed(buttonNow, lastButtonPoll, BUTTON_POLL_INTERVAL_MS)"
         self.assertIn(gate, loop)
         self.assertLess(loop.index(gate), loop.index("buttonCircle.check();"))
         self.assertLess(loop.index(gate), loop.index("buttonSquare.check();"))
         self.assertLess(loop.index("handleGrinderMenuChord()"), loop.index(gate))
+        self.assertIn("const unsigned long buttonNow = millis();", loop)
+        self.assertIn("hdsIntervalElapsed(buttonNow, lastButtonPoll, BUTTON_POLL_INTERVAL_MS)", loop)
+        self.assertIn("lastButtonPoll = buttonNow;", loop)
         self.assertTrue(elapsed(2, 0, 2))
         self.assertFalse(elapsed(1, 0, 2))
         self.assertTrue(elapsed(0x00000001, 0xFFFFFFFF, 2))

--- a/tools/test_idle_optimizations_contract.py
+++ b/tools/test_idle_optimizations_contract.py
@@ -1,0 +1,115 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HDS = (ROOT / "src" / "hds.ino").read_text(encoding="utf-8")
+MENU = (ROOT / "include" / "menu.h").read_text(encoding="utf-8")
+PARAMETER = (ROOT / "include" / "parameter.h").read_text(encoding="utf-8")
+WEBSOCKET = (ROOT / "include" / "websocket.h").read_text(encoding="utf-8")
+BLE = (ROOT / "include" / "ble.h").read_text(encoding="utf-8")
+WIFI = (ROOT / "src" / "wifi_setup.cpp").read_text(encoding="utf-8")
+WIFI_HEADER = (ROOT / "include" / "wifi_setup.h").read_text(encoding="utf-8")
+
+
+def function_body(source, name):
+    match = re.search(rf"\b\w+\s+{re.escape(name)}\([^;{{}}]*\)\s*{{", source)
+    if match is None:
+        raise AssertionError(f"missing function: {name}")
+    opening = source.index("{", match.start())
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1:index]
+    raise AssertionError(f"unterminated function: {name}")
+
+
+def elapsed(now, last, interval):
+    return ((now - last) & 0xFFFFFFFF) >= interval
+
+
+class ClientCount:
+    def __init__(self):
+        self.count = 0
+
+    def connect(self, actual_count):
+        self.count = actual_count
+
+    def disconnect(self, actual_count):
+        self.count = actual_count
+
+
+class IdleOptimizationContractTests(unittest.TestCase):
+    def test_websocket_client_cache_and_cleanup_contract(self):
+        self.assertIn("std::atomic<uint8_t> g_websocketClientCount{0};", PARAMETER)
+        self.assertIn("g_websocketClientCount.load(std::memory_order_relaxed)", PARAMETER)
+        self.assertIn("inline bool websocketHasClients()", PARAMETER)
+        connect = WEBSOCKET[WEBSOCKET.index("if (type == WS_EVT_CONNECT)"):]
+        self.assertIn("server->cleanupClients(4);", connect)
+        self.assertIn("g_websocketClientCount.store(server->count(), std::memory_order_relaxed);", connect)
+        self.assertEqual(WEBSOCKET.count("server->cleanupClients(4);"), 1)
+        self.assertEqual(WEBSOCKET.count("server->count()"), 2)
+        loop = function_body(HDS, "loop")
+        self.assertNotIn("websocket.count()", loop)
+        self.assertNotIn("cleanupClients", loop)
+        wifi_init = function_body(HDS, "_wifi_init")
+        self.assertLess(wifi_init.index("setupWebsocketEvents();"), wifi_init.index("startWebServer();"))
+
+        cache = ClientCount()
+        cache.connect(1)
+        self.assertEqual(cache.count, 1)
+        cache.disconnect(0)
+        self.assertEqual(cache.count, 0)
+
+    def test_wifi_cadence_and_rollover_contract(self):
+        self.assertIn("WIFI_SUPERVISE_INTERVAL_MS = 250", WIFI_HEADER)
+        body = function_body(WIFI, "wifiSupervise")
+        gate = "hdsIntervalElapsed(now, lastRun, WIFI_SUPERVISE_INTERVAL_MS)"
+        self.assertIn(gate, body)
+        self.assertLess(body.index(gate), body.index("WiFi.status()"))
+        self.assertFalse(elapsed(249, 0, 250))
+        self.assertTrue(elapsed(250, 0, 250))
+        self.assertTrue(elapsed(0x00000010, 0xFFFFFF00, 250))
+
+    def test_menu_dirty_refresh_contract(self):
+        self.assertIn("MENU_SAFETY_REFRESH_INTERVAL_MS = 100", MENU)
+        self.assertIn("void invalidateMenuFrame()", MENU)
+        self.assertIn("menuFrameShowsActionMessage && !actionMessageVisible", MENU)
+        show_menu = function_body(MENU, "showMenu")
+        self.assertLess(show_menu.index("menuFrameNeedsRender(now)"), show_menu.index("u8g2.firstPage()"))
+        self.assertIn("lastMenuFrameRender = now;", show_menu)
+        self.assertIn("menuFrameDirty = false;", show_menu)
+        self.assertIn("invalidateMenuFrame();", function_body(MENU, "navigateMenu"))
+        self.assertIn("invalidateMenuFrame();", function_body(MENU, "selectMenu"))
+        self.assertIn("invalidateMenuFrame();", function_body(MENU, "menuActionMessageChanged"))
+        self.assertTrue(elapsed(100, 0, 100))
+        self.assertTrue(elapsed(0x00000010, 0xFFFFFFA0, 100))
+
+    def test_pending_consumers_fast_path_before_lock(self):
+        ws = function_body(WEBSOCKET, "processWsPendingCmds")
+        ble = function_body(BLE, "processBleStatusResponse")
+        self.assertLess(ws.index("if (wsPendingMask == 0) return;"), ws.index("portENTER_CRITICAL(&wsPendingMux)"))
+        self.assertLess(ble.index("if (bleStatusResponsesPending == 0) return;"), ble.index("portENTER_CRITICAL(&bleFff4Mux)"))
+        self.assertLess(ws.index("uint32_t mask = b_ota ? (wsPendingMask & WSP_OTA_RESET) : wsPendingMask;"), ws.index("portEXIT_CRITICAL(&wsPendingMux)"))
+        self.assertLess(ble.index("bleStatusResponsesPending = bleStatusResponsesPending - 1;"), ble.index("portEXIT_CRITICAL(&bleFff4Mux)"))
+
+    def test_button_poll_cadence_contract(self):
+        self.assertIn("BUTTON_POLL_INTERVAL_MS = 2", HDS)
+        loop = function_body(HDS, "loop")
+        gate = "hdsIntervalElapsed(now, lastButtonPoll, BUTTON_POLL_INTERVAL_MS)"
+        self.assertIn(gate, loop)
+        self.assertLess(loop.index(gate), loop.index("buttonCircle.check();"))
+        self.assertLess(loop.index(gate), loop.index("buttonSquare.check();"))
+        self.assertLess(loop.index("handleGrinderMenuChord()"), loop.index(gate))
+        self.assertTrue(elapsed(2, 0, 2))
+        self.assertFalse(elapsed(1, 0, 2))
+        self.assertTrue(elapsed(0x00000001, 0xFFFFFFFF, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Cache WebSocket client presence and clean stale clients on connect.
- Throttle WiFi supervision to 250 ms.
- Render the menu only when dirty, on action-message expiry, or on the 100 ms safety refresh.
- Skip WebSocket and BLE pending processing when no work is queued.
- Poll hardware buttons every 2 ms with rollover-safe timing.

## Validation

- 35 Python tests passed, 1 skipped.
- Native PlatformIO tests passed: 16 cases.
- Firmware builds passed: esp32s3, esp32s3-grinder, esp32s3-custom.