### PR TITLE
fix(custom-build): preserve empty selections

### DIFF
--- a/cloudflare/custom-build-worker/src/worker.mjs
+++ b/cloudflare/custom-build-worker/src/worker.mjs
@@ -476,8 +476,8 @@ async function dispatchBuild(env, build) {
       ref: build.builderRef,
       inputs: {
         firmware_ref: build.configuration.firmware_ref,
-        features: build.configuration.features.join(","),
-        plugins: build.configuration.plugins.join(","),
+        features: build.configuration.features.join(",") || ",",
+        plugins: build.configuration.plugins.join(",") || ",",
         builder_ref: build.builderRef,
         builder_commit: build.builderCommit,
         source_commit: build.sourceCommit,

--- a/cloudflare/custom-build-worker/test/worker.test.mjs
+++ b/cloudflare/custom-build-worker/test/worker.test.mjs
@@ -243,8 +243,8 @@ test("publishes immutable cache entries and deduplicates public builds", async (
       assert.equal(request.inputs.source_commit, commit);
       if (dispatches === 1) {
         assert.equal(request.inputs.combination_hash, "280d0fb981fa56f7753846b33b91a5b053145d41360551f8c27c0b38e7ee955c");
-        assert.equal(request.inputs.features, "");
-        assert.equal(request.inputs.plugins, "");
+        assert.equal(request.inputs.features, ",");
+        assert.equal(request.inputs.plugins, ",");
       }
       if (failDispatch) return Response.json({message: "unavailable"}, {status: 503});
       return new Response(null, {status: 204});


### PR DESCRIPTION
GitHub Actions replaces empty workflow-dispatch inputs with their defaults. Send a comma sentinel for empty feature and plugin selections so the workflow parser resolves them back to empty lists instead of building default-web-apps. Adds regression assertions for both inputs.

Verified with the Worker test suite and a successful energy-menu-only build.