### PR TITLE
Restore legacy USB weight-enable framing

### DIFF
--- a/include/decent_protocol.h
+++ b/include/decent_protocol.h
@@ -99,7 +99,13 @@ static inline size_t decentCommandFrameLength(const uint8_t *data, size_t len, b
       if (len < 3) {
         return 0;
       }
-      return decentFixedFrameLength(len, data[2] == 0x01 ? 4 : 3);
+      if (data[2] != 0x01) {
+        return 3;
+      }
+      if (len >= 4) {
+        return 4;
+      }
+      return allowShort ? 3 : 0;
 #if defined(ACC_MPU6050) || defined(ACC_BMA400)
     case 0x21:
       return decentFixedFrameLength(len, 2);

--- a/tools/test_decent_weight_frame_contract.py
+++ b/tools/test_decent_weight_frame_contract.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+HEADER = Path(__file__).resolve().parents[1] / "include" / "decent_protocol.h"
+
+
+def main():
+    source = HEADER.read_text(encoding="utf-8")
+    start = source.index("    case 0x20:", source.index("decentCommandFrameLength"))
+    end = source.index("#if defined(ACC_MPU6050)", start)
+    weight_frame = source[start:end]
+    expected = [
+        "if (len < 3)",
+        "if (data[2] != 0x01)",
+        "return 3;",
+        "if (len >= 4)",
+        "return 4;",
+        "return allowShort ? 3 : 0;",
+    ]
+    cursor = 0
+    for snippet in expected:
+        cursor = weight_frame.index(snippet, cursor) + len(snippet)
+    print("Decent weight frame contract tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- prefer the current four-byte USB weight-enable command
- accept the legacy three-byte enable form after the existing 30 ms timeout
- retain immediate three-byte handling for disable commands

## Verification
- python tools/test_decent_weight_frame_contract.py
- pio run -e esp32s3