### PR TITLE
fix(custom-build): preserve firmware binaries across buildfs

### DIFF
--- a/tools/build_custom_firmware.py
+++ b/tools/build_custom_firmware.py
@@ -25,6 +25,9 @@ BUILD_FILES = (
     "build-manifest.json",
     "dependencies.txt",
 )
+PROGRAM_BINARIES = tuple(
+    name for name in customBuild.PUBLIC_BINARIES if name != "littlefs.bin"
+)
 MAX_REMOTE_MANIFEST_BYTES = 1024 * 1024
 
 
@@ -203,6 +206,11 @@ def createFirmwareArchive(buildDir):
             info = zipfile.ZipInfo(name, (1980, 1, 1, 0, 0, 0))
             info.external_attr = 0o100644 << 16
             archive.writestr(info, (buildDir / name).read_bytes())
+
+
+def copyBuildFiles(sourceDir, targetDir, names):
+    for name in names:
+        shutil.copy2(sourceDir / name, targetDir / name)
 
 
 def writeDependencyInventory(buildDir, checkoutRoot, environment, platformioEnvironment):
@@ -385,13 +393,17 @@ def buildCustomFirmware(
             "HDS_FIRMWARE_VERSION": identity["firmware_version"],
             "SOURCE_DATE_EPOCH": sourceEpoch,
         }
-        runCommand(["pio", "run", "-e", platformioEnvironment], checkoutRoot, environment=environment)
-        runCommand(
-            ["pio", "run", "-e", platformioEnvironment, "-t", "buildfs"],
-            checkoutRoot,
-            environment=environment,
-        )
         buildDir = checkoutRoot / ".pio.nosync" / "build" / platformioEnvironment
+        runCommand(["pio", "run", "-e", platformioEnvironment], checkoutRoot, environment=environment)
+        with tempfile.TemporaryDirectory(prefix="custom-program-") as programDirectory:
+            preservedBinaries = Path(programDirectory)
+            copyBuildFiles(buildDir, preservedBinaries, PROGRAM_BINARIES)
+            runCommand(
+                ["pio", "run", "-e", platformioEnvironment, "-t", "buildfs"],
+                checkoutRoot,
+                environment=environment,
+            )
+            copyBuildFiles(preservedBinaries, buildDir, PROGRAM_BINARIES)
         writeDependencyInventory(buildDir, checkoutRoot, environment, platformioEnvironment)
         createFirmwareArchive(buildDir)
         customBuild.writeBuildManifest(

--- a/tools/test_custom_build_execution.py
+++ b/tools/test_custom_build_execution.py
@@ -257,6 +257,18 @@ def main():
                 "firmware.bin", "firmware.factory.bin", "bootloader.bin", "partitions.bin", "littlefs.bin",
             ):
                 (buildDir / name).write_bytes(name.encode("ascii"))
+            preservedBinaries = root / "preserved-binaries"
+            preservedBinaries.mkdir()
+            customRunner.copyBuildFiles(
+                buildDir, preservedBinaries, customRunner.PROGRAM_BINARIES
+            )
+            for name in customRunner.PROGRAM_BINARIES:
+                (buildDir / name).unlink()
+            customRunner.copyBuildFiles(
+                preservedBinaries, buildDir, customRunner.PROGRAM_BINARIES
+            )
+            for name in customRunner.PROGRAM_BINARIES:
+                assert (buildDir / name).read_bytes() == name.encode("ascii")
             (buildDir / "dependencies.txt").write_text("PlatformIO Core", encoding="utf-8")
             customRunner.createFirmwareArchive(buildDir)
             archiveBytes = (buildDir / customBuild.FIRMWARE_ARCHIVE).read_bytes()


### PR DESCRIPTION
## Summary

- preserve the program binaries before the separate LittleFS build
- restore them before creating the custom firmware ZIP and manifest
- cover the preservation path in the existing custom-build execution test

## Root cause

With the current PIOArduino platform, `pio run -t buildfs` cleans the environment build directory. The firmware build succeeds, but `firmware.bin`, `bootloader.bin`, and `partitions.bin` are gone when the archive is created.

## Validation

- `python tools/test_custom_build_execution.py`
- `python tools/test_plugin_catalog.py`
- `python tools/test_custom_cache_transport.py`
- `python tools/test_ai_docs_contract.py`
- `node --test cloudflare/custom-build-worker/test/worker.test.mjs`
- full local `esp32s3-energy-menu-custom` firmware and LittleFS build with archive verification