### PR TITLE
Double/triple tap on scale top for tare and timer controls based on weight changes

### DIFF
--- a/docs/AI_REPO_MAP.md
+++ b/docs/AI_REPO_MAP.md
@@ -13,7 +13,7 @@ Local build, flash, OTA, editor, cache, and CAD files are omitted unless they ar
 | Compile-time feature flags, build environments | `platformio.ini`, `include/config.h`, `src/hds.ino` | `docs/AI_BUILD_NOTES.md` |
 | Approved plugins, patch packages, plugin CI | matching `plugins/<plugin-id>/plugin.json`, `tools/configure_custom_build.py`, `tools/build_custom_firmware.py` | `docs/AI_PLUGIN_NOTES.md`, `docs/plugin-development.md` |
 | Global firmware state | `include/parameter.h`, then every reader and writer | `docs/AI_FIRMWARE_NOTES.md` |
-| Main loop, buttons, weighing, OLED | `docs/AI_DISPLAY_NOTES.md`, `src/hds.ino`, `include/menu.h`, `include/display.h`, `include/finger_detection.h` | `docs/AI_FIRMWARE_NOTES.md` |
+| Main loop, buttons, weighing, OLED | `docs/AI_DISPLAY_NOTES.md`, `src/hds.ino`, `include/menu.h`, `include/display.h`, `include/finger_detection.h`, `include/tap_detection.h` | `docs/AI_FIRMWARE_NOTES.md` |
 | Calibration, ADC, tare stability | `include/calibration_validation.h`, `include/menu.h`, `src/hds.ino` | `docs/AI_FIRMWARE_NOTES.md` |
 | Persistent settings, defaults, migration | `include/storage.h` | `docs/AI_STORAGE_NOTES.md` |
 | Decent binary, BLE, USB, ADS debug | `include/decent_protocol.h`, then `include/ble.h` or `include/usbcomm.h` | `docs/AI_PROTOCOL_NOTES.md` |

--- a/docs/AI_STORAGE_NOTES.md
+++ b/docs/AI_STORAGE_NOTES.md
@@ -45,6 +45,8 @@ The device name lives in `wifi`, not `hds`, so renaming a scale never touches th
 | `auto_sleep` | bool | `true` |
 | `quick_boot` | bool | `false` |
 | `drift_max` | float | `0.05` |
+| `tap_tare` | bool | `false` |
+| `tap_timer` | bool | `false` |
 
 `schema` is a `uint16_t`, currently `1`. Do not rename a key or change its stored type in place. Add an explicit migration, preserve old data until the new schema is complete, then increment the schema version.
 

--- a/include/menu.h
+++ b/include/menu.h
@@ -79,6 +79,10 @@ void driftComp0050();
 void driftComp0075();
 void driftComp0100();
 void driftComp0200();
+void tapTareOn();
+void tapTareOff();
+void tapTimerOn();
+void tapTimerOff();
 #if HDS_ENABLE_GRINDER
 void grinderOn();
 void grinderOff();
@@ -113,6 +117,7 @@ Menu menuBtnFuncWhileConnected = { "Button with BLE", NULL, NULL, NULL };
 Menu menuAutoSleep = { "Auto Sleep", NULL, NULL, NULL };
 Menu menuQuickBoot = { "Quick Boot", NULL, NULL, NULL };
 Menu menuDriftComp = { "Drift Comp", NULL, NULL, NULL };
+Menu menuTapActions = { "DoubleTapTare", NULL, NULL, NULL };
 #if HDS_ENABLE_GRINDER
 Menu menuGrinder = { "Grind by weight", NULL, NULL, NULL };
 #endif
@@ -202,6 +207,14 @@ Menu menuQuickBoot0100 = { "0.1g", driftComp0100, NULL, &menuDriftComp };
 Menu menuQuickBoot0200 = { "0.2g", driftComp0200, NULL, &menuDriftComp };
 Menu *driftCompMenu[] = { &menuDriftCompBack, &menuDriftCompOff, &menuQuickBoot0050, &menuQuickBoot0075, &menuQuickBoot0100, &menuQuickBoot0200 };
 
