### PR TITLE
Fix custom build navigation and simplify fleet controls

### DIFF
--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -4,11 +4,13 @@ import {test} from "node:test";
 import {runInNewContext} from "node:vm";
 
 import {
+  buildLabel,
   buildSummary,
   deploymentState,
   lastSeenLabel,
   shortHash,
 } from "../../../docs/custom-build/fleet-state.mjs";
+import {buildEstimate, buildTimeRange} from "../../../docs/custom-build/build-estimate.mjs";
 import {
   catalogRevisionChanged,
   defaultSelection,
@@ -156,7 +158,7 @@ test("formats fleet build identity and deployment state", () => {
   assert.equal(buildSummary({
     features: ["pull-ota", "wifi"],
     plugins: [{id: "grind-by-weight", version: "1.0.0"}, {id: "pressensor", version: "2.0.0"}],
-  }), "pull-ota, wifi, grind-by-weight 1.0.0 +1");
+  }), "pull-ota, wifi, grind-by-weight 1.0.0, pressensor 2.0.0");
   assert.equal(deploymentState({
     desired_combination: hash,
     installed_combination: hash,
@@ -203,6 +205,38 @@ test("fleet browser consumes the aggregated overview without per-scale status re
   assert.ok(source.includes('/api/v1/fleet/overview'));
   assert.ok(source.includes('/api/v1/fleet/assignments'));
   assert.equal(source.includes('/api/v1/status/'), false);
+});
+
+test("build labels hide generated hashes without replacing user labels", () => {
+  assert.equal(buildLabel({label: "Build 462465C2997F"}, 0), "Build 1");
+  assert.equal(buildLabel({label: "Kitchen scale"}, 1), "Kitchen scale");
+});
+
+test("build estimates follow selected features and handle timestamps and boundaries", () => {
+  const energy = {features: ["energy-menu"], plugins: ["default-web-apps"]};
+  assert.deepEqual(buildTimeRange(energy), [10, 12]);
+  assert.deepEqual(buildTimeRange({plugins: ["default-web-apps"]}), [6, 9]);
+  assert.deepEqual(buildTimeRange(), [5, 7]);
+  assert.match(buildEstimate({state: "queued"}, energy), /Once started.*10-12 minutes/);
+  const started = Date.parse("2026-09-05T12:00:00Z");
+  const result = {state: "building", updated_at: new Date(started).toISOString()};
+  assert.match(buildEstimate(result, energy, started - 60000), /^0 min elapsed/);
+  assert.match(buildEstimate(result, energy, started + 9.9 * 60000), /^9 min elapsed.*10-12/);
+  for (const minutes of [10, 12]) {
+    assert.match(buildEstimate(result, energy, started + minutes * 60000), /Expected to finish soon/);
+  }
+  assert.match(buildEstimate(result, energy, started + 13 * 60000), /Taking longer than usual/);
+  assert.equal(buildEstimate({...result, updated_at: "invalid"}, energy), "");
+  assert.equal(buildEstimate({state: "building"}, energy), "");
+  assert.equal(buildEstimate({state: "ready"}, energy), "");
+});
+
+test("fleet options expand without copy-hash controls", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  const html = await readFile(new URL("../../../docs/custom-build/index.html", import.meta.url), "utf8");
+  assert.ok(source.includes("<details><summary>Options</summary>"));
+  assert.equal(source.includes("copyHash"), false);
+  assert.equal(html.includes("copy-hash"), false);
 });
 
 

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -25,6 +25,13 @@ Opening the Custom Build menu performs one authenticated device check-in. Custom
 the normalized compile-time `HDS_CUSTOM_BUILD_COMBINATION_HASH`; official firmware reports null.
 The response contains only linking state, one desired combination, and its canonical build state.
 
+Fresh devices start pairing from Custom Build. Once a pair code has been registered
+(`ota_custom/pair_init`), Connections exposes a separate Relink entry. Relink requires
+an explicit held-button confirmation and uses the same paused OTA task as Custom Build.
+Custom Build status screens dismiss with Square and never start relinking. Circle
+cancels the installation prompt instead of relinking. Menu visibility reads the existing
+NVS marker on Connections entry or navigation, not on each display frame.
+
 Validate the full desired hash before comparing it with the local compile-time hash. An exact match
 must return before custom manifest or signature retrieval, asset download, pending LittleFS state,
 or reboot scheduling. The Worker copy of `installed_combination` is telemetry and must never drive

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,8 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=6";
+import {initFleet} from "./fleet.js?v=7";
+import {buildEstimate} from "./build-estimate.mjs?v=1";
 
 (async () => {
   const themeStorageKey = "hds-custom-build-theme-v1";
@@ -77,7 +78,6 @@ import {initFleet} from "./fleet.js?v=6";
   const featureById = new Map(catalog.features.map(item => [item.id, item]));
   const pluginById = new Map(catalog.plugins.map(item => [item.id, item]));
   const buildButton = document.querySelector("#request-build");
-  const hashButton = document.querySelector("#copy-hash");
   const fleetPanel = document.querySelector("#fleet-panel");
   let toastTimer;
   let statusTimer;
@@ -153,14 +153,6 @@ import {initFleet} from "./fleet.js?v=6";
     toastTimer = setTimeout(() => toast.classList.remove("is-visible"), 2200);
   };
 
-  const buildEstimate = result => {
-    if (result.state === "queued") return "Usually ready in about 5 minutes.";
-    if (result.state !== "building" || !result.updated_at) return "";
-    const elapsedMinutes = Math.max(0, (Date.now() - Date.parse(result.updated_at)) / 60000);
-    const remaining = Math.ceil(5 - elapsedMinutes);
-    return remaining > 0 ? `Usually ready in about ${remaining} minute${remaining === 1 ? "" : "s"}.` : "Finishing up.";
-  };
-
   const setStatus = (result, generation = selectionGeneration) => {
     if (generation !== selectionGeneration) return;
     const buildState = document.querySelector("#build-state");
@@ -172,7 +164,7 @@ import {initFleet} from "./fleet.js?v=6";
     };
     const messages = {
       missing: "This combination has not been built yet.",
-      queued: "The build is waiting for an available runner.",
+      queued: "",
       building: "The firmware and filesystem images are being built.",
       ready: "The build archive is ready to download.",
       failed: failureMessages[result.failure_code] || "The build did not complete.",
@@ -192,12 +184,10 @@ import {initFleet} from "./fleet.js?v=6";
     updaterLink.setAttribute(
       "aria-label", updaterReady ? "Open HDS Updater for this build" : "Open HDS Updater",
     );
-    document.querySelector("#combination-hash").textContent = combinationHash;
-    hashButton.hidden = !combinationHash;
     const retryMessage = result.state === "failed" ?
       (result.retryable ? " One retry is available." : " No retries remain.") : "";
     document.querySelector("#status-message").textContent =
-      [messages[result.state] || messages.unavailable, retryMessage, buildEstimate(result)].filter(Boolean).join(" ");
+      [messages[result.state] ?? messages.unavailable, retryMessage, buildEstimate(result, currentSelection)].filter(Boolean).join(" ");
     buildButton.disabled = result.state !== "missing" && !(result.state === "failed" && result.retryable);
     const downloads = document.querySelector("#downloads");
     downloads.replaceChildren();
@@ -476,15 +466,6 @@ import {initFleet} from "./fleet.js?v=6";
         setStatus({state: "unavailable"}, generation);
         showToast("Build request rejected");
       }
-    }
-  });
-  hashButton.addEventListener("click", async () => {
-    if (!currentCombinationHash) return;
-    try {
-      await navigator.clipboard.writeText(currentCombinationHash);
-      showToast("Combination hash copied");
-    } catch {
-      showToast("Combination hash could not be copied");
     }
   });
   document.querySelector("#reset").addEventListener("click", () => {

--- a/docs/custom-build/build-estimate.mjs
+++ b/docs/custom-build/build-estimate.mjs
@@ -1,0 +1,23 @@
+export const buildTimeRange = selection => {
+  if (selection?.features?.includes("energy-menu")) return [10, 12];
+  if (selection?.plugins?.length) return [6, 9];
+  return [5, 7];
+};
+
+export const buildEstimate = (result, selection, now = Date.now()) => {
+  const [minMinutes, maxMinutes] = buildTimeRange(selection);
+  if (result.state === "queued") {
+    return `Waiting for a build runner. Once started, this build usually takes ${minMinutes}-${maxMinutes} minutes.`;
+  }
+  if (result.state !== "building" || !result.updated_at) return "";
+  const startedAt = Date.parse(result.updated_at);
+  if (!Number.isFinite(startedAt)) return "";
+  const elapsedMinutes = Math.max(0, Math.floor((now - startedAt) / 60000));
+  if (elapsedMinutes < minMinutes) {
+    return `${elapsedMinutes} min elapsed. Typical build time: ${minMinutes}-${maxMinutes} min.`;
+  }
+  if (elapsedMinutes <= maxMinutes) {
+    return `${elapsedMinutes} min elapsed. Expected to finish soon.`;
+  }
+  return `${elapsedMinutes} min elapsed. Taking longer than usual, but the build is still running.`;
+};

--- a/docs/custom-build/fleet-state.mjs
+++ b/docs/custom-build/fleet-state.mjs
@@ -4,6 +4,9 @@ const offlineAfterMs = 7 * 24 * 60 * 60 * 1000;
 export const shortHash = (value, length = 12) =>
   hashPattern.test(value || "") ? value.slice(0, length).toUpperCase() : "";
 
+export const buildLabel = (build, index) => /^Build [0-9A-F]{12}$/i.test(build.label || "")
+  ? `Build ${index + 1}` : build.label;
+
 export function buildSummary(build) {
   const features = Array.isArray(build?.features) ? build.features : [];
   const plugins = Array.isArray(build?.plugins)
@@ -11,8 +14,7 @@ export function buildSummary(build) {
     : [];
   const entries = [...features, ...plugins];
   if (!entries.length) return "Base firmware";
-  const visible = entries.slice(0, 3).join(", ");
-  return entries.length > 3 ? `${visible} +${entries.length - 3}` : visible;
+  return entries.join(", ");
 }
 
 export function deploymentState(scale, buildStates, now = Date.now()) {

--- a/docs/custom-build/fleet.css
+++ b/docs/custom-build/fleet.css
@@ -26,7 +26,7 @@
 .fleet-build-labels,
 .fleet-build-row {
   display: grid;
-  grid-template-columns: minmax(150px, 1fr) minmax(190px, 1.35fr) 142px 92px auto;
+  grid-template-columns: minmax(150px, 1fr) minmax(190px, 1.35fr) 92px 150px;
   align-items: center;
   gap: 14px;
 }
@@ -92,27 +92,16 @@
   line-height: 1.35;
 }
 
-.fleet-hash {
-  min-width: 0;
-  padding: 7px 8px;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  color: var(--code);
-  background: var(--surface-soft);
+.fleet-build-version summary {
+  margin-top: 6px;
+  color: var(--green-dark);
+  font-size: .72rem;
   cursor: pointer;
-  text-overflow: ellipsis;
 }
 
-.fleet-hash code {
-  font: 650 .67rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-}
-
-.fleet-hash:hover,
-.fleet-hash:focus-visible {
-  border-color: var(--green-line);
-  background: var(--green-soft);
-  outline: 0;
+.fleet-build-version summary:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 3px;
 }
 
 .deployment-state {
@@ -281,7 +270,7 @@
 }
 
 .scale-build strong,
-.scale-build code {
+.scale-build span {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -293,10 +282,10 @@
   font-size: .72rem;
 }
 
-.scale-build code {
+.scale-build span {
   margin-top: 4px;
   color: var(--faint);
-  font: 650 .65rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .68rem;
 }
 
 .last-seen {
@@ -312,7 +301,6 @@
     grid-template-columns: minmax(150px, 1fr) minmax(180px, 1fr) auto;
   }
 
-  .fleet-hash,
   .deployment-state { grid-row: 2; }
 
   .fleet-row-actions { grid-column: 3; grid-row: 1 / span 2; }
@@ -341,7 +329,6 @@
 
   .fleet-build-name,
   .fleet-build-version { grid-column: 1 / -1; }
-  .fleet-hash,
   .deployment-state { grid-row: auto; }
   .fleet-row-actions { grid-column: 1 / -1; grid-row: auto; justify-content: stretch; }
   .fleet-row-actions button { flex: 1; }

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -1,4 +1,4 @@
-import {buildSummary, deploymentState, lastSeenLabel, shortHash} from "./fleet-state.mjs?v=1";
+import {buildLabel, buildSummary, deploymentState, lastSeenLabel} from "./fleet-state.mjs?v=2";
 
 const storageKey = "hds-custom-build-fleet-v2";
 const legacyStorageKey = "hds-custom-build-fleet-v1";
@@ -130,13 +130,9 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     confirmDialog.showModal();
   });
 
-  const copyHash = async hash => {
-    try {
-      await navigator.clipboard.writeText(hash);
-      showToast("Combination hash copied");
-    } catch {
-      showToast("Combination hash could not be copied");
-    }
+  const labelForBuild = hash => {
+    const index = builds.findIndex(build => build.combination_hash === hash);
+    return index < 0 ? "Custom build" : buildLabel(builds[index], index);
   };
 
   const showApiError = error => {
@@ -155,7 +151,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     const readyBuilds = builds.filter(build => build.state === "ready");
     const previousHash = buildSelect.value;
     buildSelect.replaceChildren(...readyBuilds.map(build =>
-      new Option(`${build.label} · ${shortHash(build.combination_hash)}`, build.combination_hash)));
+      new Option(labelForBuild(build.combination_hash), build.combination_hash)));
     if (readyBuilds.some(build => build.combination_hash === previousHash)) {
       buildSelect.value = previousHash;
     }
@@ -210,21 +206,18 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       row.className = "fleet-build-row";
       row.innerHTML = `
         <div class="fleet-build-name"><input class="build-label" maxlength="40" aria-label="Build label"></div>
-        <div class="fleet-build-version"><strong></strong><span></span></div>
-        <button class="fleet-hash" type="button" title="Copy full combination hash"><code></code></button>
+        <div class="fleet-build-version"><strong></strong><details><summary>Options</summary><span></span></details></div>
         <span class="deployment-state"></span>
         <div class="fleet-row-actions">
           <button class="ghost-bordered-button save-build" type="button">Save</button>
           <button class="ghost-button remove-build" type="button">Remove</button>
         </div>`;
-      row.querySelector(".build-label").value = build.label;
+      row.querySelector(".build-label").value = labelForBuild(build.combination_hash);
       row.querySelector(".fleet-build-version strong").textContent = build.firmware_version;
       row.querySelector(".fleet-build-version span").textContent = buildSummary(build);
-      row.querySelector("code").textContent = shortHash(build.combination_hash);
       const state = row.querySelector(".deployment-state");
       state.textContent = build.state === "ready" ? "Ready" : "Unavailable";
       state.dataset.state = build.state;
-      row.querySelector(".fleet-hash").addEventListener("click", () => copyHash(build.combination_hash));
       row.querySelector(".save-build").addEventListener("click", async () => {
         try {
           await api(`/api/v1/fleet/builds/${build.combination_hash}`, {
@@ -238,7 +231,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
         }
       });
       row.querySelector(".remove-build").addEventListener("click", async () => {
-        if (!(await confirm("Remove saved build?", `${build.label} will remain available to existing installations.`, "Remove"))) return;
+        if (!(await confirm("Remove saved build?", `${labelForBuild(build.combination_hash)} will remain available to existing installations.`, "Remove"))) return;
         try {
           await api(`/api/v1/fleet/builds/${build.combination_hash}`, {method: "DELETE"});
           showToast("Build removed from fleet");
@@ -258,8 +251,8 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       row.innerHTML = `
         <td class="scale-select"><input type="checkbox"></td>
         <td class="scale-identity"><input class="scale-name" maxlength="40"><span class="scale-hint"></span></td>
-        <td class="scale-build" data-label="Installed"><strong></strong><code></code></td>
-        <td class="scale-build desired-build" data-label="Desired"><strong></strong><code></code></td>
+        <td class="scale-build" data-label="Installed"><strong></strong><span></span></td>
+        <td class="scale-build desired-build" data-label="Desired"><strong></strong></td>
         <td data-label="Deployment"><span class="deployment-state"></span></td>
         <td class="last-seen" data-label="Last seen"></td>
         <td><button class="ghost-bordered-button save-scale" type="button">Save</button></td>`;
@@ -277,13 +270,11 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       row.querySelector(".scale-hint").textContent = scale.serial_hint;
       const installed = row.querySelector(".scale-build");
       installed.querySelector("strong").textContent = scale.firmware_version || "Unknown";
-      installed.querySelector("code").textContent = shortHash(scale.installed_combination) ||
-        (scale.last_seen_at ? "Official" : "Unknown");
+      installed.querySelector("span").textContent = scale.installed_combination
+        ? labelForBuild(scale.installed_combination) : (scale.last_seen_at ? "Official" : "Unknown");
       const desired = row.querySelector(".desired-build");
-      const desiredBuild = builds.find(build => build.combination_hash === scale.desired_combination);
-      desired.querySelector("strong").textContent = desiredBuild?.label ||
-        (scale.desired_combination ? "Custom build" : "None");
-      desired.querySelector("code").textContent = shortHash(scale.desired_combination);
+      desired.querySelector("strong").textContent = scale.desired_combination
+        ? labelForBuild(scale.desired_combination) : "None";
       const state = row.querySelector(".deployment-state");
       state.textContent = deploymentState(scale, buildStates);
       state.dataset.state = state.textContent.toLowerCase().replaceAll(" ", "-");

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -23,8 +23,8 @@
       document.querySelector("#theme-color").content = dark ? "#111413" : "#0d6b4f";
     })();
   </script>
-  <link rel="stylesheet" href="styles.css?v=15">
-  <link rel="stylesheet" href="fleet.css?v=3">
+  <link rel="stylesheet" href="styles.css?v=16">
+  <link rel="stylesheet" href="fleet.css?v=4">
 </head>
 <body>
   <header class="topbar">
@@ -153,10 +153,6 @@
           <div class="service-section">
             <div class="service-heading">
               <span>Build status</span>
-              <button id="copy-hash" class="hash-button" type="button" title="Copy combination hash" hidden>
-                <code id="combination-hash"></code>
-                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-              </button>
             </div>
             <p id="status-message" class="status-message" role="status" aria-live="polite">Checking the build cache.</p>
             <p id="pull-ota-warning" class="pull-ota-warning" hidden>Wifi Pull OTA installs official releases and replaces this custom build.</p>
@@ -231,7 +227,7 @@
             <button id="add-fleet-build" class="primary-button" type="button" disabled>Add current build</button>
           </div>
           <div class="fleet-build-labels" aria-hidden="true">
-            <span>Label</span><span>Firmware and options</span><span>Combination</span><span>Availability</span><span></span>
+            <span>Label</span><span>Firmware and options</span><span>Availability</span><span></span>
           </div>
           <ul id="fleet-builds" class="fleet-build-list"></ul>
         </section>
@@ -300,6 +296,6 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=21"></script>
+  <script type="module" src="app.js?v=22"></script>
 </body>
 </html>

--- a/docs/custom-build/operations.md
+++ b/docs/custom-build/operations.md
@@ -48,7 +48,8 @@ firmware reports that value; official firmware reports `installed_combination: n
 records without the newer fields remain valid and appear as unknown until they check in.
 
 Full 64-character lowercase hashes are used for API identity, storage, assignment, and verification.
-The 12-character browser prefix and 8-character OLED prefix are uppercase display aids only.
+The browser uses build labels; hashes remain internal identifiers. The 8-character OLED prefix
+is an uppercase display aid only. Firmware options in saved builds can be expanded in full.
 
 ## Fleet API
 

--- a/docs/custom-build/styles.css
+++ b/docs/custom-build/styles.css
@@ -673,32 +673,6 @@
 
     .service-heading span { font-size: .78rem; font-weight: 720; }
 
-    .hash-button {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) 16px;
-      align-items: center;
-      gap: 8px;
-      width: 100%;
-      padding: 7px 8px;
-      border: 1px solid var(--line);
-      border-radius: 7px;
-      color: var(--faint);
-      background: var(--surface-soft);
-      text-align: left;
-      cursor: pointer;
-    }
-
-    .hash-button[hidden] { display: none; }
-    .hash-button:hover, .hash-button:focus-visible { border-color: var(--green-line); outline: 0; }
-    .hash-button:focus-visible { box-shadow: 0 0 0 3px rgba(13, 121, 85, .14); }
-
-    .hash-button code {
-      min-width: 0;
-      overflow-wrap: anywhere;
-      font: 600 .62rem/1.35 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    }
-
-    .hash-button svg { width: 16px; height: 16px; }
 
     .status-message {
       min-height: 42px;
@@ -1235,8 +1209,7 @@
       background: var(--green-soft-strong);
     }
 
-    html[data-theme="dark"] .recommend-button:focus-visible,
-    html[data-theme="dark"] .hash-button:focus-visible { box-shadow: 0 0 0 3px var(--focus-green); }
+    html[data-theme="dark"] .recommend-button:focus-visible { box-shadow: 0 0 0 3px var(--focus-green); }
     html[data-theme="dark"] .info-button { color: #8a9690; }
 
     html[data-theme="dark"] .tooltip {

--- a/include/custom_build_ota.h
+++ b/include/custom_build_ota.h
@@ -98,6 +98,14 @@ bool customBuildLoadCredentials(String &deviceId, String &deviceSecret, bool *pa
   return true;
 }
 
+bool customBuildRelinkAvailable() {
+  Preferences preferences;
+  if (!preferences.begin(HDS_CUSTOM_BUILD_NVS_NAMESPACE, true)) return false;
+  const bool initialized = preferences.getBool("pair_init", false);
+  preferences.end();
+  return initialized;
+}
+
 void customBuildSerialHint(char output[7]) {
   const uint64_t mac = ESP.getEfuseMac();
   snprintf(output, 7, "%06lX", (unsigned long)(mac & 0xFFFFFFUL));
@@ -191,10 +199,14 @@ bool customBuildRegisterPairCode(const char *pairCode) {
   return stored;
 }
 
-bool customBuildWaitForHold(uint8_t pin, unsigned long timeoutMs) {
+bool customBuildWaitForHold(uint8_t pin, unsigned long timeoutMs, int cancelPin = -1) {
   const unsigned long startedAt = millis();
   unsigned long heldSince = 0;
   while (millis() - startedAt < timeoutMs) {
+    if (cancelPin >= 0 && digitalRead(cancelPin) == LOW) {
+      pullOtaWaitForRelease(1000);
+      return false;
+    }
     if (digitalRead(pin) == LOW) {
       if (heldSince == 0) heldSince = millis();
       if (millis() - heldSince >= HDS_CUSTOM_BUILD_HOLD_MS) return true;
@@ -313,24 +325,26 @@ bool customBuildFetchManifest(
   return pullOtaParseManifestObject(root, manifest, assetPrefix.c_str(), false);
 }
 
-bool customBuildShowRelink(const char *line1, const char *line2) {
-  pullOtaWaitForRelease(1000);
-  pullOtaDraw(line1, line2, "Hold O relink");
-  if (!customBuildWaitForHold(BUTTON_CIRCLE, HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS)) return true;
-  return customBuildPairScale(false);
+bool customBuildConfirmRelink() {
+  if (!pullOtaWaitForRelease(3000)) return false;
+  pullOtaDraw("Relink scale?", "", "Sq back Hold O");
+  return customBuildWaitForHold(BUTTON_CIRCLE, HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS, BUTTON_SQUARE);
+}
+
+void customBuildShowStatus(const char *line1, const char *line2) {
+  pullOtaDraw(line1, line2, "Sq back");
+  customBuildWaitForDismiss(HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS);
 }
 
 bool customBuildConfirmInstall(
     const PullOtaManifest &manifest,
-    const String &combinationHash,
-    bool &relink) {
+    const String &combinationHash) {
   char hashPrefix[9];
   customBuildHashPrefix(combinationHash, hashPrefix);
   pullOtaWaitForRelease(1000);
-  pullOtaDraw(manifest.version.c_str(), hashPrefix, "Sq install O relink");
+  pullOtaDraw(manifest.version.c_str(), hashPrefix, "Hold Sq O back");
   const unsigned long startedAt = millis();
   unsigned long squareHeldSince = 0;
-  unsigned long circleHeldSince = 0;
   while (millis() - startedAt < HDS_OTA_CONFIRM_TIMEOUT_MS) {
     if (digitalRead(BUTTON_SQUARE) == LOW) {
       if (squareHeldSince == 0) squareHeldSince = millis();
@@ -339,13 +353,8 @@ bool customBuildConfirmInstall(
       squareHeldSince = 0;
     }
     if (digitalRead(BUTTON_CIRCLE) == LOW) {
-      if (circleHeldSince == 0) circleHeldSince = millis();
-      if (millis() - circleHeldSince >= HDS_CUSTOM_BUILD_HOLD_MS) {
-        relink = true;
-        return false;
-      }
-    } else {
-      circleHeldSince = 0;
+      pullOtaWaitForRelease(1000);
+      return false;
     }
     delay(20);
   }
@@ -376,29 +385,29 @@ void customBuildRun() {
     return;
   }
   if (assignment.identityRejected) {
-    customBuildShowRelink("Custom Build", "Device rejected");
+    customBuildShowStatus("Custom Build", "Device rejected");
     return;
   }
   if (!assignment.linked) {
-    customBuildPairScale(true);
+    customBuildShowStatus("Custom Build", "Not linked");
     return;
   }
   if (assignment.combinationHash.length() == 0) {
-    customBuildShowRelink("Custom Build", "No build assigned");
+    customBuildShowStatus("Custom Build", "No build assigned");
     return;
   }
   if (assignment.combinationHash == installedCombination) {
     char hashPrefix[9];
     customBuildHashPrefix(installedCombination, hashPrefix);
-    customBuildShowRelink("Already installed", hashPrefix);
+    customBuildShowStatus("Already installed", hashPrefix);
     return;
   }
   if (assignment.state == "queued" || assignment.state == "building") {
-    customBuildShowRelink("Custom Build", "Build preparing");
+    customBuildShowStatus("Custom Build", "Build preparing");
     return;
   }
   if (assignment.state != "ready") {
-    customBuildShowRelink("Custom Build", "Build unavailable");
+    customBuildShowStatus("Custom Build", "Build unavailable");
     return;
   }
   PullOtaManifest manifest;
@@ -407,11 +416,7 @@ void customBuildRun() {
     pullOtaFail("Signature failed");
     return;
   }
-  bool relink = false;
-  if (!customBuildConfirmInstall(manifest, assignment.combinationHash, relink)) {
-    if (relink) customBuildPairScale(false);
-    return;
-  }
+  if (!customBuildConfirmInstall(manifest, assignment.combinationHash)) return;
   const String rollbackCombinationHash = installedCombination;
   const bool rollbackFound = rollbackCombinationHash.length() > 0
       ? customBuildFetchManifest(rollbackCombinationHash, rollbackManifest)
@@ -428,14 +433,20 @@ void customBuildRun() {
 }
 
 void customBuildTask(void *args) {
-  (void)args;
   const unsigned long pauseStartedAt = millis();
   while (!otaRuntimeIsPaused() &&
          millis() - pauseStartedAt < OTA_RUNTIME_PAUSE_TIMEOUT_MS) {
     delay(1);
   }
-  if (otaRuntimeIsPaused()) customBuildRun();
-  else pullOtaFail("OTA runtime pause failed");
+  if (otaRuntimeIsPaused()) {
+    if (args != nullptr) {
+      if (customBuildConfirmRelink()) customBuildPairScale(false);
+    } else {
+      customBuildRun();
+    }
+  } else {
+    pullOtaFail("OTA runtime pause failed");
+  }
   portENTER_CRITICAL(&wsPendingMux);
   const bool restartPending = (wsPendingMask & WSP_OTA_RESET) != 0;
   portEXIT_CRITICAL(&wsPendingMux);
@@ -446,7 +457,7 @@ void customBuildTask(void *args) {
   vTaskDelete(NULL);
 }
 
-void customBuildMenu() {
+void customBuildStart(bool relink) {
   if (b_pullOtaRunning || b_ota) return;
   setOtaRuntimePaused(false);
   b_pullOtaRunning = true;
@@ -455,7 +466,7 @@ void customBuildMenu() {
       customBuildTask,
       "Custom OTA",
       HDS_OTA_TASK_STACK_BYTES,
-      NULL,
+      reinterpret_cast<void *>(static_cast<uintptr_t>(relink)),
       1,
       NULL);
   if (started != pdPASS) {
@@ -463,6 +474,14 @@ void customBuildMenu() {
     b_ota = false;
     pullOtaFail("OTA task failed");
   }
+}
+
+void customBuildMenu() {
+  customBuildStart(false);
+}
+
+void customBuildRelinkMenu() {
+  customBuildStart(true);
 }
 
 #endif

--- a/include/menu.h
+++ b/include/menu.h
@@ -78,6 +78,8 @@ void drawButton();
 void wifiUpdate();
 void wifiUpdate(const PullOtaTargetVersion &target);
 void customBuildMenu();
+void customBuildRelinkMenu();
+bool customBuildRelinkAvailable();
 #endif
 void showStatus();
 void showAbout();
@@ -160,6 +162,7 @@ const Menu menuWiFiStatusOption = { "WiFi Status", showWifiStatus, NULL, &menuCo
 #if HDS_FEATURE_PULL_OTA
 const Menu menuWiFiPullUpdateOption = { "WiFi Update", wifiUpdate, NULL, &menuConnections };
 const Menu menuCustomBuildOption = { "Custom Build", customBuildMenu, NULL, &menuConnections };
+const Menu menuCustomRelinkOption = { "Relink", customBuildRelinkMenu, NULL, &menuConnections };
 #endif
 const Menu menuWiFiResetOption = { "Reset WiFi", resetWifi, NULL, &menuConnections };
 #endif
@@ -180,7 +183,18 @@ const Menu *const connectionsMenu[] = {
 #endif
   &menuWiFiResetOption,
 #endif
+#if HDS_FEATURE_WIFI && HDS_FEATURE_PULL_OTA
+  &menuCustomRelinkOption,
+#endif
 };
+
+int connectionsMenuSize() {
+#if HDS_FEATURE_WIFI && HDS_FEATURE_PULL_OTA
+  return getMenuSize(connectionsMenu) - (customBuildRelinkAvailable() ? 0 : 1);
+#else
+  return getMenuSize(connectionsMenu);
+#endif
+}
 
 const Menu menuDisplayBack = { "Back", NULL, NULL, &menuDisplay };
 const Menu menuFlipScreen = { menuFlipScreenLabel, toggleFlipScreen, NULL, &menuDisplay };
@@ -1590,6 +1604,7 @@ void refreshMenuRows() {
 
 void navigateMenu(int direction) {
   recordEnergyActivity();
+  if (currentMenu == connectionsMenu) currentMenuSize = connectionsMenuSize();
   currentIndex = (currentIndex + direction + currentMenuSize) % currentMenuSize;
   currentSelection = currentMenu[currentIndex];
   invalidateMenuFrame();
@@ -1630,7 +1645,7 @@ void selectMenu() {
       currentMenuSize = getMenuSize(scaleMenu);
     } else if (currentSelection == &menuConnections) {
       currentMenu = connectionsMenu;
-      currentMenuSize = getMenuSize(connectionsMenu);
+      currentMenuSize = connectionsMenuSize();
     } else if (currentSelection == &menuDisplay) {
       currentMenu = displayMenu;
       currentMenuSize = getMenuSize(displayMenu);

--- a/tools/test_custom_build_execution.py
+++ b/tools/test_custom_build_execution.py
@@ -492,7 +492,8 @@ def main():
     assert "catalogRetryDelay = Math.min(catalogRetryDelay * 2, 30000)" in configurator
     assert "catalogRevisionChanged(fetch, catalog.catalog_revision)" in configurator
     assert "await checkStatus(selection, generation)" in configurator
-    assert "navigator.clipboard.writeText(currentCombinationHash)" in configurator
+    assert "navigator.clipboard.writeText(currentCombinationHash)" not in configurator
+    assert 'getReadyHash: () => currentBuildState === "ready" ? currentCombinationHash : ""' in configurator
     assert "expectedHash" not in configurator
     configuratorWorkflow = (
         customBuild.SCRIPT_ROOT / ".github" / "workflows" / "custom-build-configurator.yml"

--- a/tools/test_custom_build_ota_contract.py
+++ b/tools/test_custom_build_ota_contract.py
@@ -37,7 +37,32 @@ def main():
     require("include/custom_build_ota.h", 'customBuildRequest("/api/v1/device/check-in", "POST"')
     require("include/custom_build_ota.h", 'request["installed_combination"]')
     require("include/custom_build_ota.h", 'request["firmware_version"]')
-    require("include/custom_build_ota.h", 'customBuildShowRelink("Already installed", hashPrefix)')
+    require("include/custom_build_ota.h", 'customBuildShowStatus("Already installed", hashPrefix)')
+    hold = function_body(header, "bool customBuildWaitForHold(")
+    cancel = function_body(hold, "if (cancelPin >= 0")
+    assert "digitalRead(cancelPin) == LOW" in hold
+    assert "pullOtaWaitForRelease(1000);" in cancel
+    assert "return false;" in cancel
+    assert hold.index("cancelPin >= 0") < hold.index("digitalRead(pin)")
+    status = function_body(header, "void customBuildShowStatus(")
+    wait = "customBuildWaitForHold(BUTTON_CIRCLE, HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS, BUTTON_SQUARE)"
+    assert 'pullOtaDraw(line1, line2, "Sq back")' in status
+    assert "customBuildWaitForDismiss(HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS)" in status
+    assert "customBuildPairScale" not in status
+    assert "Relink" not in status
+    confirmation = function_body(header, "bool customBuildConfirmRelink()")
+    assert "if (!pullOtaWaitForRelease(3000)) return false;" in confirmation
+    assert confirmation.index("pullOtaWaitForRelease(3000)") < confirmation.index('pullOtaDraw("Relink scale?"')
+    assert confirmation.index('pullOtaDraw("Relink scale?"') < confirmation.index(wait)
+    assert "if (customBuildConfirmRelink()) customBuildPairScale(false);" in header
+    availability = function_body(header, "bool customBuildRelinkAvailable()")
+    assert "preferences.begin(HDS_CUSTOM_BUILD_NVS_NAMESPACE, true)" in availability
+    assert 'preferences.getBool("pair_init", false)' in availability
+    assert "putBool" not in availability
+    assert "customBuildStart(true);" in function_body(header, "void customBuildRelinkMenu()")
+    assert "customBuildStart(false);" in function_body(header, "void customBuildMenu()")
+    install_prompt = function_body(header, "bool customBuildConfirmInstall(")
+    assert "relink" not in install_prompt.lower()
     require("include/custom_build_ota.h", 'pullOtaDraw(manifest.version.c_str(), hashPrefix')
     require("include/custom_build_ota.h", "assignment.combinationHash,")
     require("include/custom_build_ota.h", "rollbackCombinationHash);")
@@ -68,11 +93,11 @@ def main():
     assert pairing.index("customBuildRegisterPairCode(pairCode)") < pairing.index('pullOtaDraw("Pair code"')
     assert 'pullOtaDraw("Custom Build", "Pair scale?", "Hold square")' in pairing
     rejected = function_body(run, "if (assignment.identityRejected)")
-    assert 'customBuildShowRelink("Custom Build", "Device rejected");' in rejected
+    assert 'customBuildShowStatus("Custom Build", "Device rejected");' in rejected
     assert "return;" in rejected
     assert run.index("if (assignment.identityRejected)") < run.index("if (!assignment.linked)")
     unlinked = function_body(run, "if (!assignment.linked)")
-    assert "customBuildPairScale(true);" in unlinked
+    assert 'customBuildShowStatus("Custom Build", "Not linked");' in unlinked
     assert "return;" in unlinked
     failure = function_body(run, "if (!customBuildCheckIn(")
     assert 'pullOtaFail("Service failed");' in failure
@@ -112,7 +137,10 @@ def main():
     assert "static const uint32_t HDS_OTA_TASK_STACK_BYTES" not in header
     assert '"/api/v1/fleet/' not in header
     assert "fleet_secret" not in header
-    require("include/menu.h", '"Custom Build", customBuildMenu')
+    menu = require("include/menu.h", '"Custom Build", customBuildMenu')
+    assert '"Relink", customBuildRelinkMenu' in menu
+    assert "getMenuSize(connectionsMenu) - (customBuildRelinkAvailable() ? 0 : 1)" in menu
+    assert menu.count("currentMenuSize = connectionsMenuSize();") == 2
     require("src/hds.ino", '#include "custom_build_ota.h"')
     require(".github/workflows/custom-build.yml", "HDS_CUSTOM_OTA_SIGNING_KEY_PEM")
     release = require(".github/workflows/release.yml", "python tools/write_custom_ota_public_key_header.py")

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,15 +254,16 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=21"' in indexPage
-    assert 'href="styles.css?v=15"' in indexPage
-    assert 'href="fleet.css?v=3"' in indexPage
+    assert 'type="module" src="app.js?v=22"' in indexPage
+    assert 'href="styles.css?v=16"' in indexPage
+    assert 'href="fleet.css?v=4"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage
     assert 'fetch("catalog.json"' in appScript
     assert "openscale-custom-builds.odevstudio.workers.dev" in appScript
     assert "catalog.features.filter(item => !item.hidden)" in appScript
-    assert "Usually ready in about 5 minutes" in appScript
+    assert "buildEstimate(result, currentSelection)" in appScript
+    assert 'build-estimate.mjs?v=1' in appScript
     assert "error.status === 429" in appScript
     assert "weekly build limit" in appScript.lower()
     assert "daily build limit" not in appScript.lower()
@@ -270,7 +271,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=6' in appScript
+    assert 'fleet.js?v=7' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" in fleetScript
     assert "localStorage.setItem(storageKey" not in fleetScript


### PR DESCRIPTION
## Summary

- Let Square dismiss Custom Build status screens, including Already installed.
- Keep initial pairing under Custom Build; expose Connections > Relink after pair-code registration, with explicit confirmation. Remove relinking from status and install prompts.
- Remove redundant hash displays and copy controls from the configurator, expand complete saved-build options, and use selection-aware build-time estimates.
- Preserve immutable build hashes, credentials, signature checks and rollback routing.

## Validation

- Local esp32s3 firmware build passed.
- 22 fleet/configurator Node tests passed.
- Custom OTA, OTA reboot routing and AI documentation contracts passed.
- Playwright desktop (1440px) and mobile (390px) checks passed with mocked fleet data, including complete expanded options and no horizontal page overflow.
- Earlier signed custom-to-custom firmware WiFi installation passed on COM5; user confirmed Already installed and refreshed Fleet Up to date.

## Remaining Hardware Gates

- Test the changed Square/Relink menu on the corrected firmware.
- Exercise a real LittleFS download with differing contents; the previous target's filesystem was byte-identical and reused after verification.
- Validate rollback and remaining BLE/standard hardware checks.

The existing v3.1.14-preview.2 tag is not moved. No stable tag or official preview OTA manifest is created by this PR. The known existing-device/wrong-secret 401 recovery limitation is unchanged.
