### PR TITLE
Improve custom-build fleet deployment management

### DIFF
--- a/cloudflare/custom-build-worker/src/build-coordinator.mjs
+++ b/cloudflare/custom-build-worker/src/build-coordinator.mjs
@@ -153,7 +153,7 @@ export class BuildCoordinator {
     if (url.pathname.startsWith("/device/") || url.pathname.startsWith("/fleet/")) {
       let response;
       try {
-        const result = await handleFleetRequest(request, this.state.storage);
+        const result = await handleFleetRequest(request, this.state.storage, this.env);
         response = Response.json(result);
       } catch (error) {
         const failure = error instanceof FleetError ? error : new FleetError(500, "internal_error");

--- a/cloudflare/custom-build-worker/src/fleet.mjs
+++ b/cloudflare/custom-build-worker/src/fleet.mjs
@@ -468,29 +468,13 @@ async function removeBuild(request, storage, combinationHash) {
 
 async function updateScale(request, storage, deviceId) {
   const ownerFleetId = await fleetId(request);
-  const body = await readJson(request);
-  const keys = body && typeof body === "object" && !Array.isArray(body) ? Object.keys(body).sort() : [];
-  if (!keys.length || keys.some(key => !["desired_combination", "name"].includes(key))) {
-    throw new FleetError(400, "invalid_request");
-  }
+  const body = requireObject(await readJson(request), ["name"]);
+  const name = normalizedName(body.name);
   return storage.transaction(async transaction => {
     const deviceKey = `device:${deviceId}`;
     const device = await transaction.get(deviceKey);
     if (!device || device.fleet_id !== ownerFleetId) throw new FleetError(404, "device_not_found");
-    const desiredCombination = body.desired_combination === undefined
-      ? device.desired_combination
-      : body.desired_combination;
-    if (desiredCombination !== null && !hashPattern.test(desiredCombination || "")) {
-      throw new FleetError(400, "invalid_combination_hash");
-    }
-    const desiredChanged = body.desired_combination !== undefined &&
-      desiredCombination !== device.desired_combination;
-    const updated = {
-      ...device,
-      name: body.name === undefined ? device.name : normalizedName(body.name),
-      desired_combination: desiredCombination,
-      desired_updated_at: desiredChanged ? new Date().toISOString() : device.desired_updated_at,
-    };
+    const updated = {...device, name};
     await transaction.put(deviceKey, updated);
     return {
       device_id: deviceId,

--- a/cloudflare/custom-build-worker/src/fleet.mjs
+++ b/cloudflare/custom-build-worker/src/fleet.mjs
@@ -7,6 +7,8 @@ const pairRefreshMs = 30 * 1000;
 const claimWindowMs = 60 * 1000;
 const claimsPerWindow = 10;
 const pairCreationWindowMs = 60 * 60 * 1000;
+const maxFleetBuilds = 100;
+const storageBatchSize = 128;
 export const pairCreationsPerClient = 10;
 export const pairCreationsGlobal = 500;
 
@@ -47,14 +49,14 @@ function requireObject(value, keys) {
   return value;
 }
 
-async function readJson(request) {
+async function readJson(request, maxBytes = 1024) {
   if (!request.headers.get("Content-Type")?.toLowerCase().startsWith("application/json")) {
     throw new FleetError(415, "json_required");
   }
   const declaredLength = Number(request.headers.get("Content-Length") || 0);
-  if (declaredLength > 1024) throw new FleetError(413, "request_too_large");
+  if (declaredLength > maxBytes) throw new FleetError(413, "request_too_large");
   const payload = await request.arrayBuffer();
-  if (!payload.byteLength || payload.byteLength > 1024) throw new FleetError(413, "request_too_large");
+  if (!payload.byteLength || payload.byteLength > maxBytes) throw new FleetError(413, "request_too_large");
   try {
     return JSON.parse(new TextDecoder().decode(payload));
   } catch {
@@ -90,7 +92,7 @@ async function authenticatedDevice(request, storage) {
   if (!device || !sameHash(device.secret_hash, credentials.secretHash)) {
     throw new FleetError(401, "invalid_device_credentials");
   }
-  return {deviceId: credentials.deviceId, device, key};
+  return {deviceId: credentials.deviceId, device, key, secretHash: credentials.secretHash};
 }
 
 function retryAfter(expiresAt, now) {
@@ -134,6 +136,10 @@ async function pairDevice(request, storage) {
       name: `Scale ${serialHint}`,
       fleet_id: null,
       desired_combination: null,
+      desired_updated_at: null,
+      installed_combination: null,
+      firmware_version: null,
+      last_seen_at: null,
     };
     if (device.serial_hint !== serialHint) throw new FleetError(400, "serial_hint_mismatch");
     if (device.pair_created_at && now - device.pair_created_at < pairRefreshMs) {
@@ -222,6 +228,113 @@ function fleetDevices(fleet) {
   return Array.isArray(fleet?.devices) ? fleet.devices.filter(deviceId => deviceIdPattern.test(deviceId)) : [];
 }
 
+function fleetBuilds(fleet) {
+  return Array.isArray(fleet?.builds)
+    ? fleet.builds.filter(build => hashPattern.test(build?.combination_hash || ""))
+    : [];
+}
+
+function normalizedText(value, maxLength, code) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text || text.length > maxLength || /[\u0000-\u001f\u007f]/.test(text)) {
+    throw new FleetError(400, code);
+  }
+  return text;
+}
+
+function normalizedName(value) {
+  return normalizedText(value, 40, "invalid_scale_name");
+}
+
+function normalizedBuildLabel(value) {
+  return normalizedText(value, 40, "invalid_build_label");
+}
+
+function normalizedFirmwareVersion(value) {
+  return normalizedText(value, 64, "invalid_firmware_version");
+}
+
+async function readyBuildReference(env, combinationHash) {
+  if (!hashPattern.test(combinationHash || "")) {
+    throw new FleetError(400, "invalid_combination_hash");
+  }
+  const object = await env.BUILDS.get(`v1/${combinationHash}/build-manifest.json`);
+  if (!object) throw new FleetError(409, "build_not_ready");
+  let manifest;
+  try {
+    manifest = await object.json();
+  } catch {
+    throw new FleetError(409, "build_not_ready");
+  }
+  if (manifest?.custom_build !== true || manifest.combination_hash !== combinationHash ||
+      typeof manifest.firmware_version !== "string" || !manifest.firmware_version ||
+      manifest.firmware_version.length > 64) {
+    throw new FleetError(409, "build_not_ready");
+  }
+  const features = Array.isArray(manifest.features)
+    ? manifest.features.filter(value => typeof value === "string" && value.length <= 64)
+    : [];
+  const plugins = Array.isArray(manifest.plugins) ? manifest.plugins
+    .filter(value => value && typeof value.id === "string" && value.id.length <= 64)
+    .map(value => ({
+      id: value.id,
+      version: typeof value.version === "string" && value.version.length <= 32 ? value.version : "",
+    })) : [];
+  return {
+    combination_hash: combinationHash,
+    firmware_version: manifest.firmware_version,
+    features,
+    plugins,
+  };
+}
+
+async function buildStates(hashes, storage, env) {
+  const uniqueHashes = [...new Set(hashes.filter(hash => hashPattern.test(hash || "")))];
+  return Object.fromEntries(await Promise.all(uniqueHashes.map(async hash => {
+    if (await env.BUILDS.head(`v1/${hash}/build-manifest.json`)) return [hash, "ready"];
+    const record = await storage.get(`build:${hash}`);
+    return [hash, ["queued", "building", "failed"].includes(record?.state) ? record.state : "missing"];
+  })));
+}
+
+function scaleRecord(deviceId, device) {
+  return {
+    device_id: deviceId,
+    serial_hint: device.serial_hint,
+    name: device.name,
+    desired_combination: hashPattern.test(device.desired_combination || "")
+      ? device.desired_combination : null,
+    desired_updated_at: typeof device.desired_updated_at === "string"
+      ? device.desired_updated_at : null,
+    installed_combination: hashPattern.test(device.installed_combination || "")
+      ? device.installed_combination : null,
+    firmware_version: typeof device.firmware_version === "string" ? device.firmware_version : null,
+    last_seen_at: typeof device.last_seen_at === "string" ? device.last_seen_at : null,
+  };
+}
+
+async function fleetScaleRecords(ownerFleetId, fleet, storage) {
+  return (await Promise.all(fleetDevices(fleet).map(async deviceId => {
+    const device = await storage.get(`device:${deviceId}`);
+    return device && device.fleet_id === ownerFleetId ? scaleRecord(deviceId, device) : null;
+  }))).filter(Boolean).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function fleetSnapshot(ownerFleetId, storage, env) {
+  const fleet = await storage.get(`fleet:${ownerFleetId}`);
+  const scales = await fleetScaleRecords(ownerFleetId, fleet, storage);
+  const builds = fleetBuilds(fleet);
+  const states = await buildStates([
+    ...builds.map(build => build.combination_hash),
+    ...scales.map(scale => scale.desired_combination),
+  ], storage, env);
+  return {
+    builds: builds.map(build => ({...build, state: states[build.combination_hash]})),
+    scales,
+    build_states: states,
+  };
+}
+
 async function claimDevice(request, storage) {
   await enforceClaimRate(request, storage);
   const body = requireObject(await readJson(request), ["pair_code"]);
@@ -247,43 +360,110 @@ async function claimDevice(request, storage) {
     const transferred = oldFleetKey && oldFleetKey !== newFleetKey;
     const updatedDevice = {
       ...device,
-      ...(transferred ? {desired_combination: null, name: `Scale ${device.serial_hint}`} : {}),
+      ...(transferred ? {
+        desired_combination: null,
+        desired_updated_at: null,
+        name: `Scale ${device.serial_hint}`,
+      } : {}),
       fleet_id: ownerFleetId,
       pair_code: null,
       pair_created_at: null,
     };
     const updates = {
       [deviceKey]: updatedDevice,
-      [newFleetKey]: {devices: newDevices},
+      [newFleetKey]: {...newFleet, devices: newDevices},
     };
-    if (oldFleetKey && oldFleetKey !== newFleetKey) updates[oldFleetKey] = {devices: oldDevices};
+    if (oldFleetKey && oldFleetKey !== newFleetKey) {
+      updates[oldFleetKey] = {...oldFleet, devices: oldDevices};
+    }
     await transaction.put(updates);
     await transaction.delete(pairKey);
     return {device_id: pair.device_id, serial_hint: device.serial_hint, name: updatedDevice.name};
   });
 }
 
-async function listScales(request, storage) {
+async function listScales(request, storage, env) {
   const ownerFleetId = await fleetId(request);
   const fleet = await storage.get(`fleet:${ownerFleetId}`);
-  const devices = await Promise.all(fleetDevices(fleet).map(async deviceId => {
-    const device = await storage.get(`device:${deviceId}`);
-    return device && device.fleet_id === ownerFleetId ? {
-      device_id: deviceId,
-      serial_hint: device.serial_hint,
-      name: device.name,
-      desired_combination: device.desired_combination,
-    } : null;
-  }));
-  return {scales: devices.filter(Boolean).sort((left, right) => left.name.localeCompare(right.name))};
+  const scales = await fleetScaleRecords(ownerFleetId, fleet, storage);
+  const states = await buildStates(scales.map(scale => scale.desired_combination), storage, env);
+  return {scales, build_states: states};
 }
 
-function normalizedName(value) {
-  const name = typeof value === "string" ? value.trim() : "";
-  if (!name || name.length > 40 || /[\u0000-\u001f\u007f]/.test(name)) {
-    throw new FleetError(400, "invalid_scale_name");
-  }
-  return name;
+async function fleetOverview(request, storage, env) {
+  return fleetSnapshot(await fleetId(request), storage, env);
+}
+
+async function listBuilds(request, storage, env) {
+  const ownerFleetId = await fleetId(request);
+  const fleet = await storage.get(`fleet:${ownerFleetId}`);
+  const builds = fleetBuilds(fleet);
+  const states = await buildStates(builds.map(build => build.combination_hash), storage, env);
+  return {builds: builds.map(build => ({...build, state: states[build.combination_hash]}))};
+}
+
+async function addBuild(request, storage, env) {
+  const ownerFleetId = await fleetId(request);
+  const body = requireObject(await readJson(request), ["combination_hash"]);
+  const key = `fleet:${ownerFleetId}`;
+  if (!(await storage.get(key))) throw new FleetError(404, "fleet_not_found");
+  const reference = await readyBuildReference(env, body.combination_hash);
+  return storage.transaction(async transaction => {
+    const fleet = await transaction.get(key);
+    const builds = fleetBuilds(fleet);
+    const existing = builds.find(build => build.combination_hash === reference.combination_hash);
+    if (existing) return {...existing, state: "ready"};
+    if (builds.length >= maxFleetBuilds) throw new FleetError(409, "build_library_full");
+    const added = {
+      ...reference,
+      label: `Build ${reference.combination_hash.slice(0, 12).toUpperCase()}`,
+      added_at: new Date().toISOString(),
+    };
+    await transaction.put(key, {...fleet, devices: fleetDevices(fleet), builds: [...builds, added]});
+    return {...added, state: "ready"};
+  });
+}
+
+async function renameBuild(request, storage, combinationHash) {
+  const ownerFleetId = await fleetId(request);
+  const body = requireObject(await readJson(request), ["label"]);
+  const label = normalizedBuildLabel(body.label);
+  return storage.transaction(async transaction => {
+    const key = `fleet:${ownerFleetId}`;
+    const fleet = await transaction.get(key);
+    const builds = fleetBuilds(fleet);
+    const selected = builds.find(build => build.combination_hash === combinationHash);
+    if (!selected) throw new FleetError(404, "build_not_found");
+    const updated = {...selected, label};
+    await transaction.put(key, {
+      ...fleet,
+      builds: builds.map(build => build.combination_hash === combinationHash ? updated : build),
+    });
+    return updated;
+  });
+}
+
+async function removeBuild(request, storage, combinationHash) {
+  const ownerFleetId = await fleetId(request);
+  return storage.transaction(async transaction => {
+    const key = `fleet:${ownerFleetId}`;
+    const fleet = await transaction.get(key);
+    const builds = fleetBuilds(fleet);
+    if (!builds.some(build => build.combination_hash === combinationHash)) {
+      throw new FleetError(404, "build_not_found");
+    }
+    const devices = await Promise.all(fleetDevices(fleet).map(deviceId =>
+      transaction.get(`device:${deviceId}`)));
+    if (devices.some(device => device?.fleet_id === ownerFleetId &&
+        device.desired_combination === combinationHash)) {
+      throw new FleetError(409, "build_assigned");
+    }
+    await transaction.put(key, {
+      ...fleet,
+      builds: builds.filter(build => build.combination_hash !== combinationHash),
+    });
+    return {removed_combination: combinationHash};
+  });
 }
 
 async function updateScale(request, storage, deviceId) {
@@ -303,10 +483,13 @@ async function updateScale(request, storage, deviceId) {
     if (desiredCombination !== null && !hashPattern.test(desiredCombination || "")) {
       throw new FleetError(400, "invalid_combination_hash");
     }
+    const desiredChanged = body.desired_combination !== undefined &&
+      desiredCombination !== device.desired_combination;
     const updated = {
       ...device,
       name: body.name === undefined ? device.name : normalizedName(body.name),
       desired_combination: desiredCombination,
+      desired_updated_at: desiredChanged ? new Date().toISOString() : device.desired_updated_at,
     };
     await transaction.put(deviceKey, updated);
     return {
@@ -318,32 +501,124 @@ async function updateScale(request, storage, deviceId) {
   });
 }
 
-async function deviceAssignment(request, storage) {
-  const authenticated = await authenticatedDevice(request, storage);
+async function updateAssignments(request, storage, env) {
+  const ownerFleetId = await fleetId(request);
+  const rawBody = await readJson(request, 64 * 1024);
+  const allScales = rawBody?.all === true;
+  const body = requireObject(
+    rawBody,
+    allScales ? ["all", "combination_hash"] : ["combination_hash", "device_ids"],
+  );
+  const combinationHash = body.combination_hash;
+  if (combinationHash !== null) await readyBuildReference(env, combinationHash);
+  let requestedDeviceIds = null;
+  if (!allScales) {
+    if (!Array.isArray(body.device_ids) || !body.device_ids.length ||
+        body.device_ids.some(deviceId => !deviceIdPattern.test(deviceId || ""))) {
+      throw new FleetError(400, body.device_ids?.length ? "invalid_device_id" : "empty_target_set");
+    }
+    requestedDeviceIds = [...new Set(body.device_ids)];
+  }
+  return storage.transaction(async transaction => {
+    const fleet = await transaction.get(`fleet:${ownerFleetId}`);
+    const deviceIds = allScales ? fleetDevices(fleet) : requestedDeviceIds;
+    if (!deviceIds.length) throw new FleetError(400, "empty_target_set");
+    const devices = await Promise.all(deviceIds.map(deviceId =>
+      transaction.get(`device:${deviceId}`)));
+    if (devices.some(device => !device)) throw new FleetError(404, "device_not_found");
+    if (devices.some(device => device.fleet_id !== ownerFleetId)) {
+      throw new FleetError(403, "cross_fleet_device");
+    }
+    const now = new Date().toISOString();
+    const updates = Object.fromEntries(deviceIds.map((deviceId, index) => {
+      const device = devices[index];
+      return [`device:${deviceId}`, {
+        ...device,
+        desired_combination: combinationHash,
+        desired_updated_at: device.desired_combination === combinationHash
+          ? device.desired_updated_at : now,
+      }];
+    }));
+    const entries = Object.entries(updates);
+    for (let index = 0; index < entries.length; index += storageBatchSize) {
+      await transaction.put(Object.fromEntries(entries.slice(index, index + storageBatchSize)));
+    }
+    return {combination_hash: combinationHash, device_ids: deviceIds, updated: deviceIds.length};
+  });
+}
+
+function deviceAssignmentPayload(device) {
   return {
-    linked: Boolean(authenticated.device.fleet_id),
-    name: authenticated.device.name,
-    serial_hint: authenticated.device.serial_hint,
-    desired_combination: authenticated.device.desired_combination,
+    linked: Boolean(device.fleet_id),
+    desired_combination: hashPattern.test(device.desired_combination || "")
+      ? device.desired_combination : null,
   };
 }
 
+async function deviceAssignment(request, storage) {
+  const authenticated = await authenticatedDevice(request, storage);
+  return deviceAssignmentPayload(authenticated.device);
+}
+
+async function deviceCheckIn(request, storage) {
+  const body = requireObject(
+    await readJson(request),
+    ["firmware_version", "installed_combination"],
+  );
+  if (body.installed_combination !== null &&
+      !hashPattern.test(body.installed_combination || "")) {
+    throw new FleetError(400, "invalid_combination_hash");
+  }
+  const firmwareVersion = normalizedFirmwareVersion(body.firmware_version);
+  const authenticated = await authenticatedDevice(request, storage);
+  return storage.transaction(async transaction => {
+    const device = await transaction.get(authenticated.key);
+    if (!device || !sameHash(device.secret_hash, authenticated.secretHash)) {
+      throw new FleetError(401, "invalid_device_credentials");
+    }
+    const updated = {
+      ...device,
+      installed_combination: body.installed_combination,
+      firmware_version: firmwareVersion,
+      last_seen_at: new Date().toISOString(),
+    };
+    await transaction.put(authenticated.key, updated);
+    return deviceAssignmentPayload(updated);
+  });
+}
+
 export function isDeviceApi(pathname) {
-  return pathname === "/api/v1/device/pair" || pathname === "/api/v1/device/assignment";
+  return pathname === "/api/v1/device/pair" || pathname === "/api/v1/device/assignment" ||
+    pathname === "/api/v1/device/check-in";
 }
 
 export function isFleetApi(pathname) {
-  return pathname === "/api/v1/fleet/claim" || pathname === "/api/v1/fleet/scales" ||
-    /^\/api\/v1\/fleet\/scales\/[0-9a-f]{32}$/.test(pathname);
+  return [
+    "/api/v1/fleet/claim",
+    "/api/v1/fleet/scales",
+    "/api/v1/fleet/overview",
+    "/api/v1/fleet/builds",
+    "/api/v1/fleet/assignments",
+  ].includes(pathname) || /^\/api\/v1\/fleet\/(scales\/[0-9a-f]{32}|builds\/[0-9a-f]{64})$/.test(pathname);
 }
 
-export async function handleFleetRequest(request, storage) {
+export async function handleFleetRequest(request, storage, env) {
   const url = new URL(request.url);
   if (url.pathname === "/device/pair" && request.method === "POST") return pairDevice(request, storage);
   if (url.pathname === "/device/assignment" && request.method === "GET") return deviceAssignment(request, storage);
+  if (url.pathname === "/device/check-in" && request.method === "POST") return deviceCheckIn(request, storage);
   if (url.pathname === "/fleet/claim" && request.method === "POST") return claimDevice(request, storage);
-  if (url.pathname === "/fleet/scales" && request.method === "GET") return listScales(request, storage);
-  const match = url.pathname.match(/^\/fleet\/scales\/([0-9a-f]{32})$/);
-  if (match && request.method === "PATCH") return updateScale(request, storage, match[1]);
+  if (url.pathname === "/fleet/scales" && request.method === "GET") return listScales(request, storage, env);
+  if (url.pathname === "/fleet/overview" && request.method === "GET") return fleetOverview(request, storage, env);
+  if (url.pathname === "/fleet/builds" && request.method === "GET") return listBuilds(request, storage, env);
+  if (url.pathname === "/fleet/builds" && request.method === "POST") return addBuild(request, storage, env);
+  if (url.pathname === "/fleet/assignments" && request.method === "POST") {
+    return updateAssignments(request, storage, env);
+  }
+  const scaleMatch = url.pathname.match(/^\/fleet\/scales\/([0-9a-f]{32})$/);
+  if (scaleMatch && request.method === "PATCH") return updateScale(request, storage, scaleMatch[1]);
+  const buildMatch = url.pathname.match(/^\/fleet\/builds\/([0-9a-f]{64})$/);
+  if (buildMatch && request.method === "PATCH") return renameBuild(request, storage, buildMatch[1]);
+  if (buildMatch && request.method === "DELETE") return removeBuild(request, storage, buildMatch[1]);
   throw new FleetError(404, "not_found");
 }

--- a/cloudflare/custom-build-worker/src/worker.mjs
+++ b/cloudflare/custom-build-worker/src/worker.mjs
@@ -557,14 +557,6 @@ async function fleetCoordinatorResponse(request, env, client = null) {
 
 async function fleetApi(request, env) {
   const url = new URL(request.url);
-  if (request.method === "PATCH") {
-    const update = await readJson(request.clone(), 1024);
-    const hash = update?.desired_combination;
-    if (hash !== undefined && hash !== null &&
-        (!hashPattern.test(hash) || !(await env.BUILDS.head(`v1/${hash}/build-manifest.json`)))) {
-      throw new ApiError(409, "build_not_ready");
-    }
-  }
   const response = await fleetCoordinatorResponse(
     request,
     env,

--- a/cloudflare/custom-build-worker/src/worker.mjs
+++ b/cloudflare/custom-build-worker/src/worker.mjs
@@ -88,7 +88,7 @@ function cors(request, env) {
     ? {
         "Access-Control-Allow-Origin": allowedOrigin,
         "Access-Control-Allow-Headers": "Authorization, Content-Type",
-        "Access-Control-Allow-Methods": "GET, HEAD, PATCH, POST, OPTIONS",
+        "Access-Control-Allow-Methods": "DELETE, GET, HEAD, PATCH, POST, OPTIONS",
         "Access-Control-Max-Age": "86400",
         Vary: "Origin",
       }
@@ -576,17 +576,14 @@ async function fleetApi(request, env) {
     return json(request, env, result, response.status, response.headers.get("Retry-After")
       ? {"Retry-After": response.headers.get("Retry-After")} : {});
   }
-  if (url.pathname !== "/api/v1/device/assignment" || !result.desired_combination) {
+  if (!["/api/v1/device/assignment", "/api/v1/device/check-in"].includes(url.pathname) ||
+      !result.desired_combination) {
     return json(request, env, result);
   }
   const status = await publicStatus(env, result.desired_combination);
-  const baseUrl = env.PUBLIC_BASE_URL || "https://openscale-custom-builds.odevstudio.workers.dev";
   return json(request, env, {
     ...result,
-    ...status,
-    ...(status.state === "ready" ? {
-      manifest_url: `${baseUrl}/v1/${result.desired_combination}/ota-manifest.json`,
-    } : {}),
+    state: status.state,
   });
 }
 

--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {readFile} from "node:fs/promises";
 import {test} from "node:test";
+import {runInNewContext} from "node:vm";
 
 import {
   buildSummary,
@@ -192,4 +193,51 @@ test("fleet browser consumes the aggregated overview without per-scale status re
   assert.ok(source.includes('/api/v1/fleet/overview'));
   assert.ok(source.includes('/api/v1/fleet/assignments'));
   assert.equal(source.includes('/api/v1/status/'), false);
+});
+
+
+test("theme follows the system until a saved preference overrides it", async () => {
+  const html = await readFile(new URL("../../../docs/custom-build/index.html", import.meta.url), "utf8");
+  const bootstrap = html.match(/<script id="theme-bootstrap">([\s\S]*?)<\/script>/)?.[1];
+  assert.ok(bootstrap);
+  const loadTheme = (stored, systemDark) => {
+    const dataset = {};
+    const themeColor = {content: ""};
+    runInNewContext(bootstrap, {
+      document: {
+        documentElement: {dataset},
+        querySelector: () => themeColor,
+      },
+      localStorage: {getItem: () => stored},
+      matchMedia: () => ({matches: systemDark}),
+    });
+    return {dataset, themeColor: themeColor.content};
+  };
+  assert.deepEqual(loadTheme(null, false), {
+    dataset: {themePreference: "system", theme: "light"},
+    themeColor: "#0d6b4f",
+  });
+  assert.deepEqual(loadTheme(null, true), {
+    dataset: {themePreference: "system", theme: "dark"},
+    themeColor: "#111413",
+  });
+  assert.deepEqual(loadTheme(JSON.stringify({version: 1, preference: "dark"}), false), {
+    dataset: {themePreference: "dark", theme: "dark"},
+    themeColor: "#111413",
+  });
+  assert.deepEqual(loadTheme("not json", true), {
+    dataset: {themePreference: "system", theme: "dark"},
+    themeColor: "#111413",
+  });
+  const app = await readFile(new URL("../../../docs/custom-build/app.js", import.meta.url), "utf8");
+  assert.ok(app.includes("localStorage.setItem(themeStorageKey"));
+  assert.ok(app.includes('systemTheme.addEventListener("change"'));
+});
+
+
+test("USB-ready builds use a persistent updater cue instead of flashing", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/app.js", import.meta.url), "utf8");
+  assert.ok(source.includes('result.state === "ready" && installMethod === "usb"'));
+  assert.ok(source.includes('classList.toggle("is-ready", updaterReady)'));
+  assert.equal(source.includes("is-next-step"), false);
 });

--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
+import {readFile} from "node:fs/promises";
 import {test} from "node:test";
 
+import {
+  buildSummary,
+  deploymentState,
+  lastSeenLabel,
+  shortHash,
+} from "../../../docs/custom-build/fleet-state.mjs";
 import {
   catalogRevisionChanged,
   defaultSelection,
@@ -126,4 +133,53 @@ test("detects a new static catalog after a stale reload", async () => {
     {url: "catalog.json", options: {cache: "no-store"}},
     {url: "catalog.json", options: {cache: "no-store"}},
   ]);
+});
+
+
+test("formats fleet build identity and deployment state", () => {
+  const hash = "8c6df20ccb1b9855f19dce3868b9310ecb26238cccf48557843bd428ebbc1f63";
+  const now = Date.parse("2026-09-03T12:00:00.000Z");
+  const fresh = "2026-09-03T11:00:00.000Z";
+  const assigned = "2026-09-03T11:30:00.000Z";
+  assert.equal(shortHash(hash), "8C6DF20CCB1B");
+  assert.equal(buildSummary({
+    features: ["pull-ota", "wifi"],
+    plugins: [{id: "grind-by-weight", version: "1.0.0"}, {id: "pressensor", version: "2.0.0"}],
+  }), "pull-ota, wifi, grind-by-weight 1.0.0 +1");
+  assert.equal(deploymentState({
+    desired_combination: hash,
+    installed_combination: hash,
+    last_seen_at: fresh,
+  }, {[hash]: "ready"}, now), "Up to date");
+  assert.equal(deploymentState({
+    desired_combination: hash,
+    installed_combination: null,
+    desired_updated_at: assigned,
+    last_seen_at: fresh,
+  }, {[hash]: "ready"}, now), "Update assigned");
+  assert.equal(deploymentState({
+    desired_combination: hash,
+    installed_combination: null,
+    desired_updated_at: fresh,
+    last_seen_at: assigned,
+  }, {[hash]: "ready"}, now), "Install pending");
+  assert.equal(deploymentState({
+    desired_combination: hash,
+    installed_combination: null,
+    last_seen_at: fresh,
+  }, {[hash]: "building"}, now), "Build preparing");
+  assert.equal(deploymentState({
+    desired_combination: hash,
+    installed_combination: null,
+    last_seen_at: "2026-08-01T00:00:00.000Z",
+  }, {[hash]: "ready"}, now), "Offline");
+  assert.equal(lastSeenLabel(fresh, now), "1h ago");
+});
+
+
+test("fleet browser consumes the aggregated overview without per-scale status requests", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  assert.ok(source.includes('/api/v1/fleet/overview'));
+  assert.ok(source.includes('/api/v1/fleet/assignments'));
+  assert.equal(source.includes('/api/v1/status/'), false);
 });

--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -173,6 +173,16 @@ test("formats fleet build identity and deployment state", () => {
     installed_combination: null,
     last_seen_at: "2026-08-01T00:00:00.000Z",
   }, {[hash]: "ready"}, now), "Offline");
+  assert.equal(deploymentState({
+    desired_combination: null,
+    installed_combination: null,
+    last_seen_at: fresh,
+  }, {}, now), "No update assigned");
+  assert.equal(deploymentState({
+    desired_combination: null,
+    installed_combination: null,
+    last_seen_at: null,
+  }, {}, now), "Unknown");
   assert.equal(lastSeenLabel(fresh, now), "1h ago");
 });
 

--- a/cloudflare/custom-build-worker/test/fleet.test.mjs
+++ b/cloudflare/custom-build-worker/test/fleet.test.mjs
@@ -187,15 +187,21 @@ test("pairs, assigns, authenticates, and physically relinks a scale", async () =
   const scales = await request(env, "/api/v1/fleet/scales", {authorization: fleetSecret, browser: true});
   assert.deepEqual((await scales.json()).scales.map(scale => scale.serial_hint), ["A3F921"]);
 
-  await env.BUILDS.put(`v1/${combinationHash}/build-manifest.json`);
+  await readyBuild(env, combinationHash);
   const update = await request(env, `/api/v1/fleet/scales/${deviceId}`, {
     method: "PATCH",
-    body: {name: "Bar Left", desired_combination: combinationHash},
+    body: {name: "Bar Left"},
     authorization: fleetSecret,
     browser: true,
   });
   assert.equal(update.status, 200);
   assert.equal((await update.json()).name, "Bar Left");
+  assert.equal((await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: combinationHash, device_ids: [deviceId]},
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 200);
 
   const assignment = await request(env, "/api/v1/device/assignment", {
     authorization: deviceSecret,
@@ -259,9 +265,9 @@ test("device check-in reports authoritative installed state without changing des
     pairCode: "A3F921-100001",
   });
   assert.equal((await storage.get(`device:${deviceId}`)).last_seen_at, null);
-  assert.equal((await request(env, `/api/v1/fleet/scales/${deviceId}`, {
-    method: "PATCH",
-    body: {desired_combination: combinationHash},
+  assert.equal((await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: combinationHash, device_ids: [deviceId]},
     authorization: fleetSecret,
     browser: true,
   })).status, 200);
@@ -282,9 +288,9 @@ test("device check-in reports authoritative installed state without changing des
   assert.equal(installed.firmware_version, "3.1.14-custom");
   assert.ok(Number.isFinite(Date.parse(installed.last_seen_at)));
 
-  await request(env, `/api/v1/fleet/scales/${deviceId}`, {
-    method: "PATCH",
-    body: {desired_combination: nextHash},
+  await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: nextHash, device_ids: [deviceId]},
     authorization: fleetSecret,
     browser: true,
   });
@@ -395,9 +401,9 @@ test("fleet build library stores references without owning artifacts", async () 
     authorization: deviceSecret,
     device: true,
   });
-  await request(env, `/api/v1/fleet/scales/${deviceId}`, {
-    method: "PATCH",
-    body: {desired_combination: combinationHash},
+  await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: combinationHash, device_ids: [deviceId]},
     authorization: fleetSecret,
     browser: true,
   });
@@ -406,9 +412,9 @@ test("fleet build library stores references without owning artifacts", async () 
     authorization: fleetSecret,
     browser: true,
   })).status, 409);
-  await request(env, `/api/v1/fleet/scales/${deviceId}`, {
-    method: "PATCH",
-    body: {desired_combination: null},
+  await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: null, device_ids: [deviceId]},
     authorization: fleetSecret,
     browser: true,
   });
@@ -585,16 +591,32 @@ test("legacy fleet records remain readable with unknown installed state", async 
   });
 });
 
-test("rejects unready assignments and invalid device credentials", async () => {
-  const {env} = environment();
-  const missing = await request(env, `/api/v1/fleet/scales/${deviceId}`, {
+test("rejects malformed legacy assignments and invalid device credentials", async () => {
+  const {env, storage} = environment();
+  await linkScale(env, {
+    selectedDeviceId: deviceId,
+    authorization: deviceSecret,
+    pairCode: "A3F921-100006",
+  });
+  await env.BUILDS.put(`v1/${combinationHash}/build-manifest.json`, "{}");
+  const legacy = await request(env, `/api/v1/fleet/scales/${deviceId}`, {
     method: "PATCH",
     body: {desired_combination: combinationHash},
     authorization: fleetSecret,
     browser: true,
   });
-  assert.equal(missing.status, 409);
-  assert.equal((await missing.json()).error, "build_not_ready");
+  assert.equal(legacy.status, 400);
+  assert.equal((await legacy.json()).error, "invalid_request");
+  assert.equal((await storage.get(`device:${deviceId}`)).desired_combination, null);
+  const malformed = await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: combinationHash, device_ids: [deviceId]},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal(malformed.status, 409);
+  assert.equal((await malformed.json()).error, "build_not_ready");
+  assert.equal((await storage.get(`device:${deviceId}`)).desired_combination, null);
   const assignment = await request(env, "/api/v1/device/assignment", {
     authorization: "4".repeat(64),
     device: true,

--- a/cloudflare/custom-build-worker/test/fleet.test.mjs
+++ b/cloudflare/custom-build-worker/test/fleet.test.mjs
@@ -14,18 +14,26 @@ const combinationHash = "3".repeat(64);
 class Bucket {
   constructor() {
     this.objects = new Map();
+    this.headRequests = [];
   }
 
   async put(key, body = new Uint8Array()) {
-    this.objects.set(key, {body, size: body.byteLength || 1});
+    this.objects.set(key, {body, size: body.byteLength || body.length || 1});
   }
 
   async head(key) {
+    this.headRequests.push(key);
     return this.objects.get(key) || null;
   }
 
   async get(key) {
-    return this.objects.get(key) || null;
+    const object = this.objects.get(key);
+    if (!object) return null;
+    return {
+      ...object,
+      json: async () => JSON.parse(typeof object.body === "string"
+        ? object.body : new TextDecoder().decode(object.body)),
+    };
   }
 }
 
@@ -39,8 +47,12 @@ class Storage {
   }
 
   async put(key, value) {
-    if (typeof key === "object") Object.entries(key).forEach(([name, entry]) => this.values.set(name, entry));
-    else this.values.set(key, value);
+    if (typeof key === "object") {
+      assert.ok(Object.keys(key).length <= 128);
+      Object.entries(key).forEach(([name, entry]) => this.values.set(name, entry));
+    } else {
+      this.values.set(key, value);
+    }
   }
 
   async delete(key) {
@@ -98,6 +110,47 @@ function request(env, path, {
   }), env);
 }
 
+function buildManifest(hash, overrides = {}) {
+  return {
+    custom_build: true,
+    combination_hash: hash,
+    firmware_version: "3.1.14-custom",
+    features: ["pull-ota"],
+    plugins: [{id: "grind-by-weight", version: "1.0.0"}],
+    ...overrides,
+  };
+}
+
+async function readyBuild(env, hash, overrides = {}) {
+  await env.BUILDS.put(
+    `v1/${hash}/build-manifest.json`,
+    JSON.stringify(buildManifest(hash, overrides)),
+  );
+}
+
+async function linkScale(env, {
+  selectedDeviceId,
+  authorization,
+  pairCode,
+  recoveryKey = fleetSecret,
+}) {
+  const paired = await request(env, "/api/v1/device/pair", {
+    method: "POST",
+    body: {pair_code: pairCode},
+    authorization,
+    device: true,
+    selectedDeviceId,
+  });
+  assert.equal(paired.status, 200);
+  const claimed = await request(env, "/api/v1/fleet/claim", {
+    method: "POST",
+    body: {pair_code: pairCode},
+    authorization: recoveryKey,
+    browser: true,
+  });
+  assert.equal(claimed.status, 200);
+}
+
 test("pairs, assigns, authenticates, and physically relinks a scale", async () => {
   const {env, storage} = environment();
   const pair = await request(env, "/api/v1/device/pair", {
@@ -150,13 +203,8 @@ test("pairs, assigns, authenticates, and physically relinks a scale", async () =
   });
   assert.deepEqual(await assignment.json(), {
     linked: true,
-    name: "Bar Left",
-    serial_hint: "A3F921",
     desired_combination: combinationHash,
     state: "ready",
-    combination_hash: combinationHash,
-    manifest_url: `https://builds.example.test/v1/${combinationHash}/ota-manifest.json`,
-    downloads: {"HDS_FW_custom.zip": `https://builds.example.test/v1/${combinationHash}/HDS_FW_custom.zip`},
   });
 
   storage.values.set(`device:${deviceId}`, {
@@ -193,7 +241,348 @@ test("pairs, assigns, authenticates, and physically relinks a scale", async () =
     serial_hint: "A3F921",
     name: "Scale A3F921",
     desired_combination: null,
+    desired_updated_at: null,
+    installed_combination: null,
+    firmware_version: null,
+    last_seen_at: null,
   }]);
+});
+
+test("device check-in reports authoritative installed state without changing desired state", async () => {
+  const {env, storage} = environment();
+  const nextHash = "4".repeat(64);
+  await readyBuild(env, combinationHash);
+  await readyBuild(env, nextHash);
+  await linkScale(env, {
+    selectedDeviceId: deviceId,
+    authorization: deviceSecret,
+    pairCode: "A3F921-100001",
+  });
+  assert.equal((await storage.get(`device:${deviceId}`)).last_seen_at, null);
+  assert.equal((await request(env, `/api/v1/fleet/scales/${deviceId}`, {
+    method: "PATCH",
+    body: {desired_combination: combinationHash},
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 200);
+
+  const converged = await request(env, "/api/v1/device/check-in", {
+    method: "POST",
+    body: {installed_combination: combinationHash, firmware_version: "3.1.14-custom"},
+    authorization: deviceSecret,
+    device: true,
+  });
+  assert.deepEqual(await converged.json(), {
+    linked: true,
+    desired_combination: combinationHash,
+    state: "ready",
+  });
+  const installed = await storage.get(`device:${deviceId}`);
+  assert.equal(installed.installed_combination, combinationHash);
+  assert.equal(installed.firmware_version, "3.1.14-custom");
+  assert.ok(Number.isFinite(Date.parse(installed.last_seen_at)));
+
+  await request(env, `/api/v1/fleet/scales/${deviceId}`, {
+    method: "PATCH",
+    body: {desired_combination: nextHash},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal((await storage.get(`device:${deviceId}`)).installed_combination, combinationHash);
+
+  const official = await request(env, "/api/v1/device/check-in", {
+    method: "POST",
+    body: {installed_combination: null, firmware_version: "3.1.14"},
+    authorization: deviceSecret,
+    device: true,
+  });
+  assert.equal(official.status, 200);
+  assert.equal((await official.json()).desired_combination, nextHash);
+  assert.equal((await storage.get(`device:${deviceId}`)).installed_combination, null);
+
+  await request(env, "/api/v1/device/check-in", {
+    method: "POST",
+    body: {installed_combination: nextHash, firmware_version: "3.1.15-custom"},
+    authorization: deviceSecret,
+    device: true,
+  });
+  const beforeRejectedCheckIn = await storage.get(`device:${deviceId}`);
+  const rejected = await request(env, "/api/v1/device/check-in", {
+    method: "POST",
+    body: {installed_combination: combinationHash, firmware_version: "forged"},
+    authorization: "9".repeat(64),
+    device: true,
+  });
+  assert.equal(rejected.status, 401);
+  assert.deepEqual(await storage.get(`device:${deviceId}`), beforeRejectedCheckIn);
+
+  const overview = await request(env, "/api/v1/fleet/overview", {
+    authorization: fleetSecret,
+    browser: true,
+  });
+  const [scale] = (await overview.json()).scales;
+  assert.equal(scale.desired_combination, nextHash);
+  assert.equal(scale.installed_combination, nextHash);
+  assert.equal(scale.firmware_version, "3.1.15-custom");
+});
+
+test("fleet build library stores references without owning artifacts", async () => {
+  const {env, storage} = environment();
+  await readyBuild(env, combinationHash);
+  await linkScale(env, {
+    selectedDeviceId: deviceId,
+    authorization: deviceSecret,
+    pairCode: "A3F921-100002",
+  });
+  const objectCount = env.BUILDS.objects.size;
+  const added = await request(env, "/api/v1/fleet/builds", {
+    method: "POST",
+    body: {combination_hash: combinationHash},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal(added.status, 200);
+  assert.equal((await added.json()).combination_hash, combinationHash);
+  await request(env, "/api/v1/fleet/builds", {
+    method: "POST",
+    body: {combination_hash: combinationHash},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal(env.BUILDS.objects.size, objectCount);
+  assert.equal((await request(env, "/api/v1/fleet/builds", {
+    method: "POST",
+    body: {combination_hash: "5".repeat(64)},
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 409);
+  await env.BUILDS.put("v1/5555555555555555555555555555555555555555555555555555555555555555/build-manifest.json", "{}");
+  assert.equal((await request(env, "/api/v1/fleet/builds", {
+    method: "POST",
+    body: {combination_hash: "5".repeat(64)},
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 409);
+
+  const renamed = await request(env, `/api/v1/fleet/builds/${combinationHash}`, {
+    method: "PATCH",
+    body: {label: "Bar profile"},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal((await renamed.json()).label, "Bar profile");
+  const listed = await request(env, "/api/v1/fleet/builds", {
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.deepEqual((await listed.json()).builds.map(build => ({
+    label: build.label,
+    version: build.firmware_version,
+    features: build.features,
+    plugins: build.plugins,
+    state: build.state,
+  })), [{
+    label: "Bar profile",
+    version: "3.1.14-custom",
+    features: ["pull-ota"],
+    plugins: [{id: "grind-by-weight", version: "1.0.0"}],
+    state: "ready",
+  }]);
+
+  await request(env, "/api/v1/device/check-in", {
+    method: "POST",
+    body: {installed_combination: combinationHash, firmware_version: "3.1.14-custom"},
+    authorization: deviceSecret,
+    device: true,
+  });
+  await request(env, `/api/v1/fleet/scales/${deviceId}`, {
+    method: "PATCH",
+    body: {desired_combination: combinationHash},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal((await request(env, `/api/v1/fleet/builds/${combinationHash}`, {
+    method: "DELETE",
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 409);
+  await request(env, `/api/v1/fleet/scales/${deviceId}`, {
+    method: "PATCH",
+    body: {desired_combination: null},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal((await request(env, `/api/v1/fleet/builds/${combinationHash}`, {
+    method: "DELETE",
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 200);
+  assert.ok(await env.BUILDS.head(`v1/${combinationHash}/build-manifest.json`));
+  assert.equal((await storage.get(`device:${deviceId}`)).installed_combination, combinationHash);
+  assert.deepEqual((await (await request(env, "/api/v1/fleet/builds", {
+    authorization: fleetSecret,
+    browser: true,
+  })).json()).builds, []);
+});
+
+test("bulk assignments validate every target and resolve each build state once", async () => {
+  const {env, storage} = environment();
+  const firstId = "a".repeat(32);
+  const secondId = "b".repeat(32);
+  const foreignId = "c".repeat(32);
+  const readyHash = "6".repeat(64);
+  await readyBuild(env, readyHash);
+  await linkScale(env, {
+    selectedDeviceId: firstId,
+    authorization: "a".repeat(64),
+    pairCode: "AA0001-100001",
+  });
+  await linkScale(env, {
+    selectedDeviceId: secondId,
+    authorization: "b".repeat(64),
+    pairCode: "BB0002-100002",
+  });
+  await linkScale(env, {
+    selectedDeviceId: foreignId,
+    authorization: "c".repeat(64),
+    pairCode: "CC0003-100003",
+    recoveryKey: secondFleetSecret,
+  });
+
+  const single = await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: readyHash, device_ids: [firstId]},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal((await single.json()).updated, 1);
+  const multiple = await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: readyHash, device_ids: [firstId, firstId, secondId]},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.deepEqual((await multiple.json()).device_ids, [firstId, secondId]);
+  assert.equal((await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: readyHash, device_ids: []},
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 400);
+  assert.equal((await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: readyHash, device_ids: ["invalid"]},
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 400);
+  assert.equal((await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: readyHash, device_ids: ["f".repeat(32)]},
+    authorization: fleetSecret,
+    browser: true,
+  })).status, 404);
+
+  const beforeCrossFleet = await storage.get(`device:${firstId}`);
+  const crossFleet = await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: null, device_ids: [firstId, foreignId]},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal(crossFleet.status, 403);
+  assert.deepEqual(await storage.get(`device:${firstId}`), beforeCrossFleet);
+
+  const cleared = await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: null, device_ids: [firstId, secondId]},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal((await cleared.json()).updated, 2);
+  assert.equal((await storage.get(`device:${firstId}`)).desired_combination, null);
+  const all = await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: readyHash, all: true},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal((await all.json()).updated, 2);
+  assert.equal((await storage.get(`device:${foreignId}`)).desired_combination, null);
+
+  env.BUILDS.headRequests = [];
+  const overview = await request(env, "/api/v1/fleet/overview", {
+    authorization: fleetSecret,
+    browser: true,
+  });
+  const fleet = await overview.json();
+  assert.equal(fleet.scales.length, 2);
+  assert.equal(fleet.build_states[readyHash], "ready");
+  assert.equal(env.BUILDS.headRequests.filter(key =>
+    key === `v1/${readyHash}/build-manifest.json`).length, 1);
+});
+
+test("all-scale assignment chunks storage writes at the platform limit", async () => {
+  const {env, storage} = environment();
+  await readyBuild(env, combinationHash);
+  await linkScale(env, {
+    selectedDeviceId: deviceId,
+    authorization: deviceSecret,
+    pairCode: "A3F921-100005",
+  });
+  const fleetKey = [...storage.values.keys()].find(key => key.startsWith("fleet:"));
+  const fleet = await storage.get(fleetKey);
+  const extraIds = Array.from({length: 128}, (_, index) =>
+    (index + 32).toString(16).padStart(32, "0"));
+  await storage.put(Object.fromEntries(extraIds.map((id, index) => [`device:${id}`, {
+    fleet_id: fleetKey.slice(6),
+    desired_combination: null,
+    name: `Scale ${index}`,
+  }])));
+  await storage.put(fleetKey, {...fleet, devices: [deviceId, ...extraIds]});
+
+  const response = await request(env, "/api/v1/fleet/assignments", {
+    method: "POST",
+    body: {combination_hash: combinationHash, all: true},
+    authorization: fleetSecret,
+    browser: true,
+  });
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).updated, 129);
+  assert.equal((await storage.get(`device:${extraIds.at(-1)}`)).desired_combination, combinationHash);
+});
+
+test("legacy fleet records remain readable with unknown installed state", async () => {
+  const {env, storage} = environment();
+  await linkScale(env, {
+    selectedDeviceId: deviceId,
+    authorization: deviceSecret,
+    pairCode: "A3F921-100004",
+  });
+  const current = await storage.get(`device:${deviceId}`);
+  const {
+    desired_updated_at,
+    installed_combination,
+    firmware_version,
+    last_seen_at,
+    ...legacy
+  } = current;
+  await storage.put(`device:${deviceId}`, legacy);
+  const overview = await request(env, "/api/v1/fleet/overview", {
+    authorization: fleetSecret,
+    browser: true,
+  });
+  const result = await overview.json();
+  assert.deepEqual(result.builds, []);
+  assert.deepEqual(result.scales[0], {
+    device_id: deviceId,
+    serial_hint: "A3F921",
+    name: "Scale A3F921",
+    desired_combination: null,
+    desired_updated_at: null,
+    installed_combination: null,
+    firmware_version: null,
+    last_seen_at: null,
+  });
 });
 
 test("rejects unready assignments and invalid device credentials", async () => {

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -19,6 +19,22 @@ AI-documentation audit, read `docs/AI_RELEASE_NOTES.md`.
   `HDS_CUSTOM_OTA_SIGNING_KEY_PEM`; Key 2 is the offline rotation reserve.
 - Custom OTA assignments contain only a canonical combination hash, never an asset URL.
 
+## Custom Fleet OTA
+
+Opening the Custom Build menu performs one authenticated device check-in. Custom firmware reports
+the normalized compile-time `HDS_CUSTOM_BUILD_COMBINATION_HASH`; official firmware reports null.
+The response contains only linking state, one desired combination, and its canonical build state.
+
+Validate the full desired hash before comparing it with the local compile-time hash. An exact match
+must return before custom manifest or signature retrieval, asset download, pending LittleFS state,
+or reboot scheduling. The Worker copy of `installed_combination` is telemetry and must never drive
+this decision.
+
+Fleet build references, scale lists, bulk assignment, and deployment history stay in the
+Worker/browser. Firmware must not fetch a fleet build list, add fleet-sized collections, persist a
+short hash, add background check-ins, or increase `HDS_OTA_TASK_STACK_BYTES` without measurement.
+OLED identity uses an uppercase 8-character prefix for display only.
+
 ## Release Assets
 
 Release builds publish WiFi OTA assets at the GitHub Release root:
@@ -145,5 +161,7 @@ python tools/test_ota_rollback_contract.py
 python tools/test_ota_public_key_header.py
 python tools/test_ota_reboot_routing_contract.py
 python tools/test_custom_build_ota_contract.py
+node --test cloudflare/custom-build-worker/test/fleet.test.mjs
+node --test cloudflare/custom-build-worker/test/configurator.test.mjs
 pio run -e esp32s3
 ```

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=5";
+import {initFleet} from "./fleet.js?v=6";
 
 (async () => {
   const apiBase = "https://openscale-custom-builds.odevstudio.workers.dev";

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -11,6 +11,34 @@ import {
 import {initFleet} from "./fleet.js?v=6";
 
 (async () => {
+  const themeStorageKey = "hds-custom-build-theme-v1";
+  const themeRoot = document.documentElement;
+  const themeToggle = document.querySelector("#theme-toggle");
+  const systemTheme = matchMedia("(prefers-color-scheme: dark)");
+  const applyTheme = preference => {
+    const dark = preference === "dark" || preference === "system" && systemTheme.matches;
+    themeRoot.dataset.themePreference = preference;
+    themeRoot.dataset.theme = dark ? "dark" : "light";
+    const current = preference === "system" ? "System" : dark ? "Dark" : "Light";
+    const label = `${current} theme; switch to ${dark ? "light" : "dark"} theme`;
+    themeToggle.setAttribute("aria-pressed", String(dark));
+    themeToggle.setAttribute("aria-label", label);
+    themeToggle.title = label;
+    document.querySelector("#theme-color").content = dark ? "#111413" : "#0d6b4f";
+  };
+  applyTheme(themeRoot.dataset.themePreference || "system");
+  themeToggle.addEventListener("click", () => {
+    const preference = themeRoot.dataset.theme === "dark" ? "light" : "dark";
+    applyTheme(preference);
+    try {
+      localStorage.setItem(themeStorageKey, JSON.stringify({version: 1, preference}));
+    } catch {
+    }
+  });
+  systemTheme.addEventListener("change", () => {
+    if (themeRoot.dataset.themePreference === "system") applyTheme("system");
+  });
+
   const apiBase = "https://openscale-custom-builds.odevstudio.workers.dev";
   const response = await fetch("catalog.json", {cache: "no-store"});
   if (!response.ok) throw new Error(`catalog request failed: ${response.status}`);
@@ -52,7 +80,6 @@ import {initFleet} from "./fleet.js?v=6";
   const hashButton = document.querySelector("#copy-hash");
   const fleetPanel = document.querySelector("#fleet-panel");
   let toastTimer;
-  let updaterTimer;
   let statusTimer;
   let pollTimer;
   let pollRemaining = 0;
@@ -159,6 +186,12 @@ import {initFleet} from "./fleet.js?v=6";
     buildState.textContent = labels[result.state] || result.state[0].toUpperCase() + result.state.slice(1);
     currentCombinationHash = combinationHash;
     currentBuildState = result.state;
+    const updaterLink = document.querySelector("#hds-updater-link");
+    const updaterReady = result.state === "ready" && installMethod === "usb";
+    updaterLink.classList.toggle("is-ready", updaterReady);
+    updaterLink.setAttribute(
+      "aria-label", updaterReady ? "Open HDS Updater for this build" : "Open HDS Updater",
+    );
     document.querySelector("#combination-hash").textContent = combinationHash;
     hashButton.hidden = !combinationHash;
     const retryMessage = result.state === "failed" ?
@@ -173,15 +206,6 @@ import {initFleet} from "./fleet.js?v=6";
         const link = document.createElement("a");
         link.href = href;
         link.textContent = name;
-        if (name.endsWith(".zip")) {
-          link.addEventListener("click", () => {
-            const updaterLink = document.querySelector("#hds-updater-link");
-            clearTimeout(updaterTimer);
-            updaterLink.classList.remove("is-next-step");
-            requestAnimationFrame(() => updaterLink.classList.add("is-next-step"));
-            updaterTimer = setTimeout(() => updaterLink.classList.remove("is-next-step"), 6000);
-          });
-        }
         downloads.append(link);
       });
     }

--- a/docs/custom-build/fleet-state.mjs
+++ b/docs/custom-build/fleet-state.mjs
@@ -28,7 +28,7 @@ export function deploymentState(scale, buildStates, now = Date.now()) {
     return !Number.isFinite(lastSeen) || !Number.isFinite(assigned) || lastSeen < assigned
       ? "Update assigned" : "Install pending";
   }
-  return scale.installed_combination ? "No update assigned" : "Unknown";
+  return Number.isFinite(lastSeen) || scale.installed_combination ? "No update assigned" : "Unknown";
 }
 
 export function lastSeenLabel(value, now = Date.now()) {

--- a/docs/custom-build/fleet-state.mjs
+++ b/docs/custom-build/fleet-state.mjs
@@ -1,0 +1,44 @@
+const hashPattern = /^[0-9a-f]{64}$/;
+const offlineAfterMs = 7 * 24 * 60 * 60 * 1000;
+
+export const shortHash = (value, length = 12) =>
+  hashPattern.test(value || "") ? value.slice(0, length).toUpperCase() : "";
+
+export function buildSummary(build) {
+  const features = Array.isArray(build?.features) ? build.features : [];
+  const plugins = Array.isArray(build?.plugins)
+    ? build.plugins.map(plugin => plugin.version ? `${plugin.id} ${plugin.version}` : plugin.id)
+    : [];
+  const entries = [...features, ...plugins];
+  if (!entries.length) return "Base firmware";
+  const visible = entries.slice(0, 3).join(", ");
+  return entries.length > 3 ? `${visible} +${entries.length - 3}` : visible;
+}
+
+export function deploymentState(scale, buildStates, now = Date.now()) {
+  const lastSeen = Date.parse(scale.last_seen_at || "");
+  if (Number.isFinite(lastSeen) && now - lastSeen > offlineAfterMs) return "Offline";
+  const desired = scale.desired_combination;
+  if (desired && desired === scale.installed_combination) return "Up to date";
+  const buildState = buildStates[desired];
+  if (["queued", "building"].includes(buildState)) return "Build preparing";
+  if (desired && ["failed", "missing"].includes(buildState)) return "Build unavailable";
+  if (desired) {
+    const assigned = Date.parse(scale.desired_updated_at || "");
+    return !Number.isFinite(lastSeen) || !Number.isFinite(assigned) || lastSeen < assigned
+      ? "Update assigned" : "Install pending";
+  }
+  return scale.installed_combination ? "No update assigned" : "Unknown";
+}
+
+export function lastSeenLabel(value, now = Date.now()) {
+  if (!value) return "Never";
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return "Unknown";
+  const elapsedMinutes = Math.max(0, Math.floor((now - timestamp) / 60000));
+  if (elapsedMinutes < 1) return "Just now";
+  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `${elapsedHours}h ago`;
+  return `${Math.floor(elapsedHours / 24)}d ago`;
+}

--- a/docs/custom-build/fleet.css
+++ b/docs/custom-build/fleet.css
@@ -1,0 +1,398 @@
+.fleet-section {
+  min-width: 0;
+  padding: 22px 0;
+  border-top: 1px solid var(--line);
+}
+
+.fleet-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.fleet-section-head h4 {
+  margin: 0;
+  color: var(--ink);
+  font-size: .92rem;
+}
+
+.fleet-status {
+  min-height: 19px;
+  margin: 3px 0 0;
+}
+
+.fleet-build-labels,
+.fleet-build-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(190px, 1.35fr) 142px 92px auto;
+  align-items: center;
+  gap: 14px;
+}
+
+.fleet-build-labels {
+  padding: 0 10px 8px;
+  color: var(--faint);
+  font-size: .65rem;
+  font-weight: 720;
+}
+
+.fleet-build-list {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.fleet-build-row {
+  min-height: 74px;
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.fleet-build-name,
+.fleet-build-version,
+.scale-build {
+  min-width: 0;
+}
+
+.build-label {
+  width: 100%;
+  height: 40px;
+  padding: 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  color: var(--ink);
+  background: var(--surface);
+  font: 680 .76rem/1 system-ui, sans-serif;
+  outline: 0;
+}
+
+.build-label:focus {
+  border-color: var(--green);
+  box-shadow: 0 0 0 3px rgba(13, 121, 85, .13);
+}
+
+.fleet-build-version strong,
+.fleet-build-version span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.fleet-build-version strong {
+  color: var(--ink);
+  font-size: .76rem;
+}
+
+.fleet-build-version span {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: .68rem;
+  line-height: 1.35;
+}
+
+.fleet-hash {
+  min-width: 0;
+  padding: 7px 8px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--code);
+  background: var(--surface-soft);
+  cursor: pointer;
+  text-overflow: ellipsis;
+}
+
+.fleet-hash code {
+  font: 650 .67rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.fleet-hash:hover,
+.fleet-hash:focus-visible {
+  border-color: var(--green-line);
+  background: var(--green-soft);
+  outline: 0;
+}
+
+.deployment-state {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 26px;
+  padding: 0 8px;
+  border-radius: 999px;
+  color: var(--muted);
+  background: var(--surface-soft);
+  font-size: .68rem;
+  font-weight: 720;
+  white-space: nowrap;
+}
+
+.deployment-state[data-state="ready"],
+.deployment-state[data-state="up-to-date"] {
+  color: var(--green-dark);
+  background: var(--green-soft);
+}
+
+.deployment-state[data-state="update-assigned"],
+.deployment-state[data-state="install-pending"],
+.deployment-state[data-state="build-preparing"] {
+  color: var(--amber);
+  background: var(--amber-soft);
+}
+
+.deployment-state[data-state="failed"],
+.deployment-state[data-state="build-unavailable"] {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.fleet-row-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.fleet-row-actions .ghost-bordered-button,
+.fleet-row-actions .ghost-button,
+.fleet-table .ghost-bordered-button {
+  min-height: 36px;
+  padding: 0 10px;
+}
+
+.fleet-empty-row {
+  padding: 18px 10px;
+  color: var(--muted);
+  font-size: .76rem;
+}
+
+.deployment-toolbar {
+  display: grid;
+  grid-template-columns: auto minmax(180px, 1fr) auto auto auto auto auto;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 14px;
+  padding: 10px;
+  background: var(--surface-soft);
+}
+
+.deployment-toolbar > label {
+  color: var(--muted);
+  font-size: .72rem;
+  font-weight: 720;
+}
+
+.select-all-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.select-all-control input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--green);
+}
+
+.deployment-toolbar select {
+  width: 100%;
+  height: 40px;
+  padding: 0 34px 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 7px;
+  color: var(--ink);
+  background: var(--surface);
+  font-size: .74rem;
+}
+
+.selection-count {
+  min-width: 72px;
+  color: var(--muted);
+  font-size: .7rem;
+  font-weight: 680;
+  text-align: center;
+}
+
+.deployment-toolbar .primary-button,
+.deployment-toolbar .ghost-bordered-button,
+.deployment-toolbar .ghost-button {
+  min-height: 40px;
+  padding: 0 11px;
+  white-space: nowrap;
+}
+
+.deployment-toolbar button:disabled {
+  opacity: .5;
+  cursor: default;
+}
+
+.fleet-table-wrap {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  contain: inline-size;
+}
+
+.fleet-table {
+  width: 100%;
+  min-width: 940px;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.fleet-table th,
+.fleet-table td {
+  padding: 11px 10px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.fleet-table th {
+  color: var(--faint);
+  font-size: .65rem;
+  font-weight: 720;
+}
+
+.fleet-table th:nth-child(1) { width: 42px; }
+.fleet-table th:nth-child(2) { width: 185px; }
+.fleet-table th:nth-child(3),
+.fleet-table th:nth-child(4) { width: 155px; }
+.fleet-table th:nth-child(5) { width: 126px; }
+.fleet-table th:nth-child(6) { width: 86px; }
+.fleet-table th:nth-child(7) { width: 62px; }
+
+.scale-select input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--green);
+}
+
+.fleet-table .scale-name {
+  height: 38px;
+}
+
+.fleet-table .scale-hint {
+  margin-top: 4px;
+}
+
+.scale-build strong,
+.scale-build code {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scale-build strong {
+  color: var(--ink);
+  font-size: .72rem;
+}
+
+.scale-build code {
+  margin-top: 4px;
+  color: var(--faint);
+  font: 650 .65rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.last-seen {
+  color: var(--muted);
+  font-size: .7rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 930px) {
+  .fleet-build-labels { display: none; }
+
+  .fleet-build-row {
+    grid-template-columns: minmax(150px, 1fr) minmax(180px, 1fr) auto;
+  }
+
+  .fleet-hash,
+  .deployment-state { grid-row: 2; }
+
+  .fleet-row-actions { grid-column: 3; grid-row: 1 / span 2; }
+
+  .deployment-toolbar {
+    grid-template-columns: auto minmax(180px, 1fr) auto auto;
+  }
+
+  .deployment-toolbar .primary-button,
+  .deployment-toolbar .ghost-bordered-button,
+  .deployment-toolbar .ghost-button { width: 100%; }
+}
+
+@media (max-width: 640px) {
+  .fleet-section-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .fleet-section-head .primary-button { width: 100%; }
+
+  .fleet-build-row {
+    grid-template-columns: 1fr auto;
+    gap: 10px;
+  }
+
+  .fleet-build-name,
+  .fleet-build-version { grid-column: 1 / -1; }
+  .fleet-hash,
+  .deployment-state { grid-row: auto; }
+  .fleet-row-actions { grid-column: 1 / -1; grid-row: auto; justify-content: stretch; }
+  .fleet-row-actions button { flex: 1; }
+
+  .deployment-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .deployment-toolbar > label,
+  .deployment-toolbar .select-wrap { grid-column: 1 / -1; }
+  .selection-count { text-align: left; }
+  .deployment-toolbar .ghost-button { order: initial; }
+
+  .fleet-table {
+    display: block;
+    min-width: 0;
+  }
+
+  .fleet-table thead { display: none; }
+  .fleet-table tbody { display: grid; }
+
+  .fleet-table tr {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+    gap: 8px 10px;
+    padding: 14px 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .fleet-table td {
+    display: block;
+    padding: 0;
+    border: 0;
+  }
+
+  .fleet-table .scale-select { grid-column: 1; grid-row: 1; padding-top: 10px; }
+  .fleet-table .scale-identity { grid-column: 2; grid-row: 1; }
+  .fleet-table td:last-child { grid-column: 3; grid-row: 1; }
+
+  .fleet-table td[data-label] {
+    grid-column: 2 / -1;
+    display: grid;
+    grid-template-columns: 78px minmax(0, 1fr);
+    align-items: center;
+    min-height: 30px;
+  }
+
+  .fleet-table td[data-label]::before {
+    content: attr(data-label);
+    color: var(--faint);
+    font-size: .65rem;
+    font-weight: 720;
+  }
+}

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -1,3 +1,5 @@
+import {buildSummary, deploymentState, lastSeenLabel, shortHash} from "./fleet-state.mjs?v=1";
+
 const storageKey = "hds-custom-build-fleet-v2";
 const legacyStorageKey = "hds-custom-build-fleet-v1";
 const fleetPattern = /^[A-Z2-7]{32}$/;
@@ -64,13 +66,27 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   const useFleet = document.querySelector("#use-fleet");
   const recovery = document.querySelector("#fleet-recovery");
   const recoveryKey = document.querySelector("#fleet-recovery-key");
-  const scaleList = document.querySelector("#fleet-scales");
   const fleetStatus = document.querySelector("#fleet-status");
+  const buildStatus = document.querySelector("#fleet-build-status");
+  const buildList = document.querySelector("#fleet-builds");
+  const scaleRows = document.querySelector("#fleet-scale-rows");
+  const selectAll = document.querySelector("#select-all-scales");
+  const buildSelect = document.querySelector("#fleet-build-select");
+  const selectedCount = document.querySelector("#selected-scale-count");
+  const addBuild = document.querySelector("#add-fleet-build");
+  const assignSelected = document.querySelector("#assign-selected");
+  const assignAll = document.querySelector("#assign-all");
+  const clearSelected = document.querySelector("#clear-selected");
   const pairInput = document.querySelector("#pair-code");
   const existingInput = document.querySelector("#existing-fleet-key");
   const forgetDialog = document.querySelector("#forget-fleet-dialog");
+  const confirmDialog = document.querySelector("#fleet-confirm-dialog");
   let fleetKey = loadStoredKey();
   let generation = 0;
+  let scales = [];
+  let builds = [];
+  let buildStates = {};
+  let selectedDeviceIds = new Set();
 
   const setSettingsOpen = open => {
     settings.hidden = !open;
@@ -86,7 +102,11 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       },
     });
     const result = await response.json().catch(() => ({}));
-    if (!response.ok) throw new Error(result.error || `request failed: ${response.status}`);
+    if (!response.ok) {
+      const error = new Error(result.error || `request failed: ${response.status}`);
+      error.code = result.error;
+      throw error;
+    }
     return result;
   };
 
@@ -98,92 +118,210 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     recoveryKey.value = formattedFleetKey(fleetKey);
   };
 
-  const statusLabel = state => ({
-    ready: "Ready",
-    queued: "Waiting to build",
-    building: "Building",
-    failed: "Build failed",
-    missing: "Build unavailable",
-  })[state] || "Not assigned";
+  const confirm = (title, description, action) => new Promise(resolve => {
+    document.querySelector("#fleet-confirm-heading").textContent = title;
+    document.querySelector("#fleet-confirm-description").textContent = description;
+    document.querySelector("#fleet-confirm-action").textContent = action;
+    const closed = () => {
+      confirmDialog.removeEventListener("close", closed);
+      resolve(confirmDialog.returnValue === "confirm");
+    };
+    confirmDialog.addEventListener("close", closed);
+    confirmDialog.showModal();
+  });
 
-  const scaleRow = scale => {
-    const row = document.createElement("li");
-    row.className = "scale-row";
-    const assignment = scale.assignment;
-    const readyHash = getReadyHash();
-    row.innerHTML = `
-      <div class="scale-identity">
-        <input class="scale-name" aria-label="Scale name" maxlength="40" value="">
-        <span class="scale-hint"></span>
-      </div>
-      <div class="scale-assignment">
-        <span class="scale-build-state"></span>
-        <code></code>
-      </div>
-      <div class="scale-actions">
-        <button class="ghost-button save-scale" type="button">Save name</button>
-        <button class="primary-button assign-scale" type="button">Use this build</button>
-      </div>`;
-    row.querySelector(".scale-name").value = scale.name;
-    row.querySelector(".scale-hint").textContent = scale.serial_hint;
-    row.querySelector(".scale-build-state").textContent = statusLabel(assignment?.state);
-    row.querySelector("code").textContent = scale.desired_combination?.slice(0, 8).toUpperCase() || "";
-    const assign = row.querySelector(".assign-scale");
-    row.dataset.assignedCombination = scale.desired_combination || "";
-    assign.disabled = !readyHash || readyHash === scale.desired_combination;
-    assign.textContent = readyHash === scale.desired_combination ? "Build assigned" : "Use this build";
-    row.querySelector(".save-scale").addEventListener("click", async () => {
-      const name = row.querySelector(".scale-name").value.trim();
-      try {
-        await api(`/api/v1/fleet/scales/${scale.device_id}`, {
-          method: "PATCH",
-          body: JSON.stringify({name}),
-        });
-        showToast("Scale name saved");
-        await loadScales();
-      } catch {
-        showToast("Scale name could not be saved");
-      }
-    });
-    assign.addEventListener("click", async () => {
-      const hash = getReadyHash();
-      if (!hash) return;
-      assign.disabled = true;
-      try {
-        await api(`/api/v1/fleet/scales/${scale.device_id}`, {
-          method: "PATCH",
-          body: JSON.stringify({desired_combination: hash}),
-        });
-        showToast("Build assigned to scale");
-        await loadScales();
-      } catch {
-        assign.disabled = false;
-        showToast("Build could not be assigned");
-      }
-    });
-    return row;
+  const copyHash = async hash => {
+    try {
+      await navigator.clipboard.writeText(hash);
+      showToast("Combination hash copied");
+    } catch {
+      showToast("Combination hash could not be copied");
+    }
   };
 
-  const loadScales = async () => {
+  const showApiError = error => {
+    const messages = {
+      build_assigned: "Clear this build from assigned scales before removing it",
+      build_not_ready: "Only ready custom builds can be added or assigned",
+      cross_fleet_device: "One or more scales belong to another fleet",
+      device_not_found: "One or more scales are no longer linked",
+      empty_target_set: "Select at least one scale",
+    };
+    showToast(messages[error.code] || "Fleet change could not be saved");
+  };
+
+  const renderControls = () => {
+    const selected = selectedDeviceIds.size;
+    const readyBuilds = builds.filter(build => build.state === "ready");
+    const previousHash = buildSelect.value;
+    buildSelect.replaceChildren(...readyBuilds.map(build =>
+      new Option(`${build.label} · ${shortHash(build.combination_hash)}`, build.combination_hash)));
+    if (readyBuilds.some(build => build.combination_hash === previousHash)) {
+      buildSelect.value = previousHash;
+    }
+    buildSelect.disabled = !readyBuilds.length;
+    selectedCount.textContent = `${selected} selected`;
+    assignSelected.disabled = !selected || !readyBuilds.length;
+    assignAll.disabled = !scales.length || !readyBuilds.length;
+    clearSelected.disabled = !selected;
+    selectAll.checked = Boolean(scales.length) && selected === scales.length;
+    selectAll.indeterminate = selected > 0 && selected < scales.length;
+    const readyHash = getReadyHash();
+    const alreadyAdded = builds.some(build => build.combination_hash === readyHash);
+    addBuild.disabled = !scales.length || !readyHash || alreadyAdded;
+    addBuild.textContent = alreadyAdded ? "Build added" : "Add current build";
+  };
+
+  const loadFleet = async () => {
     const currentGeneration = ++generation;
-    fleetStatus.textContent = "Loading scales";
+    fleetStatus.textContent = "Loading fleet";
+    buildStatus.textContent = "";
     try {
-      const result = await api("/api/v1/fleet/scales");
-      const scales = await Promise.all(result.scales.map(async scale => {
-        if (!scale.desired_combination) return {...scale, assignment: null};
-        try {
-          const response = await fetch(`${apiBase}/api/v1/status/${scale.desired_combination}`);
-          return {...scale, assignment: response.ok ? await response.json() : null};
-        } catch {
-          return {...scale, assignment: null};
-        }
-      }));
+      const result = await api("/api/v1/fleet/overview");
       if (currentGeneration !== generation) return;
-      scaleList.replaceChildren(...scales.map(scaleRow));
-      fleetStatus.textContent = scales.length ? "" : "No scales linked yet.";
+      scales = Array.isArray(result.scales) ? result.scales : [];
+      builds = Array.isArray(result.builds) ? result.builds : [];
+      buildStates = result.build_states || {};
+      selectedDeviceIds = new Set([...selectedDeviceIds].filter(deviceId =>
+        scales.some(scale => scale.device_id === deviceId)));
+      renderBuilds();
+      renderScales();
+      fleetStatus.textContent = scales.length
+        ? `${scales.length} scale${scales.length === 1 ? "" : "s"}` : "No scales linked yet";
+      buildStatus.textContent = builds.length
+        ? `${builds.length} saved build${builds.length === 1 ? "" : "s"}` : "No saved builds";
     } catch {
       if (currentGeneration !== generation) return;
-      fleetStatus.textContent = "Scales could not be loaded.";
+      fleetStatus.textContent = "Fleet could not be loaded";
+    }
+  };
+
+  const renderBuilds = () => {
+    if (!builds.length) {
+      const empty = document.createElement("li");
+      empty.className = "fleet-empty-row";
+      empty.textContent = "Add the ready build shown above to use it for deployments.";
+      buildList.replaceChildren(empty);
+      renderControls();
+      return;
+    }
+    buildList.replaceChildren(...builds.map(build => {
+      const row = document.createElement("li");
+      row.className = "fleet-build-row";
+      row.innerHTML = `
+        <div class="fleet-build-name"><input class="build-label" maxlength="40" aria-label="Build label"></div>
+        <div class="fleet-build-version"><strong></strong><span></span></div>
+        <button class="fleet-hash" type="button" title="Copy full combination hash"><code></code></button>
+        <span class="deployment-state"></span>
+        <div class="fleet-row-actions">
+          <button class="ghost-bordered-button save-build" type="button">Save</button>
+          <button class="ghost-button remove-build" type="button">Remove</button>
+        </div>`;
+      row.querySelector(".build-label").value = build.label;
+      row.querySelector(".fleet-build-version strong").textContent = build.firmware_version;
+      row.querySelector(".fleet-build-version span").textContent = buildSummary(build);
+      row.querySelector("code").textContent = shortHash(build.combination_hash);
+      const state = row.querySelector(".deployment-state");
+      state.textContent = build.state === "ready" ? "Ready" : "Unavailable";
+      state.dataset.state = build.state;
+      row.querySelector(".fleet-hash").addEventListener("click", () => copyHash(build.combination_hash));
+      row.querySelector(".save-build").addEventListener("click", async () => {
+        try {
+          await api(`/api/v1/fleet/builds/${build.combination_hash}`, {
+            method: "PATCH",
+            body: JSON.stringify({label: row.querySelector(".build-label").value.trim()}),
+          });
+          showToast("Build label saved");
+          await loadFleet();
+        } catch (error) {
+          showApiError(error);
+        }
+      });
+      row.querySelector(".remove-build").addEventListener("click", async () => {
+        if (!(await confirm("Remove saved build?", `${build.label} will remain available to existing installations.`, "Remove"))) return;
+        try {
+          await api(`/api/v1/fleet/builds/${build.combination_hash}`, {method: "DELETE"});
+          showToast("Build removed from fleet");
+          await loadFleet();
+        } catch (error) {
+          showApiError(error);
+        }
+      });
+      return row;
+    }));
+    renderControls();
+  };
+
+  const renderScales = () => {
+    scaleRows.replaceChildren(...scales.map(scale => {
+      const row = document.createElement("tr");
+      row.innerHTML = `
+        <td class="scale-select"><input type="checkbox"></td>
+        <td class="scale-identity"><input class="scale-name" maxlength="40"><span class="scale-hint"></span></td>
+        <td class="scale-build" data-label="Installed"><strong></strong><code></code></td>
+        <td class="scale-build desired-build" data-label="Desired"><strong></strong><code></code></td>
+        <td data-label="Deployment"><span class="deployment-state"></span></td>
+        <td class="last-seen" data-label="Last seen"></td>
+        <td><button class="ghost-bordered-button save-scale" type="button">Save</button></td>`;
+      const checkbox = row.querySelector('[type="checkbox"]');
+      checkbox.checked = selectedDeviceIds.has(scale.device_id);
+      checkbox.setAttribute("aria-label", `Select ${scale.name}`);
+      checkbox.addEventListener("change", () => {
+        selectedDeviceIds = checkbox.checked
+          ? new Set([...selectedDeviceIds, scale.device_id])
+          : new Set([...selectedDeviceIds].filter(deviceId => deviceId !== scale.device_id));
+        renderControls();
+      });
+      const name = row.querySelector(".scale-name");
+      name.value = scale.name;
+      row.querySelector(".scale-hint").textContent = scale.serial_hint;
+      const installed = row.querySelector(".scale-build");
+      installed.querySelector("strong").textContent = scale.firmware_version || "Unknown";
+      installed.querySelector("code").textContent = shortHash(scale.installed_combination) ||
+        (scale.last_seen_at ? "Official" : "Unknown");
+      const desired = row.querySelector(".desired-build");
+      const desiredBuild = builds.find(build => build.combination_hash === scale.desired_combination);
+      desired.querySelector("strong").textContent = desiredBuild?.label ||
+        (scale.desired_combination ? "Custom build" : "None");
+      desired.querySelector("code").textContent = shortHash(scale.desired_combination);
+      const state = row.querySelector(".deployment-state");
+      state.textContent = deploymentState(scale, buildStates);
+      state.dataset.state = state.textContent.toLowerCase().replaceAll(" ", "-");
+      row.querySelector(".last-seen").textContent = lastSeenLabel(scale.last_seen_at);
+      row.querySelector(".save-scale").addEventListener("click", async () => {
+        try {
+          await api(`/api/v1/fleet/scales/${scale.device_id}`, {
+            method: "PATCH",
+            body: JSON.stringify({name: name.value.trim()}),
+          });
+          showToast("Scale name saved");
+          await loadFleet();
+        } catch (error) {
+          showApiError(error);
+        }
+      });
+      return row;
+    }));
+    renderControls();
+  };
+
+  const assign = async (targets, combinationHash, label) => {
+    const count = targets.all ? scales.length : targets.device_ids.length;
+    if (count > 1 && !(await confirm(
+      `${label} ${count} scales?`,
+      combinationHash ? "The selected build will become their desired deployment." : "Their desired deployment will be cleared.",
+      label,
+    ))) return;
+    try {
+      await api("/api/v1/fleet/assignments", {
+        method: "POST",
+        body: JSON.stringify({combination_hash: combinationHash, ...targets}),
+      });
+      selectedDeviceIds = new Set();
+      showToast(`${label} complete`);
+      await loadFleet();
+    } catch (error) {
+      showApiError(error);
     }
   };
 
@@ -196,7 +334,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     saveKey(fleetKey);
     setMode(true);
     setSettingsOpen(false);
-    loadScales();
+    loadFleet();
     return true;
   };
 
@@ -205,7 +343,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     if (activateKey(key)) showToast("Recovery key created");
   });
   settingsToggle.addEventListener("click", () => setSettingsOpen(settings.hidden));
-  document.querySelector("#use-fleet").addEventListener("submit", event => {
+  useFleet.addEventListener("submit", event => {
     event.preventDefault();
     activateKey(existingInput.value);
   });
@@ -217,16 +355,18 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       showToast("Fleet key could not be copied");
     }
   });
-  document.querySelector("#forget-fleet").addEventListener("click", () => {
-    forgetDialog.showModal();
-  });
+  document.querySelector("#forget-fleet").addEventListener("click", () => forgetDialog.showModal());
   forgetDialog.addEventListener("close", () => {
     if (forgetDialog.returnValue !== "confirm") return;
     removeStoredKey(sessionStorage, storageKey);
     removeStoredKey(localStorage, legacyStorageKey);
     fleetKey = "";
     generation += 1;
-    scaleList.replaceChildren();
+    scales = [];
+    builds = [];
+    selectedDeviceIds = new Set();
+    buildList.replaceChildren();
+    scaleRows.replaceChildren();
     setMode(false);
   });
   document.querySelector("#pair-scale").addEventListener("submit", async event => {
@@ -243,20 +383,39 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       });
       pairInput.value = "";
       showToast("Scale linked");
-      await loadScales();
+      await loadFleet();
     } catch {
       showToast("Pairing code is invalid or expired");
     }
   });
-  document.addEventListener("openscale-build-status", () => {
-    const readyHash = getReadyHash();
-    scaleList.querySelectorAll(".scale-row").forEach(row => {
-      const assign = row.querySelector(".assign-scale");
-      assign.disabled = !readyHash || readyHash === row.dataset.assignedCombination;
-      assign.textContent = readyHash === row.dataset.assignedCombination ? "Build assigned" : "Use this build";
-    });
+  addBuild.addEventListener("click", async () => {
+    const combinationHash = getReadyHash();
+    if (!combinationHash) return;
+    try {
+      await api("/api/v1/fleet/builds", {
+        method: "POST",
+        body: JSON.stringify({combination_hash: combinationHash}),
+      });
+      showToast("Build added to fleet");
+      await loadFleet();
+    } catch (error) {
+      showApiError(error);
+    }
   });
+  selectAll.addEventListener("change", () => {
+    selectedDeviceIds = selectAll.checked ? new Set(scales.map(scale => scale.device_id)) : new Set();
+    renderScales();
+  });
+  buildSelect.addEventListener("change", renderControls);
+  assignSelected.addEventListener("click", () => assign(
+    {device_ids: [...selectedDeviceIds]}, buildSelect.value, "Assign",
+  ));
+  assignAll.addEventListener("click", () => assign({all: true}, buildSelect.value, "Assign to"));
+  clearSelected.addEventListener("click", () => assign(
+    {device_ids: [...selectedDeviceIds]}, null, "Clear assignment for",
+  ));
+  document.addEventListener("openscale-build-status", renderControls);
 
   setMode(Boolean(fleetKey));
-  if (fleetKey) loadScales();
+  if (fleetKey) loadFleet();
 }

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -3,10 +3,27 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="light">
-  <meta name="theme-color" content="#0d6b4f">
+  <meta name="color-scheme" content="light dark">
+  <meta id="theme-color" name="theme-color" content="#0d6b4f">
   <title>HDS Custom Build</title>
-  <link rel="stylesheet" href="styles.css?v=14">
+  <script id="theme-bootstrap">
+    (() => {
+      let preference = "system";
+      try {
+        const stored = JSON.parse(localStorage.getItem("hds-custom-build-theme-v1"));
+        if (stored?.version === 1 && ["system", "light", "dark"].includes(stored.preference)) {
+          preference = stored.preference;
+        }
+      } catch {
+      }
+      const dark = preference === "dark" ||
+        (preference === "system" && matchMedia("(prefers-color-scheme: dark)").matches);
+      document.documentElement.dataset.themePreference = preference;
+      document.documentElement.dataset.theme = dark ? "dark" : "light";
+      document.querySelector("#theme-color").content = dark ? "#111413" : "#0d6b4f";
+    })();
+  </script>
+  <link rel="stylesheet" href="styles.css?v=15">
   <link rel="stylesheet" href="fleet.css?v=3">
 </head>
 <body>
@@ -16,16 +33,38 @@
         <span class="brand-mark" aria-hidden="true"></span>
         <h1 class="brand-name">HDS custom build</h1>
       </div>
-      <nav class="topbar-links" aria-label="Related tools">
-        <a id="hds-updater-link" class="workflow-link" href="https://decentespresso.github.io/hds-updater/" target="_blank" rel="noreferrer" aria-label="Open HDS Updater">
-          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M10 14 21 3M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
-          <span>HDS Updater</span>
-        </a>
-        <a class="workflow-link" href="https://github.com/decentespresso/openscale/actions/workflows/custom-build.yml" target="_blank" rel="noreferrer" aria-label="Open source repository">
-          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M10 14 21 3M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
-          <span>Source repository</span>
-        </a>
-      </nav>
+      <div class="topbar-actions">
+        <nav class="topbar-links" aria-label="Related tools">
+          <a id="hds-updater-link" class="workflow-link" href="https://decentespresso.github.io/hds-updater/" target="_blank" rel="noreferrer" aria-label="Open HDS Updater">
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M10 14 21 3M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
+            <span>HDS Updater</span>
+          </a>
+          <a class="workflow-link" href="https://github.com/decentespresso/openscale/actions/workflows/custom-build.yml" target="_blank" rel="noreferrer" aria-label="Open source repository">
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M10 14 21 3M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
+            <span>Source repository</span>
+          </a>
+        </nav>
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false" title="Toggle color theme">
+          <svg aria-hidden="true" viewBox="0 0 68 32">
+            <rect class="theme-toggle-track" x="1" y="1" width="66" height="30" rx="15"/>
+            <g class="theme-toggle-stars">
+              <circle cx="10" cy="9" r="1.2"/>
+              <circle cx="24" cy="7" r="1"/>
+              <circle cx="29" cy="21" r="1.3"/>
+              <path d="M17 18h4M19 16v4"/>
+            </g>
+            <path class="theme-toggle-cloud" d="M43 21h14.5a3.5 3.5 0 0 0 .3-7 6 6 0 0 0-11.5-1.3A4.2 4.2 0 0 0 43 21Z"/>
+            <g class="theme-toggle-knob">
+              <circle class="theme-toggle-thumb" cx="16" cy="16" r="12"/>
+              <g class="theme-toggle-sun">
+                <circle cx="16" cy="16" r="4.5"/>
+                <path d="M16 7.5v2M16 22.5v2M7.5 16h2M22.5 16h2M10 10l1.4 1.4M20.6 20.6 22 22M10 22l1.4-1.4M20.6 11.4 22 10"/>
+              </g>
+              <path class="theme-toggle-moon" d="M20.8 19.8A7 7 0 0 1 12.2 11a6.3 6.3 0 1 0 8.6 8.8Z"/>
+            </g>
+          </svg>
+        </button>
+      </div>
     </div>
   </header>
 
@@ -261,6 +300,6 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=20"></script>
+  <script type="module" src="app.js?v=21"></script>
 </body>
 </html>

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -7,6 +7,7 @@
   <meta name="theme-color" content="#0d6b4f">
   <title>HDS Custom Build</title>
   <link rel="stylesheet" href="styles.css?v=14">
+  <link rel="stylesheet" href="fleet.css?v=3">
 </head>
 <body>
   <header class="topbar">
@@ -174,7 +175,6 @@
       </div>
 
       <div id="fleet-console" hidden>
-
         <form id="pair-scale" class="pair-scale-form">
           <label class="field-label" for="pair-code">Pairing code</label>
           <div class="inline-form">
@@ -183,8 +183,53 @@
           </div>
         </form>
 
-        <p id="fleet-status" class="fleet-status" role="status" aria-live="polite"></p>
-        <ul id="fleet-scales" class="scale-list"></ul>
+        <section class="fleet-section" aria-labelledby="fleet-builds-heading">
+          <div class="fleet-section-head">
+            <div>
+              <h4 id="fleet-builds-heading">Fleet builds</h4>
+              <p id="fleet-build-status" class="fleet-status" role="status" aria-live="polite"></p>
+            </div>
+            <button id="add-fleet-build" class="primary-button" type="button" disabled>Add current build</button>
+          </div>
+          <div class="fleet-build-labels" aria-hidden="true">
+            <span>Label</span><span>Firmware and options</span><span>Combination</span><span>Availability</span><span></span>
+          </div>
+          <ul id="fleet-builds" class="fleet-build-list"></ul>
+        </section>
+
+        <section class="fleet-section fleet-scales-section" aria-labelledby="fleet-scales-heading">
+          <div class="fleet-section-head">
+            <div>
+              <h4 id="fleet-scales-heading">Scales</h4>
+              <p id="fleet-status" class="fleet-status" role="status" aria-live="polite"></p>
+            </div>
+          </div>
+          <div class="deployment-toolbar">
+            <label for="fleet-build-select">Build</label>
+            <div class="select-wrap"><select id="fleet-build-select" disabled></select></div>
+            <label class="select-all-control"><input id="select-all-scales" type="checkbox"> All scales</label>
+            <span id="selected-scale-count" class="selection-count">0 selected</span>
+            <button id="assign-selected" class="primary-button" type="button" disabled>Assign to selected</button>
+            <button id="assign-all" class="ghost-bordered-button" type="button" disabled>Assign to all</button>
+            <button id="clear-selected" class="ghost-button" type="button" disabled>Clear assignment</button>
+          </div>
+          <div class="fleet-table-wrap">
+            <table class="fleet-table">
+              <thead>
+                <tr>
+                  <th><span class="sr-only">Select</span></th>
+                  <th>Scale</th>
+                  <th>Installed</th>
+                  <th>Desired</th>
+                  <th>Deployment</th>
+                  <th>Last seen</th>
+                  <th><span class="sr-only">Actions</span></th>
+                </tr>
+              </thead>
+              <tbody id="fleet-scale-rows"></tbody>
+            </table>
+          </div>
+        </section>
       </div>
     </section>
   </main>
@@ -205,6 +250,17 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=18"></script>
+  <dialog id="fleet-confirm-dialog" class="confirm-dialog" aria-labelledby="fleet-confirm-heading" aria-describedby="fleet-confirm-description">
+    <form method="dialog">
+      <h3 id="fleet-confirm-heading">Confirm fleet change</h3>
+      <p id="fleet-confirm-description"></p>
+      <div class="dialog-actions">
+        <button class="ghost-bordered-button" type="submit" value="cancel" autofocus>Cancel</button>
+        <button id="fleet-confirm-action" class="danger-button" type="submit" value="confirm">Confirm</button>
+      </div>
+    </form>
+  </dialog>
+
+  <script type="module" src="app.js?v=20"></script>
 </body>
 </html>

--- a/docs/custom-build/operations.md
+++ b/docs/custom-build/operations.md
@@ -26,6 +26,74 @@ The browser keeps the fleet recovery key only in tab-scoped session storage. It 
 persistent copy when the configurator next opens. Move the configurator to a dedicated origin before
 making recovery keys persistent again.
 
+## Fleet Data Model
+
+The Durable Object stores fleet records under the SHA-256 hash of the recovery key. A fleet record
+contains device IDs and immutable build references. Each build reference contains the full
+`combination_hash`, a user-editable label, firmware version, feature and plugin identifiers, and the
+time it was added. The binaries remain in R2 under `v1/<combination-hash>/`; adding or removing a
+fleet reference never copies or deletes those objects.
+
+Device records distinguish these fields:
+
+- `desired_combination` is the full custom build hash fleet management wants the scale to install.
+- `installed_combination` is the full custom build hash reported by the authenticated scale.
+- `firmware_version` is the version reported by the authenticated scale.
+- `last_seen_at` is updated only by an authenticated device check-in.
+- `desired_updated_at` records the most recent assignment change for deployment status.
+
+Assignment does not imply installation. The scale's compile-time
+`HDS_CUSTOM_BUILD_COMBINATION_HASH` is authoritative for the firmware currently executing. Custom
+firmware reports that value; official firmware reports `installed_combination: null`. Existing
+records without the newer fields remain valid and appear as unknown until they check in.
+
+Full 64-character lowercase hashes are used for API identity, storage, assignment, and verification.
+The 12-character browser prefix and 8-character OLED prefix are uppercase display aids only.
+
+## Fleet API
+
+All fleet routes require the fleet recovery key. All device routes require the device ID and device
+secret established during physical pairing.
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/device/check-in` | Report installed hash and firmware version, then receive the current assignment. |
+| `GET` | `/api/v1/fleet/overview` | Return scales, saved builds, and one canonical state per unique combination hash. |
+| `GET` | `/api/v1/fleet/builds` | List saved build references. |
+| `POST` | `/api/v1/fleet/builds` | Add one ready custom build by full combination hash. |
+| `PATCH` | `/api/v1/fleet/builds/<hash>` | Rename a saved build reference. |
+| `DELETE` | `/api/v1/fleet/builds/<hash>` | Remove an unassigned build reference. |
+| `POST` | `/api/v1/fleet/assignments` | Assign or clear a build for selected scales or every scale. |
+
+The check-in body is bounded to the two fields below. Its response stays limited to linking,
+assignment, and canonical build state; it does not include fleet lists, descriptions, or asset URLs.
+
+```json
+{
+  "installed_combination": null,
+  "firmware_version": "3.1.14"
+}
+```
+
+Selected bulk assignment uses `device_ids`; all-scale assignment uses `"all": true`. A null
+`combination_hash` deliberately clears the assignment. Target IDs are deduplicated, every target is
+validated before the transaction writes, and cross-fleet or missing targets fail the whole request.
+
+Removing a saved build that is still desired by any scale returns `409 build_assigned`. Clear or
+replace those assignments first. Removal leaves R2 artifacts and every scale's
+`installed_combination` untouched.
+
+## Scale Resource Contract
+
+The scale performs one check-in only when the Custom Build menu is opened. It retains one desired
+hash and the compile-time installed hash only for the lifetime of that operation. It does not fetch
+the build library, cache fleet data, keep deployment history, add a polling loop, or add NVS fields.
+
+After validating the full desired hash, firmware compares it with the normalized compile-time hash.
+An exact match returns before manifest, signature, firmware, LittleFS, OTA-state, or reboot work. The
+OLED shows `Already installed` and the 8-character hash prefix. The OTA task stack remains 24,576
+bytes.
+
 ## Deployment Order
 
 1. Create two custom OTA RSA key pairs, commit both public keys, save the Key 1 private key as the

--- a/docs/custom-build/styles.css
+++ b/docs/custom-build/styles.css
@@ -1,4 +1,5 @@
 :root {
+      color-scheme: light;
       --ink: #17211d;
       --muted: #66716c;
       --faint: #8b9690;
@@ -9,13 +10,28 @@
       --canvas: #f2f6f3;
       --green: #0d7955;
       --green-dark: #085f43;
+      --green-hover: #085f43;
+      --green-text-strong: #085f43;
       --green-soft: #e9f6f0;
+      --green-soft-strong: #e3f4ec;
       --green-line: #b9ddcd;
       --amber: #8b5b16;
       --amber-soft: #fff7e5;
+      --amber-line: #ecd5a7;
       --danger: #a43c3c;
+      --danger-hover: #8f3030;
       --danger-soft: #fff0f0;
+      --info: #235f87;
+      --info-soft: #edf7fd;
+      --info-line: #b8d7ed;
       --code: #101c17;
+      --focus-green: rgba(13, 121, 85, .18);
+      --focus-danger: rgba(164, 60, 60, .2);
+      --toggle-sky: #d7edf5;
+      --toggle-line: #a9cfdf;
+      --toggle-scene: #ffffff;
+      --toggle-sun: #d7942f;
+      --toggle-moon: #9ccbea;
       --shadow-sm: 0 1px 2px rgba(20, 45, 33, .04), 0 5px 16px rgba(20, 45, 33, .035);
       --shadow-lg: 0 20px 60px rgba(29, 57, 43, .09);
       --radius: 8px;
@@ -116,12 +132,58 @@
 
     .workflow-link:hover { color: var(--green); }
     .workflow-link svg { width: 18px; height: 18px; }
-    .topbar-links { display: flex; align-items: center; gap: 22px; }
-    .workflow-link.is-next-step { animation: next-step 1s ease-in-out 5; }
+    .topbar-actions, .topbar-links { display: flex; align-items: center; gap: 22px; }
 
-    @keyframes next-step {
-      50% { color: white; background: var(--green); box-shadow: 0 0 0 7px var(--green-soft); }
+    #hds-updater-link { position: relative; }
+
+    #hds-updater-link::after {
+      content: "";
+      position: absolute;
+      top: -5px;
+      right: -9px;
+      width: 7px;
+      height: 7px;
+      border: 2px solid var(--surface);
+      border-radius: 999px;
+      background: #1a9c6f;
+      opacity: 0;
+      transform: scale(.6);
+      transition: opacity .2s ease, transform .2s cubic-bezier(.22, 1, .36, 1);
     }
+
+    #hds-updater-link.is-ready { color: var(--green-text-strong); }
+    #hds-updater-link.is-ready::after { opacity: 1; transform: scale(1); }
+
+    .theme-toggle {
+      display: block;
+      width: 68px;
+      height: 32px;
+      padding: 0;
+      border: 0;
+      border-radius: 16px;
+      outline: 0;
+      background: transparent;
+      cursor: pointer;
+    }
+
+    .theme-toggle:hover .theme-toggle-track { stroke: var(--green); }
+    .theme-toggle:active svg { transform: scale(.97); }
+    .theme-toggle:focus-visible { box-shadow: 0 0 0 3px var(--focus-green); }
+    .theme-toggle svg { display: block; width: 68px; height: 32px; overflow: visible; transition: transform .12s ease; }
+    .theme-toggle-track { fill: var(--toggle-sky); stroke: var(--toggle-line); stroke-width: 1.5px; transition: stroke .16s ease; }
+    .theme-toggle-stars { fill: var(--toggle-moon); stroke: var(--toggle-moon); stroke-width: 1px; opacity: 0; transition: opacity .2s ease; }
+    .theme-toggle-cloud { fill: var(--toggle-scene); opacity: .82; transition: opacity .2s ease; }
+    .theme-toggle-knob { transition: transform .24s cubic-bezier(.22, 1, .36, 1); }
+    .theme-toggle-thumb { fill: var(--toggle-scene); }
+    .theme-toggle-sun { fill: var(--toggle-sun); stroke: var(--toggle-sun); stroke-width: 1.5px; transition: opacity .16s ease; }
+    .theme-toggle-sun path { fill: none; }
+    .theme-toggle-moon { fill: var(--toggle-moon); opacity: 0; transition: opacity .16s ease; }
+
+    html[data-theme="dark"] .theme-toggle-stars { opacity: 1; }
+    html[data-theme="dark"] .theme-toggle-cloud,
+    html[data-theme="dark"] .theme-toggle-sun { opacity: 0; }
+    html[data-theme="dark"] .theme-toggle-knob { transform: translateX(36px); }
+    html[data-theme="dark"] .theme-toggle-moon { opacity: 1; }
 
     .page {
       width: min(1180px, calc(100% - 40px));
@@ -999,7 +1061,7 @@
       .brand-mark::after { inset: 10px; }
       .workflow-link span { display: none; }
       .workflow-link { width: 36px; height: 36px; justify-content: center; border-radius: 9px; background: var(--green-soft); }
-      .topbar-links { gap: 8px; }
+      .topbar-actions, .topbar-links { gap: 8px; }
       .page { padding: 29px 0 42px; }
       .intro { margin-bottom: 22px; }
       .intro h2 { font-size: 1.8rem; }
@@ -1026,5 +1088,263 @@
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; }
       .state-checking::after, .state-queued::after, .state-building::after, .state-updating::after { animation: none; }
-      .workflow-link.is-next-step { animation: none; color: white; background: var(--green); box-shadow: 0 0 0 4px var(--green-soft); }
+    }
+
+    html[data-theme="dark"] {
+      color-scheme: dark;
+      scrollbar-color: #3a4640 #111413;
+      --ink: #eef2ef;
+      --muted: #a7b0aa;
+      --faint: #7f8b84;
+      --line: #2b332f;
+      --line-strong: #3a4640;
+      --surface: #171b19;
+      --surface-soft: #1d2320;
+      --canvas: #111413;
+      --green: #1b7f5e;
+      --green-dark: #83d6b4;
+      --green-hover: #126247;
+      --green-text-strong: #a4e6ca;
+      --green-soft: #142820;
+      --green-soft-strong: #183329;
+      --green-line: #315846;
+      --amber: #dfaa59;
+      --amber-soft: #2c2417;
+      --amber-line: #67502c;
+      --danger: #e47b7b;
+      --danger-hover: #bd5f5f;
+      --danger-soft: #2d1919;
+      --info: #9ccbea;
+      --info-soft: #142431;
+      --info-line: #315773;
+      --code: #dce8e0;
+      --focus-green: rgba(27, 127, 94, .3);
+      --focus-danger: rgba(228, 123, 123, .24);
+      --toggle-sky: #1d2d29;
+      --toggle-line: #3a4640;
+      --toggle-scene: #eef2ef;
+      --toggle-sun: #dfaa59;
+      --toggle-moon: #9ccbea;
+      --shadow-sm: 0 1px 2px rgba(0, 0, 0, .32), 0 3px 8px rgba(0, 0, 0, .16);
+      --shadow-lg: 0 24px 70px rgba(0, 0, 0, .45);
+    }
+
+    html[data-theme="dark"] ::selection {
+      color: #ffffff;
+      background: var(--green);
+    }
+
+    html[data-theme="dark"] input,
+    html[data-theme="dark"] select,
+    html[data-theme="dark"] button,
+    html[data-theme="dark"] textarea { color-scheme: dark; }
+
+    html[data-theme="dark"] input::placeholder,
+    html[data-theme="dark"] textarea::placeholder {
+      color: var(--faint);
+      opacity: 1;
+    }
+
+    html[data-theme="dark"] select option {
+      color: var(--ink);
+      background: var(--surface);
+    }
+
+    html[data-theme="dark"] .topbar {
+      border-bottom-color: rgba(58, 70, 64, .88);
+      background: rgba(23, 27, 25, .9);
+      box-shadow: 0 1px 0 rgba(0, 0, 0, .2);
+    }
+
+    html[data-theme="dark"] .brand-mark::before { background: var(--surface); }
+    html[data-theme="dark"] .workflow-link:hover { color: var(--green-text-strong); }
+
+    html[data-theme="dark"] .panel {
+      border-color: var(--line);
+      background: rgba(23, 27, 25, .96);
+      box-shadow: var(--shadow-sm);
+    }
+
+    html[data-theme="dark"] .eyebrow::before,
+    html[data-theme="dark"] .ready::before,
+    html[data-theme="dark"] #hds-updater-link::after {
+      background: #35ad7d;
+      box-shadow: 0 0 0 4px var(--green-soft);
+    }
+
+    html[data-theme="dark"] select:hover,
+    html[data-theme="dark"] .inline-form input:hover,
+    html[data-theme="dark"] .scale-name:hover { border-color: #53625a; }
+
+    html[data-theme="dark"] select:focus-visible,
+    html[data-theme="dark"] .inline-form input:focus,
+    html[data-theme="dark"] .recovery-key input:focus,
+    html[data-theme="dark"] .scale-name:focus,
+    html[data-theme="dark"] .build-label:focus {
+      border-color: var(--green);
+      box-shadow: 0 0 0 3px var(--focus-green);
+    }
+
+    html[data-theme="dark"] .option-card:hover {
+      border-color: #46524c;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, .22);
+    }
+
+    html[data-theme="dark"] .option-card.is-checked {
+      border-color: var(--green-line);
+      background: #15231d;
+    }
+
+    html[data-theme="dark"] .option-card.is-required {
+      border-color: #2c4c3d;
+      background: #18231e;
+    }
+
+    html[data-theme="dark"] .option-card.is-disabled {
+      border-color: var(--line);
+      background: var(--surface-soft);
+    }
+
+    html[data-theme="dark"] .check-box {
+      border-color: #65736c;
+      color: #ffffff;
+      background: #111513;
+    }
+
+    html[data-theme="dark"] .native-check:checked + .check-target .check-box {
+      border-color: var(--green);
+      color: #ffffff;
+      background: var(--green);
+      box-shadow: 0 2px 8px rgba(27, 127, 94, .3);
+    }
+
+    html[data-theme="dark"] .native-check:focus-visible + .check-target .check-box {
+      outline-color: var(--focus-green);
+    }
+
+    html[data-theme="dark"] .option-card.is-unavailable .status-badge {
+      border-color: var(--amber-line);
+      color: var(--amber);
+      background: var(--amber-soft);
+    }
+
+    html[data-theme="dark"] .recommend-button:hover,
+    html[data-theme="dark"] .recommend-button:focus-visible {
+      border-color: var(--green);
+      color: var(--green-text-strong);
+      background: var(--green-soft-strong);
+    }
+
+    html[data-theme="dark"] .recommend-button:focus-visible,
+    html[data-theme="dark"] .hash-button:focus-visible { box-shadow: 0 0 0 3px var(--focus-green); }
+    html[data-theme="dark"] .info-button { color: #8a9690; }
+
+    html[data-theme="dark"] .tooltip {
+      border-color: #3a4640;
+      color: #eef4f0;
+      background: #101412;
+      box-shadow: 0 8px 12px rgba(0, 0, 0, .48);
+    }
+
+    html[data-theme="dark"] .state-checking::before,
+    html[data-theme="dark"] .state-queued::before,
+    html[data-theme="dark"] .state-building::before,
+    html[data-theme="dark"] .state-updating::before,
+    html[data-theme="dark"] .state-rate-limited::before {
+      background: #d39b45;
+      box-shadow: 0 0 0 4px var(--amber-soft);
+    }
+
+    html[data-theme="dark"] .state-checking::after,
+    html[data-theme="dark"] .state-queued::after,
+    html[data-theme="dark"] .state-building::after,
+    html[data-theme="dark"] .state-updating::after { border-color: #d39b45; }
+
+    html[data-theme="dark"] .resolved-chip { color: #b5c0ba; }
+
+    html[data-theme="dark"] .pull-ota-warning {
+      border-color: var(--info-line);
+      color: var(--info);
+      background: var(--info-soft);
+    }
+
+    html[data-theme="dark"] .downloads a:hover,
+    html[data-theme="dark"] .downloads a:focus-visible {
+      color: var(--green-text-strong);
+      background: var(--green-soft);
+    }
+
+    html[data-theme="dark"] .primary-button {
+      border-color: var(--green);
+      color: #ffffff;
+      background: var(--green);
+      box-shadow: 0 5px 8px rgba(27, 127, 94, .24);
+    }
+
+    html[data-theme="dark"] .primary-button:hover {
+      border-color: var(--green-hover);
+      color: #ffffff;
+      background: var(--green-hover);
+      box-shadow: 0 5px 8px rgba(0, 0, 0, .22);
+    }
+
+    html[data-theme="dark"] .primary-button:focus-visible,
+    html[data-theme="dark"] .ghost-button:focus-visible,
+    html[data-theme="dark"] .ghost-bordered-button:focus-visible,
+    html[data-theme="dark"] .icon-button:focus-visible,
+    html[data-theme="dark"] .install-option:has(input:focus-visible) { outline-color: var(--focus-green); }
+
+    html[data-theme="dark"] .primary-button:disabled {
+      border-color: var(--line-strong);
+      color: var(--faint);
+      background: var(--surface-soft);
+      box-shadow: none;
+    }
+
+    html[data-theme="dark"] .helper-card {
+      border-color: #39443e;
+      color: var(--muted);
+      background: rgba(29, 35, 32, .78);
+    }
+
+    html[data-theme="dark"] .ghost-bordered-button:hover,
+    html[data-theme="dark"] .icon-button:hover {
+      border-color: var(--green-line);
+      color: var(--green-text-strong);
+      background: var(--green-soft);
+    }
+
+    html[data-theme="dark"] .toast {
+      border-color: #3b4942;
+      color: #eef2ef;
+      background: #121714;
+      box-shadow: 0 8px 12px rgba(0, 0, 0, .45);
+    }
+
+    html[data-theme="dark"] .confirm-dialog {
+      color: var(--ink);
+      background: var(--surface);
+    }
+
+    html[data-theme="dark"] .confirm-dialog::backdrop {
+      background: rgba(0, 0, 0, .66);
+      backdrop-filter: blur(2px);
+    }
+
+    html[data-theme="dark"] .danger-button {
+      border-color: var(--danger);
+      color: #ffffff;
+      background: #b95d5d;
+    }
+
+    html[data-theme="dark"] .danger-button:hover {
+      border-color: var(--danger-hover);
+      background: var(--danger-hover);
+    }
+
+    html[data-theme="dark"] .danger-button:focus-visible { outline-color: var(--focus-danger); }
+
+    @media (hover: hover) {
+      html[data-theme="dark"] .panel { transition: border-color .18s ease, box-shadow .18s ease; }
+      html[data-theme="dark"] .panel:hover { border-color: #333d38; }
     }

--- a/include/custom_build_ota.h
+++ b/include/custom_build_ota.h
@@ -35,7 +35,6 @@ struct CustomBuildAssignment {
   bool linked = false;
   String state = "";
   String combinationHash = "";
-  String name = "";
 };
 
 void customBuildRandomHex(char *output, size_t byteCount) {
@@ -56,6 +55,19 @@ bool customBuildHexValueValid(const String &value, size_t length) {
           (character >= 'a' && character <= 'f'))) return false;
   }
   return true;
+}
+
+void customBuildHashPrefix(const String &hash, char output[9]) {
+  if (!customBuildHexValueValid(hash, 64)) {
+    output[0] = '\0';
+    return;
+  }
+  for (size_t index = 0; index < 8; index++) {
+    const char character = hash.charAt(index);
+    output[index] = character >= 'a' && character <= 'f'
+        ? character - 'a' + 'A' : character;
+  }
+  output[8] = '\0';
 }
 
 bool customBuildLoadCredentials(String &deviceId, String &deviceSecret) {
@@ -128,19 +140,25 @@ bool customBuildRequest(
   return read;
 }
 
-bool customBuildReadAssignment(CustomBuildAssignment &assignment) {
+bool customBuildCheckIn(
+    const String &installedCombination,
+    CustomBuildAssignment &assignment) {
+  JsonDocument request;
+  request["installed_combination"] = installedCombination.length() > 0
+      ? installedCombination.c_str() : nullptr;
+  request["firmware_version"] = pullOtaCurrentVersion();
+  String requestBody;
+  serializeJson(request, requestBody);
   String body;
-  if (!customBuildRequest("/api/v1/device/assignment", "GET", "", body)) return false;
+  if (!customBuildRequest("/api/v1/device/check-in", "POST", requestBody, body)) return false;
   JsonDocument document;
   if (deserializeJson(document, body)) return false;
   JsonObject root = document.as<JsonObject>();
   const char *state = root["state"] | "";
   const char *combinationHash = root["desired_combination"] | "";
-  const char *name = root["name"] | "";
   assignment.linked = root["linked"] | false;
   assignment.state = state;
   assignment.combinationHash = combinationHash;
-  assignment.name = name;
   if (assignment.combinationHash.length() > 0 &&
       !customBuildHexValueValid(assignment.combinationHash, 64)) return false;
   return true;
@@ -287,9 +305,14 @@ bool customBuildShowRelink(const char *line1, const char *line2) {
   return customBuildPairScale(false);
 }
 
-bool customBuildConfirmInstall(const PullOtaManifest &manifest, bool &relink) {
+bool customBuildConfirmInstall(
+    const PullOtaManifest &manifest,
+    const String &combinationHash,
+    bool &relink) {
+  char hashPrefix[9];
+  customBuildHashPrefix(combinationHash, hashPrefix);
   pullOtaWaitForRelease(1000);
-  pullOtaDraw("Custom Build", manifest.version.c_str(), "Sq install O relink");
+  pullOtaDraw(manifest.version.c_str(), hashPrefix, "Sq install O relink");
   const unsigned long startedAt = millis();
   unsigned long squareHeldSince = 0;
   unsigned long circleHeldSince = 0;
@@ -320,8 +343,9 @@ void customBuildRun() {
     pullOtaFail("Network failed");
     return;
   }
+  const String installedCombination = pullOtaCurrentCombinationHash();
   CustomBuildAssignment assignment;
-  if (!customBuildReadAssignment(assignment)) {
+  if (!customBuildCheckIn(installedCombination, assignment)) {
     pullOtaFail("Service failed");
     return;
   }
@@ -333,8 +357,10 @@ void customBuildRun() {
     customBuildShowRelink("Custom Build", "No build assigned");
     return;
   }
-  if (assignment.combinationHash == HDS_CUSTOM_BUILD_COMBINATION_HASH) {
-    customBuildShowRelink("Installed", pullOtaCurrentVersion().c_str());
+  if (assignment.combinationHash == installedCombination) {
+    char hashPrefix[9];
+    customBuildHashPrefix(installedCombination, hashPrefix);
+    customBuildShowRelink("Already installed", hashPrefix);
     return;
   }
   if (assignment.state == "queued" || assignment.state == "building") {
@@ -352,11 +378,11 @@ void customBuildRun() {
     return;
   }
   bool relink = false;
-  if (!customBuildConfirmInstall(manifest, relink)) {
+  if (!customBuildConfirmInstall(manifest, assignment.combinationHash, relink)) {
     if (relink) customBuildPairScale(false);
     return;
   }
-  const String rollbackCombinationHash = pullOtaCurrentCombinationHash();
+  const String rollbackCombinationHash = installedCombination;
   const bool rollbackFound = rollbackCombinationHash.length() > 0
       ? customBuildFetchManifest(rollbackCombinationHash, rollbackManifest)
       : pullOtaFetchCurrentReleaseManifest(rollbackManifest);

--- a/tools/test_custom_build_ota_contract.py
+++ b/tools/test_custom_build_ota_contract.py
@@ -10,6 +10,20 @@ def require(path, value):
     return text
 
 
+def function_body(text, signature):
+    start = text.index(signature)
+    opening = text.index("{", start)
+    depth = 0
+    for index in range(opening, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[opening + 1:index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
 def main():
     header = require("include/custom_build_ota.h", 'HDS_CUSTOM_BUILD_NVS_NAMESPACE[] = "ota_custom"')
     require("include/custom_build_ota.h", "customBuildRandomHex(newDeviceId, 16)")
@@ -20,6 +34,11 @@ def main():
     require("include/custom_build_ota.h", 'pullOtaDraw("Pair code", pairCode, "Valid 12 hours")')
     require("include/custom_build_ota.h", 'String(HDS_CUSTOM_BUILD_SERVICE_URL) + "/v1/" + combinationHash')
     require("include/custom_build_ota.h", "customBuildFetchManifest(rollbackCombinationHash, rollbackManifest)")
+    require("include/custom_build_ota.h", 'customBuildRequest("/api/v1/device/check-in", "POST"')
+    require("include/custom_build_ota.h", 'request["installed_combination"]')
+    require("include/custom_build_ota.h", 'request["firmware_version"]')
+    require("include/custom_build_ota.h", 'customBuildShowRelink("Already installed", hashPrefix)')
+    require("include/custom_build_ota.h", 'pullOtaDraw(manifest.version.c_str(), hashPrefix')
     require("include/custom_build_ota.h", "assignment.combinationHash,")
     require("include/custom_build_ota.h", "rollbackCombinationHash);")
     pull_ota = require("include/pull_ota.h", 'preferences.putString("combo", combinationHash) == 64')
@@ -28,6 +47,34 @@ def main():
     assert "loaded.rollbackVersion, loaded.rollbackCombinationHash" in pull_ota
     assert "loaded.asset.url, loaded.combinationHash" in pull_ota
     assert "loaded.rollbackAsset.url, loaded.rollbackCombinationHash" in pull_ota
+    assert '#define HDS_CUSTOM_BUILD_COMBINATION_HASH ""' in pull_ota
+    assert "HDS_OTA_TASK_STACK_BYTES = 24576" in pull_ota
+    current_hash = function_body(pull_ota, "String pullOtaCurrentCombinationHash()")
+    assert "HDS_CUSTOM_BUILD_COMBINATION_HASH" in current_hash
+    run = function_body(header, "void customBuildRun()")
+    installed = run.index("const String installedCombination = pullOtaCurrentCombinationHash()")
+    check_in = run.index("customBuildCheckIn(installedCombination, assignment)")
+    no_op = run.index("if (assignment.combinationHash == installedCombination)")
+    ready_state = run.index('if (assignment.state == "queued"')
+    manifest = run.index("customBuildFetchManifest(assignment.combinationHash, manifest)")
+    install = run.index("pullOtaInstall(")
+    assert installed < check_in < no_op < ready_state < manifest < install
+    no_op_body = run[no_op:ready_state]
+    assert "return;" in no_op_body
+    for forbidden in (
+        "customBuildFetchManifest",
+        "customBuildFetchManifestSignature",
+        "pullOtaStreamAsset",
+        "pullOtaStorePendingLittleFs",
+        "pullOtaInstall",
+        "remoteQueueResetAt",
+    ):
+        assert forbidden not in no_op_body
+    check_in_body = function_body(header, "bool customBuildCheckIn(")
+    assert check_in_body.index("deserializeJson") < check_in_body.index("customBuildHexValueValid")
+    assert "std::vector" not in header
+    assert "static const uint32_t HDS_OTA_TASK_STACK_BYTES" not in header
+    assert '"/api/v1/fleet/' not in header
     assert "fleet_secret" not in header
     require("include/menu.h", '"Custom Build", customBuildMenu')
     require("src/hds.ino", '#include "custom_build_ota.h"')

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,8 +254,8 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=20"' in indexPage
-    assert 'href="styles.css?v=14"' in indexPage
+    assert 'type="module" src="app.js?v=21"' in indexPage
+    assert 'href="styles.css?v=15"' in indexPage
     assert 'href="fleet.css?v=3"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,8 +254,9 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=18"' in indexPage
+    assert 'type="module" src="app.js?v=20"' in indexPage
     assert 'href="styles.css?v=14"' in indexPage
+    assert 'href="fleet.css?v=3"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage
     assert 'fetch("catalog.json"' in appScript
@@ -269,7 +270,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=5' in appScript
+    assert 'fleet.js?v=6' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" in fleetScript
     assert "localStorage.setItem(storageKey" not in fleetScript


### PR DESCRIPTION
Follow-up to #172.

## Summary

- Add a server-side fleet build library of immutable ready-build references without copying or deleting R2 artifacts.
- Separate desired deployment state from authenticated, device-reported installed state.
- Add atomic selected/all-scale assignment and deliberate clearing, with ownership and target validation.
- Replace per-scale browser status requests with one aggregated fleet overview and one state resolution per unique hash.
- Make the compile-time custom combination hash authoritative on-device and return locally before any redundant OTA retrieval.

## API and data model

New authenticated routes:

- `POST /api/v1/device/check-in`
- `GET /api/v1/fleet/overview`
- `GET|POST /api/v1/fleet/builds`
- `PATCH|DELETE /api/v1/fleet/builds/<combination-hash>`
- `POST /api/v1/fleet/assignments`

Fleet records now retain build references with label, firmware/options summary, and added timestamp. Device records lazily gain `desired_updated_at`, `installed_combination`, `firmware_version`, and `last_seen_at`. Existing records remain readable with missing fields treated as null. Bulk writes are chunked at the Durable Object 128-entry storage limit while remaining inside one transaction.

## Browser

The fleet view now provides saved builds, full-hash copy, installed and desired columns, deployment state, last-seen time, responsive scale selection, select-all, selected/all-scale assignment, deliberate clearing, and confirmations for multi-scale changes. Hashes remain full-length identities; the browser displays a 12-character uppercase prefix.

## Firmware

The Custom Build menu performs one compact authenticated check-in. Custom firmware reports normalized `HDS_CUSTOM_BUILD_COMBINATION_HASH`; official firmware reports null.

After validating the returned full desired hash, firmware compares it with that local compile-time identity. An exact match shows `Already installed` and the 8-character uppercase prefix, then returns before manifest, signature, firmware, LittleFS, OTA-state, or reboot paths. A differing hash continues through the existing signed-manifest flow. Install confirmation shows target version plus hash prefix.

## Scale resources

Controlled `esp32s3` size comparison against `45edef5`:

- Static RAM: 56,508 bytes before and after, delta 0 bytes.
- Flash: 1,669,429 bytes before; 1,668,065 bytes after, delta -1,364 bytes.
- OTA task stack: unchanged at 24,576 bytes.
- Heap: no persistent or fleet-proportional allocation. Check-in adds only operation-local strings and bounded request/response JSON; exact peak heap was not instrumented.

Fleet size and saved-build count therefore do not change scale-side storage or steady-state memory.

## Verification

- `node --test cloudflare/custom-build-worker/test/fleet.test.mjs` - 10 passed
- `node --test cloudflare/custom-build-worker/test/configurator.test.mjs` - 6 passed
- `node --test cloudflare/custom-build-worker/test/worker.test.mjs` - 2 passed
- `python tools/test_plugin_catalog.py`
- `python tools/test_plugin_ci_contract.py`
- `python tools/test_custom_build_ota_contract.py`
- `python tools/test_custom_build_execution.py`
- `python tools/test_custom_ota_public_key_header.py`
- `python tools/test_custom_cache_transport.py`
- `python tools/test_pull_ota_contract.py`
- `python tools/test_ota_runtime_isolation_contract.py`
- `python tools/test_ota_rollback_contract.py`
- `python tools/test_ota_reboot_routing_contract.py`
- `python tools/test_ota_input_isolation_contract.py`
- `python tools/test_ota_public_key_header.py` - 9 passed
- `python tools/test_ai_docs_contract.py`
- `pio run -e esp32s3`
- `pio run -e esp32s3-custom`
- Browser checks at desktop and 390 px mobile widths, with zero page overflow
- `git diff --check`
- GitHub Actions: 11 checks passed

The OTA contract regression asserts that equal full hashes return before manifest retrieval or installation and that the current identity originates from the compile-time macro.

## Intentionally omitted

- No background heartbeat or WiFi wake solely for telemetry.
- No on-scale build list, picker, deployment history, fleet collection, or new NVS field.
- No post-boot network check-in; the next intentional Custom Build menu check-in reports the running compile-time identity.