+Menu menuTapBack = { "Back", NULL, NULL, &menuTapActions };
+Menu menuTapTareOn = { "2x Tare On", tapTareOn, NULL, &menuTapActions };
+Menu menuTapTareOff = { "2x Tare Off", tapTareOff, NULL, &menuTapActions };
+Menu menuTapTimerOn = { "3x Timer On", tapTimerOn, NULL, &menuTapActions };
+Menu menuTapTimerOff = { "3x Timer Off", tapTimerOff, NULL, &menuTapActions };
+Menu *tapActionsMenu[] = { &menuTapBack, &menuTapTareOn, &menuTapTareOff,
+                           &menuTapTimerOn, &menuTapTimerOff };
+
 #if HDS_ENABLE_GRINDER
 Menu menuGrinderBack = { "Back", NULL, NULL, &menuGrinder };
 Menu menuGrinderOn = { "Enable", grinderOn, NULL, &menuGrinder };
@@ -226,7 +239,7 @@ Menu *mainMenu[] = {
   &menuStatus,
   &menuAbout, &menuLogo, &menuHeartbeat, &menuFlipScreen, &menuTimeOnTop,
   &menuBtnFuncWhileConnected, &menuAutoSleep, &menuQuickBoot, &menuDriftComp,
-  &menuBatInfo,
+  &menuTapActions, &menuBatInfo,
   &menuBatteryProtect,
 #if HDS_ENABLE_GRINDER
   &menuGrinder,
@@ -264,6 +277,7 @@ void linkSubmenus() {
   menuAutoSleep.subMenu = autoSleepMenu[0];
   menuQuickBoot.subMenu = quickBootMenu[0];
   menuDriftComp.subMenu = driftCompMenu[0];
+  menuTapActions.subMenu = tapActionsMenu[0];
 #if HDS_ENABLE_GRINDER
   menuGrinder.subMenu = grinderMenu[0];
 #endif
@@ -510,6 +524,42 @@ void heartbeatOff() {
   t_actionMessageDelay = 1000;
   storagePutBool(KEY_HEARTBEAT, b_requireHeartBeat);
   Serial.println("Heartbeat detection...Off");
+}
+
+void tapTareOn() {
+  b_tapTareEnabled = true;
+  actionMessage = "2x Tare On";
+  t_actionMessage = millis();
+  t_actionMessageDelay = 1000;
+  storagePutBool(KEY_TAP_TARE, b_tapTareEnabled);
+  Serial.println("2x tap tare On stored in NVS.");
+}
+
+void tapTareOff() {
+  b_tapTareEnabled = false;
+  actionMessage = "2x Tare Off";
+  t_actionMessage = millis();
+  t_actionMessageDelay = 1000;
+  storagePutBool(KEY_TAP_TARE, b_tapTareEnabled);
+  Serial.println("2x tap tare Off stored in NVS.");
+}
+
+void tapTimerOn() {
+  b_tapTimerEnabled = true;
+  actionMessage = "3x Timer On";
+  t_actionMessage = millis();
+  t_actionMessageDelay = 1000;
+  storagePutBool(KEY_TAP_TIMER, b_tapTimerEnabled);
+  Serial.println("3x tap timer On stored in NVS.");
+}
+
+void tapTimerOff() {
+  b_tapTimerEnabled = false;
+  actionMessage = "3x Timer Off";
+  t_actionMessage = millis();
+  t_actionMessageDelay = 1000;
+  storagePutBool(KEY_TAP_TIMER, b_tapTimerEnabled);
+  Serial.println("3x tap timer Off stored in NVS.");
 }
 
 void flipScreenOn() {
@@ -1720,6 +1770,9 @@ void selectMenu() {
     } else if (currentSelection == &menuDriftComp) {
       currentMenu = driftCompMenu;
       currentMenuSize = getMenuSize(driftCompMenu);
+    } else if (currentSelection == &menuTapActions) {
+      currentMenu = tapActionsMenu;
+      currentMenuSize = getMenuSize(tapActionsMenu);
 #if HDS_ENABLE_GRINDER
     } else if (currentSelection == &menuGrinder) {
       b_grinderMenuDirectEntry = false;

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -106,6 +106,8 @@ volatile bool b_requireHeartBeat = true;
 volatile bool b_screenFlipped = false;
 volatile bool b_timeOnTop = false;
 volatile bool b_btnFuncWhileConnected = false;
+bool b_tapTareEnabled = false;
+bool b_tapTimerEnabled = false;
 
 //
 int windowLength = 5;  // default window length

--- a/include/storage.h
+++ b/include/storage.h
@@ -27,6 +27,8 @@ constexpr const char *KEY_WIFI_BOOT = "wifi_boot";
 constexpr const char *KEY_AUTO_SLEEP = "auto_sleep";
 constexpr const char *KEY_QUICK_BOOT = "quick_boot";
 constexpr const char *KEY_DRIFT_MAX = "drift_max";
+constexpr const char *KEY_TAP_TARE = "tap_tare";
+constexpr const char *KEY_TAP_TIMER = "tap_timer";
 constexpr const char *KEY_BAT_PROTECT = "bat_protect";
 constexpr const char *KEY_BAT_CAPACITY_SET = "bat_cap_set";
 
@@ -118,7 +120,8 @@ inline bool storageHasAllSettings() {
     KEY_CAL1, KEY_CONTAINER, KEY_MODE, KEY_POUROVER, KEY_ESPRESSO,
     KEY_BEEP, KEY_WELCOME, KEY_BAT_CAL, KEY_HEARTBEAT, KEY_SCREEN_FLIP,
     KEY_TIME_ON_TOP, KEY_BTN_CONN, KEY_WIFI_BOOT, KEY_AUTO_SLEEP,
-    KEY_QUICK_BOOT, KEY_DRIFT_MAX, KEY_BAT_PROTECT, KEY_BAT_CAPACITY_SET
+    KEY_QUICK_BOOT, KEY_DRIFT_MAX, KEY_TAP_TARE, KEY_TAP_TIMER,
+    KEY_BAT_PROTECT, KEY_BAT_CAPACITY_SET
   };
   for (const char *key : keys) {
     if (!settingsPreferences.isKey(key)) {
@@ -145,6 +148,8 @@ inline bool storageEnsureDefaults() {
          storageEnsureBool(KEY_AUTO_SLEEP, true) &&
          storageEnsureBool(KEY_QUICK_BOOT, false) &&
          storageEnsureFloat(KEY_DRIFT_MAX, 0.05f) &&
+         storageEnsureBool(KEY_TAP_TARE, false) &&
+         storageEnsureBool(KEY_TAP_TIMER, false) &&
          storageEnsureBool(KEY_BAT_PROTECT, false) &&
          storageEnsureBool(KEY_BAT_CAPACITY_SET, false);
 }
@@ -237,6 +242,8 @@ inline bool storageMigrateLegacyEeprom() {
                   storageEnsureBool(KEY_AUTO_SLEEP, storageLegacyBool(LEGACY_AUTO_SLEEP_ADDRESS, true)) &&
                   storageEnsureBool(KEY_QUICK_BOOT, storageLegacyBool(LEGACY_QUICK_BOOT_ADDRESS, false)) &&
                   storageEnsureFloat(KEY_DRIFT_MAX, driftMax) &&
+                  storageEnsureBool(KEY_TAP_TARE, false) &&
+                  storageEnsureBool(KEY_TAP_TIMER, false) &&
                   storageEnsureBool(KEY_BAT_PROTECT, false) &&
                   storageEnsureBool(KEY_BAT_CAPACITY_SET, false);
   EEPROM.end();

--- a/include/tap_detection.h
+++ b/include/tap_detection.h
@@ -1,0 +1,128 @@
+#ifndef TAP_DETECTION_H
+#define TAP_DETECTION_H
+
+#include <Arduino.h>
+#include <math.h>
+#include "parameter.h"
+#include "finger_detection.h"
+
+// Pan double/triple tap detection on the raw weight signal:
+// 1. steady state: sample every 100ms; 5 samples (500ms) spread <0.5g -> baseline
+// 2. peak: rise then fall, height above baseline >20g
+// 3. sequence: peaks closer than 400ms chain up
+//    - 2 peaks, no 3rd within 400ms = double tap -> tare
+//    - 3 consecutive peaks = triple tap -> timer (start/stop/reset cycle)
+// 4. fire 500ms after the decision (peak sequence rejects placed objects)
+constexpr float TAP_PEAK_G = 20.0f;
+constexpr float TAP_PEAK_SLOPE = 2.0f;
+constexpr unsigned long TAP_SAMPLE_MS = 100;
+constexpr uint8_t TAP_STEADY_N = 5;
+constexpr float TAP_STEADY_RANGE = 0.5f;
+constexpr unsigned long TAP_DOUBLE_MS = 400;
+constexpr unsigned long TAP_TARE_DELAY_MS = 500;
+
+static float tapHist[TAP_STEADY_N] = {0};
+static uint8_t tapHistIdx = 0;
+static uint8_t tapHistCount = 0;
+static unsigned long tapSampleMs = 0;
+static bool tapSteady = false;
+static float tapBaseline = 0.0f;
+static float tapPrevW = 0.0f;
+static bool tapRising = false;
+static unsigned long tapLastPeakMs = 0;
+static uint8_t tapSeqCount = 0;
+static bool tapDecisionPending = false;
+static unsigned long tapDecisionAtMs = 0;
+static bool tapActionArmed = false;
+static unsigned long tapActionAtMs = 0;
+static bool tapTripleArmed = false;
+
+void tapDetectTick() {
+  if (b_bootTare || b_bootFreshTarePending) {
+    return;
+  }
+  unsigned long now = millis();
+  float w = f_current_raw_value;
+
+  if (now - tapSampleMs >= TAP_SAMPLE_MS) {
+    tapSampleMs = now;
+    tapHist[tapHistIdx] = w;
+    tapHistIdx = (tapHistIdx + 1) % TAP_STEADY_N;
+    if (tapHistCount < TAP_STEADY_N) tapHistCount++;
+    if (tapHistCount >= TAP_STEADY_N) {
+      float lo = tapHist[0];
+      float hi = tapHist[0];
+      float sum = 0;
+      for (uint8_t i = 0; i < TAP_STEADY_N; i++) {
+        if (tapHist[i] < lo) lo = tapHist[i];
+        if (tapHist[i] > hi) hi = tapHist[i];
+        sum += tapHist[i];
+      }
+      if (hi - lo < TAP_STEADY_RANGE) {
+        tapSteady = true;
+        tapBaseline = sum / TAP_STEADY_N;
+      } else if (fabsf(w - tapBaseline) > TAP_PEAK_SLOPE) {
+        tapSteady = false;
+      }
+    }
+  }
+
+  if (w > tapPrevW + TAP_PEAK_SLOPE) {
+    tapRising = true;
+  } else if (w < tapPrevW - TAP_PEAK_SLOPE && tapRising) {
+    tapRising = false;
+    float height = tapPrevW - tapBaseline;
+    if (height > TAP_PEAK_G) {
+      if (now - tapLastPeakMs < TAP_DOUBLE_MS) {
+        tapSeqCount++;
+        if (tapSeqCount == 3) {
+          tapDecisionPending = false;
+          tapSeqCount = 0;
+          if (b_tapTimerEnabled) {
+            tapActionArmed = true;
+            tapTripleArmed = true;
+            tapActionAtMs = now;
+            Serial.println("[TAP] triple tap -> timer");
+          }
+        } else {
+          tapDecisionPending = true;
+          tapDecisionAtMs = now;
+        }
+      } else {
+        tapSeqCount = 1;
+      }
+      tapLastPeakMs = now;
+    }
+  }
+  tapPrevW = w;
+
+  if (tapDecisionPending && now - tapDecisionAtMs >= TAP_DOUBLE_MS) {
+    tapDecisionPending = false;
+    tapSeqCount = 0;
+    if (b_tapTareEnabled) {
+      tapActionArmed = true;
+      tapTripleArmed = false;
+      tapActionAtMs = now;
+      Serial.println("[TAP] double tap -> tare");
+    }
+  }
+
+  if (tapActionArmed && now - tapActionAtMs >= TAP_TARE_DELAY_MS) {
+    tapActionArmed = false;
+    if (millis() - t_menuExitTime > 1000) {
+      if (tapTripleArmed) {
+        scaleTimer();
+      } else {
+        b_weight_quick_zero = true;
+        t_quickZeroStart = millis();
+        t_tareByButton = millis();
+        b_tareByButton = true;
+      }
+#ifdef BUZZER
+      buzzer.beep(1, BUZZER_DURATION);
+#endif
+    }
+  }
+}
+
+#endif

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -33,6 +33,7 @@
 #include "usbcomm.h"
 #include "fuel_gauge.h"
 #include "finger_detection.h"
+#include "tap_detection.h"
 
 #if HDS_ENABLE_GRINDER
 #ifndef GRINDER_MENU_CHORD_HOLD_MS
@@ -678,6 +679,8 @@ void setup() {
   b_timeOnTop = storageGetBool(KEY_TIME_ON_TOP, false);
   b_btnFuncWhileConnected = storageGetBool(KEY_BTN_CONN, false);
   b_autoSleep = storageGetBool(KEY_AUTO_SLEEP, true);
+  b_tapTareEnabled = storageGetBool(KEY_TAP_TARE, false);
+  b_tapTimerEnabled = storageGetBool(KEY_TAP_TIMER, false);
   if (b_mode > 1) {
     b_mode = 0;
     storagePutInt(KEY_MODE, b_mode);
@@ -1676,6 +1679,7 @@ if (!b_hasFuelGauge) {
           }
         }
         pureScale();
+        tapDetectTick();
         updateOled();
 #if HDS_ENABLE_GRINDER
         grinderRuntimeTick(f_displayedValue);


### PR DESCRIPTION
# PR: Double/triple tap on scale top — tare and timer controls based on weight changes

## Summary

Lets the user control the scale by tapping the scale top (pan) instead of
the physical buttons:

- **Double tap** the scale top -> **tare**
- **Triple tap** the scale top -> **timer** (start / stop / reset cycle)

Both features are opt-in via a new **DoubleTapTare** menu and are **off by
default**. Tapping is detected purely from the weight signal, no GPIO or
sensor changes.

## Detection algorithm

Steady-state based peak detection on the raw ADC weight:

- 100 ms sampling; when 5 consecutive samples (500 ms) stay within 0.5 g
  of each other, the mean becomes the steady baseline.
- A tap is a rise-then-fall whose peak exceeds the baseline by more than
  20 g (slope 2 g/sample).
- Peaks closer than 400 ms chain into a sequence: 2 peaks with no 3rd
  within 400 ms = double tap; 3 consecutive peaks = triple tap. The third
  peak cancels the pending double decision, so a 3-tap never falls back to
  tare.
- The action fires 500 ms after the decision, which rejects placed
  objects (a cup placed on the scale rises and stays; it never forms a
  peak).

## Design

- **No new protocol events**: tap actions reuse the existing button paths
  (`b_tareByButton` for tare, `scaleTimer()` for the timer cycle), so
  quick-zero behavior, grinder hooks, and BLE/USB/WebSocket behavior stay
  consistent with button presses.
- Detector runs on `f_current_raw_value` in the weighing loop, gated
  during boot fresh tare and 1 s after menu exit.
- Settings persisted in NVS (`tap_tare`, `tap_timer`, default `false`);
  existing devices get the defaults without a schema migration.

## Changes

| File | Change |
|---|---|
| `include/tap_detection.h` | New: steady-state tap detector state machine |
| `include/menu.h` | `DoubleTapTare` submenu with `2x Tare` / `3x Timer` toggles |
| `include/storage.h` | New `tap_tare` / `tap_timer` keys (defaults for new and legacy devices) |
| `include/parameter.h` | Runtime toggle flags |
| `src/hds.ino` | Load settings at boot, tick detector in the weighing loop |
| `docs/AI_STORAGE_NOTES.md` | Storage schema table |
| `docs/AI_REPO_MAP.md` | File routing |

## Testing

- Built and flashed to the HDS 9.0.5 hardware (ESP32-S3, CH9102 serial).
- Verified on device: boot fresh tare, 1 Hz weight stream, menu toggles,
  double-tap tare, triple-tap timer start/stop/reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
