### PR TITLE
Fix main custom build validation during release prep

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -222,6 +222,12 @@ jobs:
           ref: ${{ inputs.builder_commit || github.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Create prospective release tag for main validation
+        if: inputs.firmware_ref == 'main'
+        run: |
+          if ! git show-ref --verify --quiet refs/tags/v3.1.14; then
+            git tag v3.1.14 "${{ github.sha }}"
+          fi
       - uses: actions/cache@v6
         with:
           path: |

--- a/tools/test_plugin_ci_contract.py
+++ b/tools/test_plugin_ci_contract.py
@@ -51,6 +51,8 @@ def main():
     assert "compile-matrix:" not in customWorkflow
     dispatchBuild = customWorkflow.split("\n  build:\n", 1)[1]
     assert dispatchBuild.lstrip().startswith("if: github.event_name == 'workflow_dispatch'")
+    assert "if: inputs.firmware_ref == 'main'" in dispatchBuild
+    assert 'git tag v3.1.14 "${{ github.sha }}"' in dispatchBuild
 
     assert "dependency-build:" not in otaWorkflow
     assert "pio run -e" not in otaWorkflow


### PR DESCRIPTION
## Summary
- create the prospective local `v3.1.14` tag for `main` workflow dispatches before catalog validation
- keep pre-release `v3.1.14` dispatches dependent on the real tag
- add a workflow contract regression

## Failure fixed
Run 33912115248 failed before compilation because `test_plugin_catalog.py` tried to read `platformio.ini` from the not-yet-created `v3.1.14` tag. Pull-request jobs already create the prospective tag; the dispatch job did not.

## Tests
- `python tools/test_plugin_ci_contract.py`
- `python tools/test_custom_build_execution.py`
- `python tools/test_plugin_catalog.py` in an isolated checkout with the prospective local tag
- `git diff --check`