### PR TITLE
Fix WiFi-only custom build startup panic

### DIFF
--- a/include/wifi_config_server.h
+++ b/include/wifi_config_server.h
@@ -354,6 +354,9 @@ static bool wifiConfigConsumeByte(char value) {
 }
 
 static bool wifiConfigStartServer() {
+  if (!WiFi.STA.started() && !WiFi.AP.started()) {
+    return false;
+  }
   const int serverSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
   if (serverSocket < 0) {
     return false;

--- a/tools/test_mdns_name_contract.py
+++ b/tools/test_mdns_name_contract.py
@@ -80,6 +80,11 @@ def check_endpoint(webserver_source):
 
 
 def check_mini_config_server(mini_server, hds_source):
+    start = mini_server.index("static bool wifiConfigStartServer()")
+    guard = mini_server.index("if (!WiFi.STA.started() && !WiFi.AP.started())", start)
+    socket = mini_server.index("socket(AF_INET, SOCK_STREAM, IPPROTO_IP)", start)
+    assert start < guard < socket
+    assert "return false;" in mini_server[guard:socket]
     if "HDS_FEATURE_WIFI && !HDS_FEATURE_WEBSERVER" not in mini_server:
         raise AssertionError("mini setup server must only compile for WiFi without Webserver")
     for snippet in (


### PR DESCRIPTION
## Fix

Gate the WiFi-only mini HTTP server's socket creation on the STA or AP started event. The main loop can reach this server while the separate low-priority WiFi init task has not initialized lwIP yet. Calling socket in that window can assert in xQueueSemaphoreTake.

This keeps the existing bounded retry and checks framework interface readiness rather than adding cross-task state. Both station and provisioning AP paths remain supported.

## Hardware Evidence

- Signed minimal build 99fbe5f7 at f37ccd1 installed firmware and differing LittleFS successfully, then repeatedly panicked on ordinary boot.
- Recovered the scale on COM5 with the prior verified firmware and filesystem, without writing NVS, otadata or the partition table.
- Built and USB-flashed the minimal pull-ota/wifi profile with this guard and version 3.1.14-preview.3-startup-test, using the same empty filesystem as the failing build.
- Three consecutive hardware resets each passed 45 seconds of observation: exactly one boot, no panic/backtrace, weight output, mini HTTP server started, and HTTP 200 from its setup page.
- Local esp32s3-custom build and mdns/mini-server contract test passed.

## Remaining Gates

Signed custom-to-custom WiFi retest and rollback hardware testing remain pending. The earlier failure occurred after application validity marking, so it did not automatically roll back; this PR does not change that policy. No release tag is created or moved.
