### PR TITLE
feat: optional Wake-on-Weight mode via RTC timer polling

### DIFF
--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -47,6 +47,23 @@ Do not add an environment merely because it exists. Changes limited to ADS1232 b
 - `check_platform_freshness.py` compares the explicit pioarduino pin with the latest stable release as an advisory pre-build check. It never fails offline builds; set `HDS_SKIP_PLATFORM_CHECK=1` only when the check should be skipped deliberately.
 - `.gitattributes` enforces LF line endings repo-wide.
 
+### Windows Energy-Menu Builds
+
+The PM-capable energy-menu environments compile ESP-IDF libraries. Use a
+short physical worktree path, such as `D:\w180`, with its ignored local
+`.pio-core` directory. Set `PLATFORMIO_BUILD_DIR` to `D:\w180\build` for
+that build. Long paths can exceed Windows command-line limits during
+linker-script generation. A `subst` alias is not sufficient: CMake resolves
+the physical path while other build steps keep the alias, which can break
+generated certificate source paths. Do not change the firmware or dependency
+pins to work around these path errors.
+
+Keep normal and custom-SDK builds in separate core directories. The custom
+builder rewrites the installed framework; switching variants in one core
+can leave mismatched headers and libraries. For example, use `.pio-core` for
+the energy-menu build and `build\normal-core` for the normal build, setting
+`PLATFORMIO_CORE_DIR` per invocation. Both directories are ignored.
+
 ## Enabling a Stable Custom Base
 
 In the release-preparation pull request, add the prospective `vX.Y.Z` tag to `FIRMWARE_REFS`, compatible plugin manifests, and the Worker's `ALLOWED_FIRMWARE_REFS` without removing `main` or making the tag the default. Regenerate both custom-build catalogs. When the tag does not exist, pull-request jobs may create a temporary local tag at the candidate commit and must pass its resolved commit explicitly when compiling the stable custom build. Do not create or push the real tag before the pre-tag gate passes. After the catalog commit reaches the trusted builder branch and the real tag exists, deploy the overlapping Worker configuration, then switch the configurator and build defaults to `vX.Y.Z` in a follow-up commit. After the stable path is live and before publishing the release, remove `main` from the catalog and Worker allow-list so development builds cannot consume production build quota. The configurator displays `vX.Y.Z` as `X.Y.Z (stable)`, and the resulting firmware reports `X.Y.Z-custom`.

--- a/docs/AI_GPIO_NOTES.md
+++ b/docs/AI_GPIO_NOTES.md
@@ -80,6 +80,15 @@ Current active config is `V8_1` with `TWO_BUTTON`.
 | `PWR_CTRL` | output low, `gpio_hold_en` | yes |
 | `BUTTON_CIRCLE`, `BUTTON_SQUARE`, `BATTERY_CHARGING` | RTC input pull-up, EXT1 wake any-low | RTC mode released in setup |
 
+Wake-on-Weight (`include/wake_on_weight.h`) adds a second release/re-latch
+path: an RTC-timer micro-wakeup releases `gpio_hold` on `SCALE_SCLK`,
+`SCALE_PDWN`, `SCALE_DOUT`, `PWR_CTRL` only, raises `PWR_CTRL` briefly to
+read one ADS1232 conversion, then re-latches exactly those four pins before
+re-entering deep sleep. OLED, I2C, secondary-scale, and `ACC_PWR_CTRL` holds
+are never touched by the micro path; the normal `setup()` release block
+(`gpio_hold_dis` sequence in `src/hds.ino`) is idempotent on pins the micro
+path already released.
+
 ## Change Checklist
 
 - If a pin is used for wake, verify RTC GPIO support and update `PIN_BITMASK`.

--- a/docs/AI_REPO_MAP.md
+++ b/docs/AI_REPO_MAP.md
@@ -20,7 +20,7 @@ Local build, flash, OTA, editor, cache, and CAD files are omitted unless they ar
 | WiFi, AP setup, credentials, mDNS | `src/wifi_setup.cpp`, `include/wifi_setup.h`, `include/mdns_name.h` | `docs/AI_BUILD_NOTES.md` |
 | HTTP and LittleFS serving | `include/webserver.h`, matching `plugins/default-web-apps/assets/` file | `docs/AI_FIRMWARE_NOTES.md` |
 | `/snapshot` WebSocket behavior | `include/websocket.h` | `docs/AI_FIRMWARE_NOTES.md`, `docs/AI_PROTOCOL_NOTES.md` |
-| Power, soft sleep, wake, shutdown | `include/power.h`, `include/websocket.h`, `src/hds.ino` | `docs/AI_GPIO_NOTES.md`, `docs/AI_FIRMWARE_NOTES.md` |
+| Power, soft sleep, wake, shutdown | `include/power.h`, `include/websocket.h`, `include/wake_on_weight.h`, `src/hds.ino` | `docs/AI_GPIO_NOTES.md`, `docs/AI_FIRMWARE_NOTES.md` |
 | WiFi OTA, manifests, signing, rollback | `include/pull_ota.h`, `include/ota_rollback.h`, `.github/workflows/release.yml` | `docs/AI_OTA_NOTES.md` |
 | Release preparation, tagging, assets, and documentation audit | `.github/workflows/release.yml`, `tools/generate_release_manifest.py`, `README.md`, changes since the previous release tag | `docs/AI_RELEASE_NOTES.md`, plus affected topic notes |
 | Motion and ESP-NOW | `include/gyro.h`, `include/espnow.h` | `docs/AI_GPIO_NOTES.md` when pins or power are involved |

--- a/docs/wake-on-weight.md
+++ b/docs/wake-on-weight.md
@@ -1,0 +1,120 @@
+# Wake-on-Weight
+
+Optional feature: after a normal button/auto-off deep sleep, the scale wakes
+itself on an RTC timer, briefly powers the load-cell rail, reads one raw
+ADS1232 conversion, and either goes straight back to sleep (nothing placed)
+or continues into a full normal boot (weight placed).
+
+Runtime-gated: always compiled, off by default, no platformio environment or
+custom-build flag. Requires the ADS1232 load-cell path (`ADS1232ADC`).
+
+## Settings
+
+Power menu row `Wake: Off / 0.5s / 1s / 2s`, cycling entry (same pattern as
+`Drift:`), NVS key `wow_interval` under the `hds` namespace. Stored via
+`storageEnsureInt(KEY_WOW_INTERVAL, 0)` in all three storage paths so legacy
+EEPROM migration keeps `storageHasAllSettings()` satisfied. The stored
+value defaults to off — the ECO behavior (~100 µA deep sleep, physical
+button wake only).
+
+Setting the interval does not arm anything by itself. Ticks only start from a
+sleep that qualifies (see below).
+
+## What wakes the device
+
+Deep sleep still wakes on EXT1 (buttons + charging pin) exactly as before.
+When Wake-on-Weight is active the RTC timer is a second wake source that
+coexists with EXT1: a button press during a tick's sleep still EXT1-wakes
+into a full boot.
+
+## Arming (`wowCaptureBaselineForSleep` in `include/wake_on_weight.h`)
+
+Called from `esp32_sleep()` in `include/power.h` just before
+`scale.powerDown()`. Arms only when all of:
+
+- `i_wow_interval > 0` (setting not Off)
+- `i_lowBatteryCount == 0` (low battery disables the feature)
+- `f_calibration_value != CALIBRATION_VALUE_DEFAULT` (scale is calibrated)
+- `scale.getDebugInfo().validSamples > 0` (a live reading exists; setup-time
+  sleeps and gyro accidental-touch boots never arm)
+
+When armed it stores in `RTC_DATA_ATTR` (first use in this repo, survives
+deep sleep without wearing NVS):
+
+- `baselineRaw` = current `smoothedValue` (raw counts; the tare offset is
+  common mode and cancels in the delta)
+- `thresholdRaw` = `max(50 g × calibration factor, 500 counts)` floor
+- `intervalUs` from the setting
+- `magic` + `armed` markers
+
+The timer is enabled by `wowArmSleepTimer()` in the same teardown chain,
+**after** the energy-menu block's `esp_sleep_disable_wakeup_source`. When the
+feature is off or disarmed the timer source is explicitly disabled again —
+the RTC timer configuration otherwise persists across deep-sleep cycles and
+would keep waking the device after the user turns the setting back to Off.
+
+## Micro-wakeup (`wowMicroWakeOrContinue`)
+
+First call in `setup()` (before reset-reason handling, NVS init, or any
+peripheral init; the tick path never touches NVS or the battery). Only acts
+when the wake cause is `ESP_SLEEP_WAKEUP_TIMER` and the `magic`/`armed`
+markers are valid — every other boot falls straight through.
+
+Per tick, in order:
+
+1. Run at 80 MHz (`setCpuFrequencyMhz(80)`, the device's normal clock).
+2. Release `gpio_hold` on `SCALE_SCLK`, `SCALE_PDWN`, `SCALE_DOUT`,
+   `PWR_CTRL` only (per-pin first, then `gpio_deep_sleep_hold_dis()`);
+   OLED/I2C/ACC/SCALE2 rails stay off and held.
+3. `PWR_CTRL` HIGH, settle 10 ms, then a local `ADS1232_ADC` object (fresh
+   mutexes after the full reset; `begin()` performs the PDWN reset pulse).
+4. Poll `update()` for the first DRDY at 10 SPS with a 250 ms timeout
+   (typical first conversion ≈ 100 ms; the "20 ms burst" from early feature
+   drafts is not possible at 10 SPS — one sample costs ~100-130 ms).
+5. `powerDown()` the ADC.
+
+Decision:
+
+- No sample within the timeout, or `dataOutOfRange` → back to sleep, retry
+  next tick (no false boots on ADC faults).
+- `|raw − baseline| <= threshold` → re-latch the four pins
+  (`PWR_CTRL` LOW + hold), re-assert EXT1 wake pins + timer, `tickCount++`,
+  `esp_deep_sleep_start()`.
+- `|raw − baseline| > threshold` → clear `armed`, log, and **return into the
+  normal `setup()` flow** (OLED, BLE, boot tare). `GPIO_power_on_with`
+  stays -1 so BLE enables and the button-hold check is skipped, as for a
+  timer wake today. The normal boot tare then zeros whatever was placed —
+  same semantics as putting a cup on before pressing the button.
+
+## Behavior notes
+
+- Charging: arming is allowed (plugging in still EXT1-wakes into a full
+  boot; a manual shutdown while charging may tick).
+- Low battery: never arms once `i_lowBatteryCount > 0`; the micro path never
+  reads the battery.
+- Uncalibrated scale: setting can be changed but nothing arms until the
+  scale is calibrated.
+- Each tick prints one `[wow]` line on Serial before energy quieting exists.
+
+## Power budget
+
+10 SPS bounds the per-tick on-time (~110-130 ms at 80 MHz ≈ 8-15 mA plus the
+~1-2 mA load-cell/ADC rail). Average current estimates for the three
+intervals against the deep-sleep ~100 µA baseline (700 mAh cell):
+
+| Setting | On-time / tick | Avg current | Standby |
+| --- | --- | --- | --- |
+| 0.5 s | ~130 ms | ~3.1 mA | ~9 days |
+| 1 s | ~130 ms | ~1.7 mA | ~18 days |
+| 2 s | ~130 ms | ~0.9 mA | ~33 days |
+
+Measure with a real ammeter or the USB Sleep Test before trusting these;
+they are estimates pending hardware confirmation.
+
+## Related code
+
+- `include/wake_on_weight.h` — micro-wake, baseline capture, timer arming
+- `include/power.h` — `esp32_sleep()` arming hooks
+- `include/menu.h` — Power menu cycling row
+- `include/storage.h`, `include/parameter.h` — NVS key + globals
+- `tools/test_wake_on_weight_contract.py` — read-only source contract

--- a/docs/wake-on-weight.md
+++ b/docs/wake-on-weight.md
@@ -8,24 +8,44 @@ or continues into a full normal boot (weight placed).
 Runtime-gated: always compiled, off by default, no platformio environment or
 custom-build flag. Requires the ADS1232 load-cell path (`ADS1232ADC`).
 
-## Settings
+## Setting
 
-Power menu row `Wake: Off / 0.5s / 1s / 2s`, cycling entry (same pattern as
-`Drift:`), NVS key `wow_interval` under the `hds` namespace. Stored via
+Power menu row `Wake: Off / 2s / 3s / 4s` (cycling entry, same pattern as
+`Drift:`), NVS key `wow_interval` (int) under the `hds` namespace. Stored via
 `storageEnsureInt(KEY_WOW_INTERVAL, 0)` in all three storage paths so legacy
-EEPROM migration keeps `storageHasAllSettings()` satisfied. The stored
-value defaults to off — the ECO behavior (~100 µA deep sleep, physical
+EEPROM migration keeps `storageHasAllSettings()` satisfied. The stored value
+defaults to off (index 0) — the ECO behavior (~100 µA deep sleep, physical
 button wake only).
 
-Setting the interval does not arm anything by itself. Ticks only start from a
-sleep that qualifies (see below).
+Changing the menu does not re-arm a sleep already in progress: the interval
+is snapshotted into RTC memory at each sleep entry, so a running tick cycle
+keeps its old cadence until the next qualifying sleep.
+
+## Tick cadence
+
+Measured on V8.1, one tick costs ~850 ms end to end: ≈300 ms ROM/Arduino
+boot at 240 MHz before the tick code runs, ~100 ms rail settle, ~400 ms
+until the first ADS1232 conversion at 10 SPS, then the re-latch and
+re-sleep. Duty cycles by setting:
+
+| Setting | Duty | Notes |
+| --- | --- | --- |
+| Off | — | ECO mode, no ticks |
+| 2 s | ~43% | barely leaves time asleep; battery-heavy |
+| 3 s | ~28% | usable compromise |
+| 4 s | ~21% | recommended default |
+
+The tick downclocks to the lowest supported CPU frequency, 20 MHz
+(`setCpuFrequencyMhz(20)`, S3 minimum below the 240/160/80 PLL tiers), for
+the ADC wait and restores the frequency the chip booted at (`bootFreqMhz`)
+if weight is detected, so a detected full boot behaves like any other full
+boot.
 
 ## What wakes the device
 
 Deep sleep still wakes on EXT1 (buttons + charging pin) exactly as before.
-When Wake-on-Weight is active the RTC timer is a second wake source that
-coexists with EXT1: a button press during a tick's sleep still EXT1-wakes
-into a full boot.
+The RTC timer is a second wake source that coexists with EXT1: a button press
+during a tick's sleep still EXT1-wakes into a full boot.
 
 ## Arming (`wowCaptureBaselineForSleep` in `include/wake_on_weight.h`)
 
@@ -34,7 +54,8 @@ Called from `esp32_sleep()` in `include/power.h` just before
 
 - `i_wow_interval > 0` (setting not Off)
 - `i_lowBatteryCount == 0` (low battery disables the feature)
-- `f_calibration_value != CALIBRATION_VALUE_DEFAULT` (scale is calibrated)
+- `f_calibration_value != CALIBRATION_VALUE_DEFAULT` (scale is calibrated;
+  signed calibration factors are supported via `fabsf`)
 - `scale.getDebugInfo().validSamples > 0` (a live reading exists; setup-time
   sleeps and gyro accidental-touch boots never arm)
 
@@ -43,15 +64,14 @@ deep sleep without wearing NVS):
 
 - `baselineRaw` = current `smoothedValue` (raw counts; the tare offset is
   common mode and cancels in the delta)
-- `thresholdRaw` = `max(50 g × calibration factor, 500 counts)` floor
-- `intervalUs` from the setting
+- `thresholdRaw` = `max(50 g × |calibration factor|, 500 counts)` floor
+- `intervalUs` from the menu setting (snapshot)
 - `magic` + `armed` markers
 
-The timer is enabled by `wowArmSleepTimer()` in the same teardown chain,
-**after** the energy-menu block's `esp_sleep_disable_wakeup_source`. When the
-feature is off or disarmed the timer source is explicitly disabled again —
-the RTC timer configuration otherwise persists across deep-sleep cycles and
-would keep waking the device after the user turns the setting back to Off.
+The timer is enabled by `wowArmSleepTimer()` after the baseline capture —
+**after** the energy-menu block's `esp_sleep_disable_wakeup_source` — and
+only when armed; the disable is gated on "enabled earlier in this boot" so
+ordinary sleeps never trip the ESP-IDF "Incorrect wakeup source" error.
 
 ## Micro-wakeup (`wowMicroWakeOrContinue`)
 
@@ -62,15 +82,15 @@ markers are valid — every other boot falls straight through.
 
 Per tick, in order:
 
-1. Run at 80 MHz (`setCpuFrequencyMhz(80)`, the device's normal clock).
+1. Log tick count + boot frequency, then run at 20 MHz.
 2. Release `gpio_hold` on `SCALE_SCLK`, `SCALE_PDWN`, `SCALE_DOUT`,
    `PWR_CTRL` only (per-pin first, then `gpio_deep_sleep_hold_dis()`);
-   OLED/I2C/ACC/SCALE2 rails stay off and held.
-3. `PWR_CTRL` HIGH, settle 10 ms, then a local `ADS1232_ADC` object (fresh
-   mutexes after the full reset; `begin()` performs the PDWN reset pulse).
-4. Poll `update()` for the first DRDY at 10 SPS with a 250 ms timeout
-   (typical first conversion ≈ 100 ms; the "20 ms burst" from early feature
-   drafts is not possible at 10 SPS — one sample costs ~100-130 ms).
+   OLED/I2C/secondary-scale/`ACC_PWR_CTRL` rails stay off and held.
+3. `PWR_CTRL` HIGH, settle 100 ms, then a local `ADS1232_ADC` object (fresh
+   after the full reset; `begin()` performs the PDWN reset pulse).
+4. Poll for the first DRDY at 10 SPS with a 900 ms timeout (measured on
+   hardware: first conversion arrives ~400 ms after rail power; the original
+   250 ms window never caught it).
 5. `powerDown()` the ADC.
 
 Decision:
@@ -78,13 +98,18 @@ Decision:
 - No sample within the timeout, or `dataOutOfRange` → back to sleep, retry
   next tick (no false boots on ADC faults).
 - `|raw − baseline| <= threshold` → re-latch the four pins
-  (`PWR_CTRL` LOW + hold), re-assert EXT1 wake pins + timer, `tickCount++`,
-  `esp_deep_sleep_start()`.
-- `|raw − baseline| > threshold` → clear `armed`, log, and **return into the
-  normal `setup()` flow** (OLED, BLE, boot tare). `GPIO_power_on_with`
-  stays -1 so BLE enables and the button-hold check is skipped, as for a
-  timer wake today. The normal boot tare then zeros whatever was placed —
-  same semantics as putting a cup on before pressing the button.
+  (`PWR_CTRL` LOW + hold), re-assert EXT1 wake pins + the snapshotted
+  interval timer, `tickCount++`, `esp_deep_sleep_start()`.
+- `|raw − baseline| > threshold` → clear `armed`, restore the boot frequency,
+  log, and **return into the normal `setup()` flow** (OLED, BLE, boot tare).
+  `GPIO_power_on_with` stays -1 so BLE enables and the button-hold check is
+  skipped, as for a timer wake today. The normal boot tare then zeros
+  whatever was placed — same semantics as putting a cup on before pressing
+  the button.
+
+Measured idle behavior on the bench (empty scale, 4 s ticks): consecutive
+tick samples drift ~70-90 raw counts (~7-9 g equivalent at a ~1000 counts/g
+calibration) — thermal drift, comfortably under the 50 g threshold.
 
 ## Behavior notes
 
@@ -94,19 +119,21 @@ Decision:
   reads the battery.
 - Uncalibrated scale: setting can be changed but nothing arms until the
   scale is calibrated.
-- Each tick prints one `[wow]` line on Serial before energy quieting exists.
+- Each tick prints a short `[wow]` line on Serial before energy quieting
+  exists.
 
 ## Power budget
 
-10 SPS bounds the per-tick on-time (~110-130 ms at 80 MHz ≈ 8-15 mA plus the
-~1-2 mA load-cell/ADC rail). Average current estimates for the three
-intervals against the deep-sleep ~100 µA baseline (700 mAh cell):
+Per tick ≈ 850 ms active at 20 MHz (below the PLL tiers the draw is
+dominated by the load-cell/ADC rail; measure on hardware) against the
+deep-sleep ~100 µA baseline (700 mAh cell). Rough estimates assuming
+~6 mA active:
 
-| Setting | On-time / tick | Avg current | Standby |
+| Setting | Duty | Avg current | Standby |
 | --- | --- | --- | --- |
-| 0.5 s | ~130 ms | ~3.1 mA | ~9 days |
-| 1 s | ~130 ms | ~1.7 mA | ~18 days |
-| 2 s | ~130 ms | ~0.9 mA | ~33 days |
+| 2 s | ~43% | ~2.6 mA | ~11 days |
+| 3 s | ~28% | ~1.8 mA | ~16 days |
+| 4 s | ~21% | ~1.3 mA | ~22 days |
 
 Measure with a real ammeter or the USB Sleep Test before trusting these;
 they are estimates pending hardware confirmation.

--- a/docs/wake-on-weight.md
+++ b/docs/wake-on-weight.md
@@ -1,147 +1,155 @@
 # Wake-on-Weight
 
-Optional feature: after a normal button/auto-off deep sleep, the scale wakes
-itself on an RTC timer, briefly powers the load-cell rail, reads one raw
-ADS1232 conversion, and either goes straight back to sleep (nothing placed)
-or continues into a full normal boot (weight placed).
+Wake-on-Weight (WoW) defaults to off. When enabled, normal shutdown captures
+the current weight, then RTC timer wakes briefly power the primary ADS1232
+and compare one conversion against that baseline. A change greater than the
+50 g threshold (with a 500-raw-count minimum) continues into normal boot,
+including boot tare. Removing weight can
+also trigger a boot. No separate firmware or energy-menu build is required.
 
-Runtime-gated: always compiled, off by default, no platformio environment or
-custom-build flag. Requires the ADS1232 load-cell path (`ADS1232ADC`).
+## Setting and Timing
 
-## Setting
+The Power menu row is `WakeOnWeight o / 2 / 3 / 4`. The confirmation says
+`Off / Sleep 2s / Sleep 3s / Sleep 4s`. These are **sleep intervals**, not
+detection periods. The NVS key `wow_interval` stores indices 0 through 3;
+all default and migration paths use 0. The selected interval is snapshotted
+at shutdown. Changing it does not change a sleep session already underway.
 
-Power menu row `Wake: Off / 2s / 3s / 4s` (cycling entry, same pattern as
-`Drift:`), NVS key `wow_interval` (int) under the `hds` namespace. Stored via
-`storageEnsureInt(KEY_WOW_INTERVAL, 0)` in all three storage paths so legacy
-EEPROM migration keeps `storageHasAllSettings()` satisfied. The stored value
-defaults to off (index 0) — the ECO behavior (~100 µA deep sleep, physical
-button wake only).
+The timer starts when entering deep sleep, after the micro-wake work.
+The detection period is sleep interval plus micro-wake duration. The PR's
+V8.1 measurement was approximately 850 ms per micro-wake, including about
+300 ms ROM/Arduino startup, 100 ms rail settling, and the first 10 SPS ADC
+conversion. Firmware polling has a separate 900 ms timeout after settling.
+The revised path runs before Serial initialization and does not log per tick;
+its exact duration must be remeasured on hardware.
 
-Changing the menu does not re-arm a sleep already in progress: the interval
-is snapshotted into RTC memory at each sleep entry, so a running tick cycle
-keeps its old cadence until the next qualifying sleep.
-
-## Tick cadence
-
-Measured on V8.1, one tick costs ~850 ms end to end: ≈300 ms ROM/Arduino
-boot at 240 MHz before the tick code runs, ~100 ms rail settle, ~400 ms
-until the first ADS1232 conversion at 10 SPS, then the re-latch and
-re-sleep. Duty cycles by setting:
-
-| Setting | Duty | Notes |
+| Sleep interval | Estimated detection period | Active duty |
 | --- | --- | --- |
-| Off | — | ECO mode, no ticks |
-| 2 s | ~43% | barely leaves time asleep; battery-heavy |
-| 3 s | ~28% | usable compromise |
-| 4 s | ~21% | recommended default |
+| 2 s | 2.85 s | 29.8% |
+| 3 s | 3.85 s | 22.1% |
+| 4 s | 4.85 s | 17.5% |
 
-The tick downclocks to the lowest supported CPU frequency, 20 MHz
-(`setCpuFrequencyMhz(20)`, S3 minimum below the 240/160/80 PLL tiers), for
-the ADC wait and restores the frequency the chip booted at (`bootFreqMhz`)
-if weight is detected, so a detected full boot behaves like any other full
-boot.
+Duty is `0.85 / (sleep seconds + 0.85)`, not `0.85 / sleep seconds`.
+ADC failures lengthen the active portion. Sampling is intermittent: a load
+placed and removed between samples can be missed.
 
-## What wakes the device
+## Button and Charging Wake
 
-Deep sleep still wakes on EXT1 (buttons + charging pin) exactly as before.
-The RTC timer is a second wake source that coexists with EXT1: a button press
-during a tick's sleep still EXT1-wakes into a full boot.
+Normal deep sleep keeps the existing EXT1 any-low button and charging wake
+sources. During a WoW micro-wake, the same RTC input pins are checked on
+entry, every 2 ms during rail settling and ADC polling, after ADC cleanup,
+and immediately before the final pin-latch/sleep sequence. A detected press
+aborts the micro-wake and continues into normal boot without waiting for ADC
+readiness. Square has priority over circle, and both have priority over
+charging, matching the normal multi-pin wake mapping.
 
-## Arming (`wowCaptureBaselineForSleep` in `include/wake_on_weight.h`)
+A button accepted during a micro-wake is remembered through setup, so release
+during later initialization cannot send it back to sleep. Only this accepted
+WoW button wake bypasses the subsequent button-hold gate. Ordinary EXT1 boots
+retain their existing quick-boot/500 ms hold behavior. Circle/square BLE
+selection and charging-only boot behavior remain unchanged. Weight-only boot
+leaves `GPIO_power_on_with` at -1 as before.
 
-Called from `esp32_sleep()` in `include/power.h` just before
-`scale.powerDown()`. Arms only when all of:
+Polling is not an edge latch: pulses shorter than the polling/scheduler gap,
+or entirely within ROM/Arduino startup before setup, are not guaranteed.
+The roughly 500 ms normal power-button press is longer than the measured
+startup window. After the final check there are no intentional waits before
+sleep; a normal press starting there remains low for EXT1. Test these
+boundaries on hardware; host checks cannot establish electrical timing.
 
-- `i_wow_interval > 0` (setting not Off)
-- `i_lowBatteryCount == 0` (low battery disables the feature)
-- `f_calibration_value != CALIBRATION_VALUE_DEFAULT` (scale is calibrated;
-  signed calibration factors are supported via `fabsf`)
-- `scale.getDebugInfo().validSamples > 0` (a live reading exists; setup-time
-  sleeps and gyro accidental-touch boots never arm)
+## Session Protection
 
-When armed it stores in `RTC_DATA_ATTR` (first use in this repo, survives
-deep sleep without wearing NVS):
+Arming requires a valid interval, calibration, and an existing live sample.
+An observed low-battery count or a known voltage below 3.2 V prevents arming.
+Non-finite or overflowing calibration thresholds also prevent arming.
 
-- `baselineRaw` = current `smoothedValue` (raw counts; the tare offset is
-  common mode and cancels in the delta)
-- `thresholdRaw` = `max(50 g × |calibration factor|, 500 counts)` floor
-- `intervalUs` from the menu setting (snapshot)
-- `magic` + `armed` markers
+Battery protection during sleep uses a **900-tick maximum per session**,
+not recurring voltage measurements. At the measured 850 ms active duration,
+this is about 43, 58, or 73 minutes for 2, 3, or 4 s sleep intervals. It is a
+tick bound, not a precise wall-clock deadline; slow startup and ADC timeouts
+extend elapsed time. After the limit, WoW is disabled for that sleep session
+and the device stays in ordinary deep sleep until a physical/charging wake.
+A later qualifying shutdown starts a new session. The saved menu setting
+does not change. This deliberately does not provide all-night WoW standby.
 
-The timer is enabled by `wowArmSleepTimer()` after the baseline capture —
-**after** the energy-menu block's `esp_sleep_disable_wakeup_source` — and
-only when armed; the disable is gated on "enabled earlier in this boot" so
-ordinary sleeps never trip the ESP-IDF "Incorrect wakeup source" error.
+Five consecutive ADC timeouts or unusable conversions also disable WoW for
+the current session. One reliable conversion resets the failure count.
+Both fallback paths preserve EXT1 and leave the timer unarmed in the fresh
+deep-sleep boot. They do not run the normal shutdown path or recapture a
+baseline. A button/charging request takes priority over fallback.
 
-## Micro-wakeup (`wowMicroWakeOrContinue`)
+No micro-wake initializes I2C, ADS1115, OLED, radio, storage, or battery ADC.
+No NVS reads or writes occur. V8.1's `BATTERY_PIN` is only a placeholder;
+using `analogRead(BATTERY_PIN)` would not measure its battery. The session
+cap bounds extra WoW consumption but is not a voltage cutoff or a substitute
+for cell protection. A cell already near empty can still discharge below
+the normal cutoff during that bounded session.
 
-First call in `setup()` (before reset-reason handling, NVS init, or any
-peripheral init; the tick path never touches NVS or the battery). Only acts
-when the wake cause is `ESP_SLEEP_WAKEUP_TIMER` and the `magic`/`armed`
-markers are valid — every other boot falls straight through.
+## Resources and GPIOs
 
-Per tick, in order:
+RTC state is an explicit 20-byte structure in `include/parameter.h`: magic,
+armed flag, consecutive failure count, tick count, baseline, threshold, and
+sleep interval. Arming resets both counters; the layout has a new magic.
+Transient setup flags are not retained. No cross-task state is introduced.
 
-1. Log tick count + boot frequency, then run at 20 MHz.
-2. Release `gpio_hold` on `SCALE_SCLK`, `SCALE_PDWN`, `SCALE_DOUT`,
-   `PWR_CTRL` only (per-pin first, then `gpio_deep_sleep_hold_dis()`);
-   OLED/I2C/secondary-scale/`ACC_PWR_CTRL` rails stay off and held.
-3. `PWR_CTRL` HIGH, settle 100 ms, then a local `ADS1232_ADC` object (fresh
-   after the full reset; `begin()` performs the PDWN reset pulse).
-4. Poll for the first DRDY at 10 SPS with a 900 ms timeout (measured on
-   hardware: first conversion arrives ~400 ms after rail power; the original
-   250 ms window never caught it).
-5. `powerDown()` the ADC.
+The micro-wake releases only primary `SCLK`, `PDWN`, `DOUT`, and `PWR_CTRL`
+holds. In builds without ESP-IDF power management, it runs at 20 MHz during
+polling and restores the boot CPU frequency on continuation into setup.
+PM-enabled builds, including the energy-menu build, leave frequency control
+to ESP-IDF. Changing the hardware clock directly would bypass its frequency
+and tick bookkeeping. Other per-pin holds stay in place.
+Before re-sleep it holds the primary clock and PDWN low, DOUT as input,
+and the main rail low, exactly as the normal sleep path does.
 
-Decision:
+The temporary ADS1232 uses polling mode only. Every constructed instance
+gets `powerDown()` followed by `end()` before either boot continuation or
+deep sleep. The pinned driver's `end()` deletes its synchronization resources
+without changing pin modes; no driver or dependency update is needed.
 
-- No sample within the timeout, or `dataOutOfRange` → back to sleep, retry
-  next tick (no false boots on ADC faults).
-- `|raw − baseline| <= threshold` → re-latch the four pins
-  (`PWR_CTRL` LOW + hold), re-assert EXT1 wake pins + the snapshotted
-  interval timer, `tickCount++`, `esp_deep_sleep_start()`.
-- `|raw − baseline| > threshold` → clear `armed`, restore the boot frequency,
-  log, and **return into the normal `setup()` flow** (OLED, BLE, boot tare).
-  `GPIO_power_on_with` stays -1 so BLE enables and the button-hold check is
-  skipped, as for a timer wake today. The normal boot tare then zeros
-  whatever was placed — same semantics as putting a cup on before pressing
-  the button.
+## Hardware Scope
 
-Measured idle behavior on the bench (empty scale, 4 s ticks): consecutive
-tick samples drift ~70-90 raw counts (~7-9 g equivalent at a ~1000 counts/g
-calibration) — thermal drift, comfortably under the 50 g threshold.
+Only **ESP32-S3 V8.1** has the PR's bench validation. Compilation remains
+under `ADS1232ADC`; that macro alone is not a hardware validation claim.
 
-## Behavior notes
+- V8.0 and V7.5 share the primary ADC pins 11/12/13, rail pin 3, and RTC
+  wake pins 1/2/10 with V8.1. Their pin maps support the same micro path,
+  but their electrical settling/current behavior has not been validated.
+- V7.4 uses primary pins 8/9/18 and wake pins 1/2/6, also compatible with
+  S3 digital holds and RTC inputs. Its secondary GPIO35 can conflict with
+  some PSRAM modules, an existing board/sleep constraint.
+- V7.3 and V7.2 have legacy missing secondary-scale/accessory macros in the
+  surrounding normal sleep implementation. V6/V5 lack the required power
+  and charging definitions. These legacy configurations cannot be certified
+  by enabling `ADS1232ADC`; no unrelated board repair is included here.
 
-- Charging: arming is allowed (plugging in still EXT1-wakes into a full
-  boot; a manual shutdown while charging may tick).
-- Low battery: never arms once `i_lowBatteryCount > 0`; the micro path never
-  reads the battery.
-- Uncalibrated scale: setting can be changed but nothing arms until the
-  scale is calibrated.
-- Each tick prints a short `[wow]` line on Serial before energy quieting
-  exists.
+GPIO3 is a strapping pin. Existing board pull/load assumptions are unchanged.
+Primary ADC pins need digital hold support, not RTC wake capability; only
+the buttons and charging inputs need RTC capability. Older compatible
+revisions are not unnecessarily disabled, but require board-level testing.
 
-## Power budget
+## Power Estimate
 
-Per tick ≈ 850 ms active at 20 MHz (below the PLL tiers the draw is
-dominated by the load-cell/ADC rail; measure on hardware) against the
-deep-sleep ~100 µA baseline (700 mAh cell). Rough estimates assuming
-~6 mA active:
+With the illustrative assumptions of 6 mA average **across the entire active
+window** and 0.1 mA asleep, `Iavg = duty * 6 + (1 - duty) * 0.1`:
 
-| Setting | Duty | Avg current | Standby |
-| --- | --- | --- | --- |
-| 2 s | ~43% | ~2.6 mA | ~11 days |
-| 3 s | ~28% | ~1.8 mA | ~16 days |
-| 4 s | ~21% | ~1.3 mA | ~22 days |
+| Sleep interval | Estimated average while WoW cycles |
+| --- | --- |
+| 2 s | 1.86 mA |
+| 3 s | 1.40 mA |
+| 4 s | 1.13 mA |
 
-Measure with a real ammeter or the USB Sleep Test before trusting these;
-they are estimates pending hardware confirmation.
+The startup part runs at the boot clock, not 20 MHz. PM-enabled builds also
+use their configured frequency policy during polling. The 6 mA assumption is
+not a measured whole-cycle current and may underestimate consumption.
+Continuous multi-day standby projections are inappropriate because of the
+900-tick cap. After fallback only ordinary deep-sleep consumption remains.
+Measure complete cycles with an ammeter, including startup and failed reads.
 
-## Related code
+## Verification
 
-- `include/wake_on_weight.h` — micro-wake, baseline capture, timer arming
-- `include/power.h` — `esp32_sleep()` arming hooks
-- `include/menu.h` — Power menu cycling row
-- `include/storage.h`, `include/parameter.h` — NVS key + globals
-- `tools/test_wake_on_weight_contract.py` — read-only source contract
+Run `python tools/test_wake_on_weight_contract.py` and
+`python tools/test_wake_on_weight_runtime.py`, then build `esp32s3` and
+`esp32s3-energy-menu`. Hardware follow-up should sweep normal button presses
+across startup, rail settling, ADC wait, and sleep handoff; check both buttons,
+charging insertion, ADC disconnect/recovery, session expiry, boot tare,
+resource cleanup, and whole-cycle current. WoW-off sleep must remain unchanged.

--- a/include/menu.h
+++ b/include/menu.h
@@ -552,7 +552,7 @@ void cycleWakeOnWeight() {
   const bool stored = storagePutInt(KEY_WOW_INTERVAL, next);
   if (stored) i_wow_interval = next;
   updateWakeOnWeightLabel();
-  static const char *const valueText[] = { "Off", "2s", "3s", "4s" };
+  static const char *const valueText[] = { "Off", "Sleep 2s", "Sleep 3s", "Sleep 4s" };
   actionMessage = stored ? "WakeOnWeight" : "Save Failed";
   actionMessage2 = stored ? valueText[next] : "WakeOnWeight";
   menuActionMessageChanged();

--- a/include/menu.h
+++ b/include/menu.h
@@ -95,6 +95,9 @@ void toggleBtnFuncWhileConnected();
 void toggleAutoSleep();
 void toggleQuickBoot();
 void cycleDriftComp();
+#ifdef ADS1232ADC
+void cycleWakeOnWeight();
+#endif
 void toggleTapTare();
 void toggleTapTimer();
 void refreshMenuRows();
@@ -140,6 +143,9 @@ char menuFlipScreenLabel[] = "Flip Screen o";
 char menuTimeOnTopLabel[] = "Top: Weight";
 char menuAutoSleepLabel[] = "Auto Sleep o";
 char menuQuickBootLabel[] = "Quick Boot o";
+#ifdef ADS1232ADC
+char menuWakeOnWeightLabel[20] = "Wake: Off";
+#endif
 #if HDS_FEATURE_WIFI
 char menuWifiLabel[] = "WiFi o";
 #endif
@@ -212,10 +218,16 @@ const Menu *const displayMenu[] = { &menuDisplayBack, &menuFlipScreen,
 const Menu menuPowerBack = { "Back", NULL, NULL, &menuPower };
 const Menu menuAutoSleep = { menuAutoSleepLabel, toggleAutoSleep, NULL, &menuPower };
 const Menu menuQuickBoot = { menuQuickBootLabel, toggleQuickBoot, NULL, &menuPower };
+#ifdef ADS1232ADC
+const Menu menuWakeOnWeight = { menuWakeOnWeightLabel, cycleWakeOnWeight, NULL, &menuPower };
+#endif
 #if HDS_ENABLE_ENERGY_MENU
 #include "energy_menu.h"
 #endif
 const Menu *const powerMenu[] = { &menuPowerBack, &menuAutoSleep, &menuQuickBoot,
+#ifdef ADS1232ADC
+                                  &menuWakeOnWeight,
+#endif
 #if HDS_ENABLE_ENERGY_MENU
                                   &menuEnergyOledRedraw, &menuEnergyOledIdle,
                                   &menuEnergyLightSleep,
@@ -524,6 +536,28 @@ void toggleQuickBoot() {
   toggleStoredBool(b_quickBoot, KEY_QUICK_BOOT, "Quick Boot",
                    menuQuickBootLabel);
 }
+
+#ifdef ADS1232ADC
+void updateWakeOnWeightLabel() {
+  static const char *const labels[] = { "Off", "0.5s", "1s", "2s" };
+  const uint8_t index = (i_wow_interval > 0 && i_wow_interval < WOW_INTERVAL_COUNT)
+                            ? i_wow_interval
+                            : 0;
+  snprintf(menuWakeOnWeightLabel, sizeof(menuWakeOnWeightLabel), "Wake: %s",
+           labels[index]);
+}
+
+void cycleWakeOnWeight() {
+  const int next = (i_wow_interval + 1) % WOW_INTERVAL_COUNT;
+  const bool stored = storagePutInt(KEY_WOW_INTERVAL, next);
+  if (stored) i_wow_interval = next;
+  updateWakeOnWeightLabel();
+  actionMessage = stored ? "Wake on" : "Save Failed";
+  actionMessage2 = stored ? String(menuWakeOnWeightLabel + 6) : "Wake on Weight";
+  menuActionMessageChanged();
+  t_actionMessageDelay = 1000;
+}
+#endif
 
 void cycleDriftComp() {
   constexpr float values[] = { 0.0f, 0.05f, 0.075f, 0.10f, 0.20f };
@@ -1570,6 +1604,9 @@ void refreshMenuRows() {
   updateToggleLabel(menuFlipScreenLabel, b_screenFlipped);
   updateToggleLabel(menuAutoSleepLabel, b_autoSleep);
   updateToggleLabel(menuQuickBootLabel, b_quickBoot);
+#ifdef ADS1232ADC
+  updateWakeOnWeightLabel();
+#endif
   updateToggleLabel(menuTapTareLabel, b_tapTareEnabled);
   updateToggleLabel(menuTapTimerLabel, b_tapTimerEnabled);
   snprintf(menuTimeOnTopLabel, sizeof(menuTimeOnTopLabel), "Top: %s",

--- a/include/menu.h
+++ b/include/menu.h
@@ -539,7 +539,7 @@ void toggleQuickBoot() {
 
 #ifdef ADS1232ADC
 void updateWakeOnWeightLabel() {
-  static const char *const labels[] = { "Off", "0.5s", "1s", "2s" };
+  static const char *const labels[] = { "Off", "2s", "3s", "4s" };
   const uint8_t index = (i_wow_interval > 0 && i_wow_interval < WOW_INTERVAL_COUNT)
                             ? i_wow_interval
                             : 0;

--- a/include/menu.h
+++ b/include/menu.h
@@ -144,7 +144,7 @@ char menuTimeOnTopLabel[] = "Top: Weight";
 char menuAutoSleepLabel[] = "Auto Sleep o";
 char menuQuickBootLabel[] = "Quick Boot o";
 #ifdef ADS1232ADC
-char menuWakeOnWeightLabel[20] = "Wake: Off";
+char menuWakeOnWeightLabel[24] = "WakeOnWeight o";
 #endif
 #if HDS_FEATURE_WIFI
 char menuWifiLabel[] = "WiFi o";
@@ -539,12 +539,12 @@ void toggleQuickBoot() {
 
 #ifdef ADS1232ADC
 void updateWakeOnWeightLabel() {
-  static const char *const labels[] = { "Off", "2s", "3s", "4s" };
+  static const char *const labels[] = { "o", "2", "3", "4" };
   const uint8_t index = (i_wow_interval > 0 && i_wow_interval < WOW_INTERVAL_COUNT)
                             ? i_wow_interval
                             : 0;
-  snprintf(menuWakeOnWeightLabel, sizeof(menuWakeOnWeightLabel), "Wake: %s",
-           labels[index]);
+  snprintf(menuWakeOnWeightLabel, sizeof(menuWakeOnWeightLabel),
+           "WakeOnWeight %s", labels[index]);
 }
 
 void cycleWakeOnWeight() {
@@ -552,8 +552,9 @@ void cycleWakeOnWeight() {
   const bool stored = storagePutInt(KEY_WOW_INTERVAL, next);
   if (stored) i_wow_interval = next;
   updateWakeOnWeightLabel();
-  actionMessage = stored ? "Wake on" : "Save Failed";
-  actionMessage2 = stored ? String(menuWakeOnWeightLabel + 6) : "Wake on Weight";
+  static const char *const valueText[] = { "Off", "2s", "3s", "4s" };
+  actionMessage = stored ? "WakeOnWeight" : "Save Failed";
+  actionMessage2 = stored ? valueText[next] : "WakeOnWeight";
   menuActionMessageChanged();
   t_actionMessageDelay = 1000;
 }

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -379,7 +379,7 @@ bool b_ads1115InitFail = true;  //ads1115 not detected flag
 volatile bool b_wifiOnBoot = false;
 volatile bool b_autoSleep = true;
 volatile bool b_quickBoot = false;
-int i_wow_interval = 0;  // Wake-on-Weight tick selection: 0=off 1=0.5s 2=1s 3=2s
+int i_wow_interval = 0;  // Wake-on-Weight: 0=off 1=2s 2=3s 3=4s
 unsigned int i_buttonBootDelay = 500;
 bool b_showChargingUI = false;
 #if HDS_ENABLE_GRINDER

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -379,6 +379,7 @@ bool b_ads1115InitFail = true;  //ads1115 not detected flag
 volatile bool b_wifiOnBoot = false;
 volatile bool b_autoSleep = true;
 volatile bool b_quickBoot = false;
+int i_wow_interval = 0;  // Wake-on-Weight tick selection: 0=off 1=0.5s 2=1s 3=2s
 unsigned int i_buttonBootDelay = 500;
 bool b_showChargingUI = false;
 #if HDS_ENABLE_GRINDER
@@ -574,6 +575,8 @@ int i_battery = 0;                          //电池充电循环变量
 int i_batteryRefreshTareInterval = 30 * 1000;  //Refresh battery every 30 seconds
 unsigned long t_batteryRefresh = 0;         //Battery refresh timestamp
 float f_batteryVoltage = 0;
+int i_lowBatteryCount = 0;
+int i_lowBatteryCountTotal = 0;
 #ifdef AVR
 float f_vref = 4.72;                  //5V pin true reading
 float f_true_battery_reading = 4.72;  //需测量usb vcc电压（不一定是usb，可以是电池电压）

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -379,7 +379,21 @@ bool b_ads1115InitFail = true;  //ads1115 not detected flag
 volatile bool b_wifiOnBoot = false;
 volatile bool b_autoSleep = true;
 volatile bool b_quickBoot = false;
-int i_wow_interval = 0;  // Wake-on-Weight: 0=off 1=2s 2=3s 3=4s
+int i_wow_interval = 0;
+#ifdef ADS1232ADC
+struct WowRtcState {
+  uint32_t magic;
+  uint8_t armed;
+  uint8_t consecutiveFailures;
+  uint16_t tickCount;
+  int32_t baselineRaw;
+  int32_t thresholdRaw;
+  uint32_t intervalUs;
+};
+RTC_DATA_ATTR WowRtcState wowRtc;
+bool wowTimerArmedThisBoot = false;
+bool wowButtonWake = false;
+#endif
 unsigned int i_buttonBootDelay = 500;
 bool b_showChargingUI = false;
 #if HDS_ENABLE_GRINDER

--- a/include/power.h
+++ b/include/power.h
@@ -115,6 +115,8 @@ void releaseWakePinsFromRtcMode() {
   rtc_gpio_deinit((gpio_num_t)BATTERY_CHARGING);
 }
 
+#include "wake_on_weight.h"
+
 void print_wakeup_reason() {
   esp_sleep_wakeup_cause_t wakeup_reason;
 
@@ -181,6 +183,7 @@ void esp32_sleep() {
   setEnergyIdleWakeEnabled(false);
   esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
 #endif
+  wowArmSleepTimer();
 #if HDS_ENABLE_GRINDER
   beforeDeepSleepFlush();
 #endif
@@ -200,6 +203,7 @@ void esp32_sleep() {
     mpu.enableSleep(true);
   }
 #endif
+  wowCaptureBaselineForSleep();
   scale.powerDown();
 #ifdef ESP32C3
   esp_deep_sleep_enable_gpio_wakeup(1 << GPIO_NUM_BUTTON_POWER, ESP_GPIO_WAKEUP_GPIO_LOW);
@@ -355,8 +359,6 @@ float getUsbVoltage(int usbPin) {
   return usbVoltage;
 }
 
-int i_lowBatteryCount = 0;
-int i_lowBatteryCountTotal = 0;
 bool processNewBatterySample() {
   if (!powerCadence.batterySamples.shouldEvaluate(powerCadence.batterySampleSequence)) {
     return false;

--- a/include/power.h
+++ b/include/power.h
@@ -183,7 +183,6 @@ void esp32_sleep() {
   setEnergyIdleWakeEnabled(false);
   esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
 #endif
-  wowArmSleepTimer();
 #if HDS_ENABLE_GRINDER
   beforeDeepSleepFlush();
 #endif
@@ -204,6 +203,7 @@ void esp32_sleep() {
   }
 #endif
   wowCaptureBaselineForSleep();
+  wowArmSleepTimer();
   scale.powerDown();
 #ifdef ESP32C3
   esp_deep_sleep_enable_gpio_wakeup(1 << GPIO_NUM_BUTTON_POWER, ESP_GPIO_WAKEUP_GPIO_LOW);

--- a/include/storage.h
+++ b/include/storage.h
@@ -27,6 +27,7 @@ constexpr const char *KEY_WIFI_BOOT = "wifi_boot";
 constexpr const char *KEY_AUTO_SLEEP = "auto_sleep";
 constexpr const char *KEY_QUICK_BOOT = "quick_boot";
 constexpr const char *KEY_DRIFT_MAX = "drift_max";
+constexpr const char *KEY_WOW_INTERVAL = "wow_interval";
 #if HDS_ENABLE_ENERGY_MENU
 constexpr const char *KEY_ENERGY_SCHEMA = "energy_schema";
 constexpr uint16_t ENERGY_SCHEMA_VERSION = 9;
@@ -178,7 +179,8 @@ inline bool storageHasAllSettings() {
     KEY_CAL1, KEY_CONTAINER, KEY_MODE, KEY_POUROVER, KEY_ESPRESSO,
     KEY_BEEP, KEY_WELCOME, KEY_BAT_CAL, KEY_HEARTBEAT, KEY_SCREEN_FLIP,
     KEY_TIME_ON_TOP, KEY_BTN_CONN, KEY_WIFI_BOOT, KEY_AUTO_SLEEP,
-    KEY_QUICK_BOOT, KEY_DRIFT_MAX, KEY_TAP_TARE, KEY_TAP_TIMER
+    KEY_QUICK_BOOT, KEY_DRIFT_MAX, KEY_TAP_TARE, KEY_TAP_TIMER,
+    KEY_WOW_INTERVAL
   };
   for (const char *key : keys) {
     if (!settingsPreferences.isKey(key)) {
@@ -206,7 +208,8 @@ inline bool storageEnsureDefaults() {
          storageEnsureBool(KEY_QUICK_BOOT, false) &&
          storageEnsureFloat(KEY_DRIFT_MAX, 0.05f) &&
          storageEnsureBool(KEY_TAP_TARE, false) &&
-         storageEnsureBool(KEY_TAP_TIMER, false);
+         storageEnsureBool(KEY_TAP_TIMER, false) &&
+         storageEnsureInt(KEY_WOW_INTERVAL, 0);
 }
 
 inline bool storageLegacyBool(size_t address, bool defaultValue) {
@@ -298,7 +301,8 @@ inline bool storageMigrateLegacyEeprom() {
                   storageEnsureBool(KEY_QUICK_BOOT, storageLegacyBool(LEGACY_QUICK_BOOT_ADDRESS, false)) &&
                   storageEnsureFloat(KEY_DRIFT_MAX, driftMax) &&
                   storageEnsureBool(KEY_TAP_TARE, false) &&
-                  storageEnsureBool(KEY_TAP_TIMER, false);
+                  storageEnsureBool(KEY_TAP_TIMER, false) &&
+                  storageEnsureInt(KEY_WOW_INTERVAL, 0);
   EEPROM.end();
   return migrated;
 }

--- a/include/wake_on_weight.h
+++ b/include/wake_on_weight.h
@@ -15,12 +15,12 @@
 #include "declare.h"
 
 const float WOW_TRIGGER_GRAMS = 50.0f;
-const unsigned long WOW_READ_TIMEOUT_MS = 250;
-const unsigned long WOW_RAIL_SETTLE_MS = 10;
+const unsigned long WOW_READ_TIMEOUT_MS = 900;
+const unsigned long WOW_RAIL_SETTLE_MS = 100;
 const int32_t WOW_MIN_THRESHOLD_RAW = 500;
 const uint32_t WOW_RTC_MAGIC = 0x574F5731;
 const uint8_t WOW_INTERVAL_COUNT = 4;
-const uint32_t wowIntervalUs[WOW_INTERVAL_COUNT] = { 0, 500000, 1000000, 2000000 };
+const uint64_t wowIntervalUs[WOW_INTERVAL_COUNT] = { 0, 2000000, 3000000, 4000000 };
 
 struct WowRtcState {
   uint32_t magic;
@@ -43,30 +43,42 @@ void wowCaptureBaselineForSleep() {
   wowRtc.armed = 1;
   wowRtc.baselineRaw = scale.getDebugInfo().smoothedValue;
   wowRtc.thresholdRaw =
-      max((int32_t)(WOW_TRIGGER_GRAMS * f_calibration_value + 0.5f),
+      max((int32_t)(WOW_TRIGGER_GRAMS * fabsf(f_calibration_value) + 0.5f),
           WOW_MIN_THRESHOLD_RAW);
   const uint8_t index =
-      (i_wow_interval > 0 && i_wow_interval < WOW_INTERVAL_COUNT) ? i_wow_interval : 0;
+      (i_wow_interval > 0 && i_wow_interval < WOW_INTERVAL_COUNT)
+          ? i_wow_interval
+          : 0;
   wowRtc.intervalUs = wowIntervalUs[index];
 }
+
+static bool wowTimerArmedThisBoot = false;
 
 void wowArmSleepTimer() {
   if (wowRtc.armed && wowRtc.intervalUs > 0) {
     esp_sleep_enable_timer_wakeup(wowRtc.intervalUs);
-  } else {
+    wowTimerArmedThisBoot = true;
+  } else if (wowTimerArmedThisBoot) {
     esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
+    wowTimerArmedThisBoot = false;
   }
 }
 
-static bool wowReadOneSample(ADS1232_ADC &adc, int32_t &rawSample) {
+static bool wowReadOneSample(ADS1232_ADC &adc, int32_t &rawSample,
+                             bool &outOfRange, unsigned long &elapsedMs) {
   const unsigned long startedAt = millis();
   while (millis() - startedAt < WOW_READ_TIMEOUT_MS) {
-    if (adc.update()) {
-      rawSample = adc.getDebugInfo().rawValue;
-      return true;
+    if (digitalRead(SCALE_DOUT) == LOW) {
+      if (adc.update()) {
+        elapsedMs = millis() - startedAt;
+        rawSample = adc.getDebugInfo().rawValue;
+        outOfRange = adc.getDebugInfo().dataOutOfRange;
+        return true;
+      }
     }
     delay(2);
   }
+  elapsedMs = millis() - startedAt;
   return false;
 }
 
@@ -85,10 +97,8 @@ static void wowLatchMicroPins() {
 void wowMicroWakeOrContinue() {
   if (esp_sleep_get_wakeup_cause() != ESP_SLEEP_WAKEUP_TIMER) return;
   if (wowRtc.magic != WOW_RTC_MAGIC || !wowRtc.armed) return;
-  Serial.printf("[wow] tick=%lu armed=1 interval=%lu us\n",
-                (unsigned long)wowRtc.tickCount,
-                (unsigned long)wowRtc.intervalUs);
-  setCpuFrequencyMhz(80);
+  const unsigned long bootFreqMhz = getCpuFrequencyMhz();
+  setCpuFrequencyMhz(20);
   gpio_hold_dis((gpio_num_t)SCALE_SCLK);
   gpio_hold_dis((gpio_num_t)SCALE_PDWN);
   gpio_hold_dis((gpio_num_t)SCALE_DOUT);
@@ -101,11 +111,14 @@ void wowMicroWakeOrContinue() {
 
   ADS1232_ADC wowAdc(SCALE_DOUT, SCALE_SCLK, SCALE_PDWN, SCALE_A0);
   wowAdc.begin();
+  bool outOfRange = false;
+  unsigned long elapsedMs = 0;
   int32_t rawSample = 0;
-  const bool gotSample = wowReadOneSample(wowAdc, rawSample);
+  const bool gotSample =
+      wowReadOneSample(wowAdc, rawSample, outOfRange, elapsedMs);
   wowAdc.powerDown();
 
-  if (gotSample && !wowAdc.getDebugInfo().dataOutOfRange) {
+  if (gotSample && !outOfRange) {
     const int32_t delta = rawSample > wowRtc.baselineRaw
                               ? rawSample - wowRtc.baselineRaw
                               : wowRtc.baselineRaw - rawSample;
@@ -115,11 +128,12 @@ void wowMicroWakeOrContinue() {
       wowRtc.armed = 0;
       Serial.printf("[wow] weight detected: delta=%ld > thresh=%ld, full boot\n",
                     (long)delta, (long)wowRtc.thresholdRaw);
+      setCpuFrequencyMhz(bootFreqMhz);
       return;
     }
-    Serial.printf("[wow] tick=%lu delta=%ld thresh=%ld\n",
-                  (unsigned long)wowRtc.tickCount, (long)delta,
-                  (long)wowRtc.thresholdRaw);
+    Serial.printf("[wow] tick=%lu raw=%ld delta=%ld thresh=%ld\n",
+                  (unsigned long)wowRtc.tickCount, (long)rawSample,
+                  (long)delta, (long)wowRtc.thresholdRaw);
   } else {
     Serial.printf("[wow] tick=%lu no reliable sample, retrying next tick\n",
                   (unsigned long)wowRtc.tickCount);

--- a/include/wake_on_weight.h
+++ b/include/wake_on_weight.h
@@ -1,0 +1,144 @@
+#ifndef WAKE_ON_WEIGHT_H
+#define WAKE_ON_WEIGHT_H
+
+#include <Arduino.h>
+#include "config.h"
+#include "parameter.h"
+#ifdef ESP32
+#include <esp_sleep.h>
+#include <driver/gpio.h>
+#include <driver/rtc_io.h>
+#endif
+
+#ifdef ADS1232ADC
+#include <ADS1232_ADC.h>
+#include "declare.h"
+
+const float WOW_TRIGGER_GRAMS = 50.0f;
+const unsigned long WOW_READ_TIMEOUT_MS = 250;
+const unsigned long WOW_RAIL_SETTLE_MS = 10;
+const int32_t WOW_MIN_THRESHOLD_RAW = 500;
+const uint32_t WOW_RTC_MAGIC = 0x574F5731;
+const uint8_t WOW_INTERVAL_COUNT = 4;
+const uint32_t wowIntervalUs[WOW_INTERVAL_COUNT] = { 0, 500000, 1000000, 2000000 };
+
+struct WowRtcState {
+  uint32_t magic;
+  uint8_t armed;
+  int32_t baselineRaw;
+  int32_t thresholdRaw;
+  uint32_t intervalUs;
+  uint32_t tickCount;
+  int32_t lastSampleRaw;
+  int32_t lastDeltaRaw;
+};
+RTC_DATA_ATTR WowRtcState wowRtc;
+
+void wowCaptureBaselineForSleep() {
+  wowRtc.armed = 0;
+  if (i_wow_interval <= 0 || i_lowBatteryCount > 0) return;
+  if (f_calibration_value == CALIBRATION_VALUE_DEFAULT) return;
+  if (scale.getDebugInfo().validSamples <= 0) return;
+  wowRtc.magic = WOW_RTC_MAGIC;
+  wowRtc.armed = 1;
+  wowRtc.baselineRaw = scale.getDebugInfo().smoothedValue;
+  wowRtc.thresholdRaw =
+      max((int32_t)(WOW_TRIGGER_GRAMS * f_calibration_value + 0.5f),
+          WOW_MIN_THRESHOLD_RAW);
+  const uint8_t index =
+      (i_wow_interval > 0 && i_wow_interval < WOW_INTERVAL_COUNT) ? i_wow_interval : 0;
+  wowRtc.intervalUs = wowIntervalUs[index];
+}
+
+void wowArmSleepTimer() {
+  if (wowRtc.armed && wowRtc.intervalUs > 0) {
+    esp_sleep_enable_timer_wakeup(wowRtc.intervalUs);
+  } else {
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
+  }
+}
+
+static bool wowReadOneSample(ADS1232_ADC &adc, int32_t &rawSample) {
+  const unsigned long startedAt = millis();
+  while (millis() - startedAt < WOW_READ_TIMEOUT_MS) {
+    if (adc.update()) {
+      rawSample = adc.getDebugInfo().rawValue;
+      return true;
+    }
+    delay(2);
+  }
+  return false;
+}
+
+static void wowLatchMicroPins() {
+  pinMode(SCALE_SCLK, OUTPUT); digitalWrite(SCALE_SCLK, LOW);
+  gpio_hold_en((gpio_num_t)SCALE_SCLK);
+  pinMode(SCALE_PDWN, OUTPUT); digitalWrite(SCALE_PDWN, LOW);
+  gpio_hold_en((gpio_num_t)SCALE_PDWN);
+  pinMode(SCALE_DOUT, INPUT);
+  gpio_hold_en((gpio_num_t)SCALE_DOUT);
+  digitalWrite(PWR_CTRL, LOW);
+  gpio_hold_en((gpio_num_t)PWR_CTRL);
+  gpio_deep_sleep_hold_en();
+}
+
+void wowMicroWakeOrContinue() {
+  if (esp_sleep_get_wakeup_cause() != ESP_SLEEP_WAKEUP_TIMER) return;
+  if (wowRtc.magic != WOW_RTC_MAGIC || !wowRtc.armed) return;
+  Serial.printf("[wow] tick=%lu armed=1 interval=%lu us\n",
+                (unsigned long)wowRtc.tickCount,
+                (unsigned long)wowRtc.intervalUs);
+  setCpuFrequencyMhz(80);
+  gpio_hold_dis((gpio_num_t)SCALE_SCLK);
+  gpio_hold_dis((gpio_num_t)SCALE_PDWN);
+  gpio_hold_dis((gpio_num_t)SCALE_DOUT);
+  gpio_hold_dis((gpio_num_t)PWR_CTRL);
+  gpio_deep_sleep_hold_dis();
+
+  pinMode(PWR_CTRL, OUTPUT);
+  digitalWrite(PWR_CTRL, HIGH);
+  delay(WOW_RAIL_SETTLE_MS);
+
+  ADS1232_ADC wowAdc(SCALE_DOUT, SCALE_SCLK, SCALE_PDWN, SCALE_A0);
+  wowAdc.begin();
+  int32_t rawSample = 0;
+  const bool gotSample = wowReadOneSample(wowAdc, rawSample);
+  wowAdc.powerDown();
+
+  if (gotSample && !wowAdc.getDebugInfo().dataOutOfRange) {
+    const int32_t delta = rawSample > wowRtc.baselineRaw
+                              ? rawSample - wowRtc.baselineRaw
+                              : wowRtc.baselineRaw - rawSample;
+    wowRtc.lastSampleRaw = rawSample;
+    wowRtc.lastDeltaRaw = delta;
+    if (delta > wowRtc.thresholdRaw) {
+      wowRtc.armed = 0;
+      Serial.printf("[wow] weight detected: delta=%ld > thresh=%ld, full boot\n",
+                    (long)delta, (long)wowRtc.thresholdRaw);
+      return;
+    }
+    Serial.printf("[wow] tick=%lu delta=%ld thresh=%ld\n",
+                  (unsigned long)wowRtc.tickCount, (long)delta,
+                  (long)wowRtc.thresholdRaw);
+  } else {
+    Serial.printf("[wow] tick=%lu no reliable sample, retrying next tick\n",
+                  (unsigned long)wowRtc.tickCount);
+  }
+
+  configureWakePinsForDeepSleep();
+  esp_sleep_enable_ext1_wakeup_io(PIN_BITMASK, ESP_EXT1_WAKEUP_ANY_LOW);
+  wowLatchMicroPins();
+  esp_sleep_enable_timer_wakeup(wowRtc.intervalUs);
+  wowRtc.tickCount++;
+  esp_deep_sleep_start();
+}
+
+#else  // !ADS1232ADC
+
+inline void wowCaptureBaselineForSleep() {}
+inline void wowArmSleepTimer() {}
+inline void wowMicroWakeOrContinue() {}
+
+#endif  // ADS1232ADC
+
+#endif  // WAKE_ON_WEIGHT_H

--- a/include/wake_on_weight.h
+++ b/include/wake_on_weight.h
@@ -18,41 +18,28 @@ const float WOW_TRIGGER_GRAMS = 50.0f;
 const unsigned long WOW_READ_TIMEOUT_MS = 900;
 const unsigned long WOW_RAIL_SETTLE_MS = 100;
 const int32_t WOW_MIN_THRESHOLD_RAW = 500;
-const uint32_t WOW_RTC_MAGIC = 0x574F5731;
+const uint32_t WOW_RTC_MAGIC = 0x574F5732;
+const uint16_t WOW_MAX_TICKS = 900;
+const uint8_t WOW_MAX_FAILURES = 5;
 const uint8_t WOW_INTERVAL_COUNT = 4;
 const uint64_t wowIntervalUs[WOW_INTERVAL_COUNT] = { 0, 2000000, 3000000, 4000000 };
 
-struct WowRtcState {
-  uint32_t magic;
-  uint8_t armed;
-  int32_t baselineRaw;
-  int32_t thresholdRaw;
-  uint32_t intervalUs;
-  uint32_t tickCount;
-  int32_t lastSampleRaw;
-  int32_t lastDeltaRaw;
-};
-RTC_DATA_ATTR WowRtcState wowRtc;
-
 void wowCaptureBaselineForSleep() {
   wowRtc.armed = 0;
-  if (i_wow_interval <= 0 || i_lowBatteryCount > 0) return;
+  if (i_wow_interval <= 0 || i_wow_interval >= WOW_INTERVAL_COUNT || i_lowBatteryCount > 0) return;
+  if (isfinite(f_batteryVoltage) && f_batteryVoltage > 0 && f_batteryVoltage < lowBatteryThreshold) return;
   if (f_calibration_value == CALIBRATION_VALUE_DEFAULT) return;
+  if (!isValidCalibrationValue(f_calibration_value)) return;
+  const float threshold = WOW_TRIGGER_GRAMS * fabsf(f_calibration_value);
   if (scale.getDebugInfo().validSamples <= 0) return;
   wowRtc.magic = WOW_RTC_MAGIC;
   wowRtc.armed = 1;
+  wowRtc.tickCount = 0;
+  wowRtc.consecutiveFailures = 0;
   wowRtc.baselineRaw = scale.getDebugInfo().smoothedValue;
-  wowRtc.thresholdRaw =
-      max((int32_t)(WOW_TRIGGER_GRAMS * fabsf(f_calibration_value) + 0.5f),
-          WOW_MIN_THRESHOLD_RAW);
-  const uint8_t index =
-      (i_wow_interval > 0 && i_wow_interval < WOW_INTERVAL_COUNT)
-          ? i_wow_interval
-          : 0;
-  wowRtc.intervalUs = wowIntervalUs[index];
+  wowRtc.thresholdRaw = max((int32_t)(threshold + 0.5f), WOW_MIN_THRESHOLD_RAW);
+  wowRtc.intervalUs = wowIntervalUs[i_wow_interval];
 }
-
-static bool wowTimerArmedThisBoot = false;
 
 void wowArmSleepTimer() {
   if (wowRtc.armed && wowRtc.intervalUs > 0) {
@@ -64,13 +51,32 @@ void wowArmSleepTimer() {
   }
 }
 
-static bool wowReadOneSample(ADS1232_ADC &adc, int32_t &rawSample,
-                             bool &outOfRange, unsigned long &elapsedMs) {
+static bool wowPhysicalWakeRequested() {
+  const int pin = rtc_gpio_get_level((gpio_num_t)BUTTON_SQUARE) == LOW ? BUTTON_SQUARE
+                  : rtc_gpio_get_level((gpio_num_t)BUTTON_CIRCLE) == LOW ? BUTTON_CIRCLE
+                  : rtc_gpio_get_level((gpio_num_t)BATTERY_CHARGING) == LOW ? BATTERY_CHARGING
+                  : -1;
+  if (pin < 0) return false;
+  GPIO_power_on_with = pin;
+  wowButtonWake = pin != BATTERY_CHARGING;
+  return true;
+}
+
+static bool wowWaitForRail() {
+  const unsigned long startedAt = millis();
+  while (millis() - startedAt < WOW_RAIL_SETTLE_MS) {
+    if (wowPhysicalWakeRequested()) return false;
+    delay(2);
+  }
+  return !wowPhysicalWakeRequested();
+}
+
+static bool wowReadOneSample(ADS1232_ADC &adc, int32_t &rawSample, bool &outOfRange) {
   const unsigned long startedAt = millis();
   while (millis() - startedAt < WOW_READ_TIMEOUT_MS) {
+    if (wowPhysicalWakeRequested()) return false;
     if (digitalRead(SCALE_DOUT) == LOW) {
       if (adc.update()) {
-        elapsedMs = millis() - startedAt;
         rawSample = adc.getDebugInfo().rawValue;
         outOfRange = adc.getDebugInfo().dataOutOfRange;
         return true;
@@ -78,7 +84,6 @@ static bool wowReadOneSample(ADS1232_ADC &adc, int32_t &rawSample,
     }
     delay(2);
   }
-  elapsedMs = millis() - startedAt;
   return false;
 }
 
@@ -94,11 +99,23 @@ static void wowLatchMicroPins() {
   gpio_deep_sleep_hold_en();
 }
 
+static void wowSetCpuFrequencyMhz(unsigned long frequencyMhz) {
+#ifdef CONFIG_PM_ENABLE
+  (void)frequencyMhz;
+#else
+  setCpuFrequencyMhz(frequencyMhz);
+#endif
+}
+
 void wowMicroWakeOrContinue() {
   if (esp_sleep_get_wakeup_cause() != ESP_SLEEP_WAKEUP_TIMER) return;
   if (wowRtc.magic != WOW_RTC_MAGIC || !wowRtc.armed) return;
+  if (wowPhysicalWakeRequested()) {
+    wowRtc.armed = 0;
+    return;
+  }
   const unsigned long bootFreqMhz = getCpuFrequencyMhz();
-  setCpuFrequencyMhz(20);
+  wowSetCpuFrequencyMhz(20);
   gpio_hold_dis((gpio_num_t)SCALE_SCLK);
   gpio_hold_dis((gpio_num_t)SCALE_PDWN);
   gpio_hold_dis((gpio_num_t)SCALE_DOUT);
@@ -107,43 +124,55 @@ void wowMicroWakeOrContinue() {
 
   pinMode(PWR_CTRL, OUTPUT);
   digitalWrite(PWR_CTRL, HIGH);
-  delay(WOW_RAIL_SETTLE_MS);
+  if (!wowWaitForRail()) {
+    wowRtc.armed = 0;
+    wowSetCpuFrequencyMhz(bootFreqMhz);
+    return;
+  }
 
   ADS1232_ADC wowAdc(SCALE_DOUT, SCALE_SCLK, SCALE_PDWN, SCALE_A0);
   wowAdc.begin();
   bool outOfRange = false;
-  unsigned long elapsedMs = 0;
   int32_t rawSample = 0;
   const bool gotSample =
-      wowReadOneSample(wowAdc, rawSample, outOfRange, elapsedMs);
+      wowReadOneSample(wowAdc, rawSample, outOfRange);
   wowAdc.powerDown();
+  wowAdc.end();
+
+  if (GPIO_power_on_with >= 0 || wowPhysicalWakeRequested()) {
+    wowRtc.armed = 0;
+    wowSetCpuFrequencyMhz(bootFreqMhz);
+    return;
+  }
 
   if (gotSample && !outOfRange) {
-    const int32_t delta = rawSample > wowRtc.baselineRaw
-                              ? rawSample - wowRtc.baselineRaw
-                              : wowRtc.baselineRaw - rawSample;
-    wowRtc.lastSampleRaw = rawSample;
-    wowRtc.lastDeltaRaw = delta;
+    wowRtc.consecutiveFailures = 0;
+    const int64_t delta = rawSample > wowRtc.baselineRaw
+                              ? (int64_t)rawSample - wowRtc.baselineRaw
+                              : (int64_t)wowRtc.baselineRaw - rawSample;
     if (delta > wowRtc.thresholdRaw) {
       wowRtc.armed = 0;
-      Serial.printf("[wow] weight detected: delta=%ld > thresh=%ld, full boot\n",
-                    (long)delta, (long)wowRtc.thresholdRaw);
-      setCpuFrequencyMhz(bootFreqMhz);
+      wowSetCpuFrequencyMhz(bootFreqMhz);
       return;
     }
-    Serial.printf("[wow] tick=%lu raw=%ld delta=%ld thresh=%ld\n",
-                  (unsigned long)wowRtc.tickCount, (long)rawSample,
-                  (long)delta, (long)wowRtc.thresholdRaw);
   } else {
-    Serial.printf("[wow] tick=%lu no reliable sample, retrying next tick\n",
-                  (unsigned long)wowRtc.tickCount);
+    wowRtc.consecutiveFailures++;
+  }
+
+  wowRtc.tickCount++;
+  if (wowRtc.consecutiveFailures >= WOW_MAX_FAILURES || wowRtc.tickCount >= WOW_MAX_TICKS) {
+    wowRtc.armed = 0;
   }
 
   configureWakePinsForDeepSleep();
   esp_sleep_enable_ext1_wakeup_io(PIN_BITMASK, ESP_EXT1_WAKEUP_ANY_LOW);
+  if (wowPhysicalWakeRequested()) {
+    wowRtc.armed = 0;
+    wowSetCpuFrequencyMhz(bootFreqMhz);
+    return;
+  }
   wowLatchMicroPins();
-  esp_sleep_enable_timer_wakeup(wowRtc.intervalUs);
-  wowRtc.tickCount++;
+  if (wowRtc.armed) esp_sleep_enable_timer_wakeup(wowRtc.intervalUs);
   esp_deep_sleep_start();
 }
 

--- a/include/wake_on_weight.h
+++ b/include/wake_on_weight.h
@@ -31,12 +31,13 @@ void wowCaptureBaselineForSleep() {
   if (f_calibration_value == CALIBRATION_VALUE_DEFAULT) return;
   if (!isValidCalibrationValue(f_calibration_value)) return;
   const float threshold = WOW_TRIGGER_GRAMS * fabsf(f_calibration_value);
-  if (scale.getDebugInfo().validSamples <= 0) return;
+  const auto info = scale.getDebugInfo();
+  if (info.validSamples <= 0 || info.dataOutOfRange || info.signalTimeout) return;
   wowRtc.magic = WOW_RTC_MAGIC;
   wowRtc.armed = 1;
   wowRtc.tickCount = 0;
   wowRtc.consecutiveFailures = 0;
-  wowRtc.baselineRaw = scale.getDebugInfo().smoothedValue;
+  wowRtc.baselineRaw = info.smoothedValue;
   wowRtc.thresholdRaw = max((int32_t)(threshold + 0.5f), WOW_MIN_THRESHOLD_RAW);
   wowRtc.intervalUs = wowIntervalUs[i_wow_interval];
 }

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -769,13 +769,13 @@ void beforeDeepSleepFlush() {
 #endif
 
 void setup() {
+  wowMicroWakeOrContinue();
 #if HDS_ENABLE_ENERGY_MENU
   energyIdle.mainTask = xTaskGetCurrentTaskHandle();
 #endif
   Serial.begin(115200);
   while (!Serial)
     ;
-  wowMicroWakeOrContinue();
   {
     esp_reset_reason_t r = esp_reset_reason();
     g_resetReasonCode = (uint8_t)r;
@@ -850,6 +850,9 @@ void setup() {
     b_ble_enabled = true;
   }
   while (true && GPIO_power_on_with > 0) {
+#ifdef ADS1232ADC
+    if (wowButtonWake) break;
+#endif
     if (i_buttonBootDelay == 0){
       Serial.println("Quick boot. Powering on...");
       break;

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -775,6 +775,7 @@ void setup() {
   Serial.begin(115200);
   while (!Serial)
     ;
+  wowMicroWakeOrContinue();
   {
     esp_reset_reason_t r = esp_reset_reason();
     g_resetReasonCode = (uint8_t)r;
@@ -811,6 +812,7 @@ void setup() {
 
   b_quickBoot = storageGetBool(KEY_QUICK_BOOT, false);
   i_buttonBootDelay = b_quickBoot ? 0 : 500;
+  i_wow_interval = storageGetInt(KEY_WOW_INTERVAL, 0);
 
   Serial.println("NVS settings init success");
 

--- a/tools/test_wake_on_weight_contract.py
+++ b/tools/test_wake_on_weight_contract.py
@@ -1,4 +1,3 @@
-import re
 import unittest
 from pathlib import Path
 
@@ -32,8 +31,13 @@ class WakeOnWeightContractTests(unittest.TestCase):
     def test_feature_header_exists_with_rtc_state(self):
         self.assertIn("RTC_DATA_ATTR", WOW)
         self.assertIn("WOW_RTC_MAGIC", WOW)
-        self.assertIn("wowIntervalUs", WOW)
         self.assertIn("WOW_TRIGGER_GRAMS", WOW)
+        self.assertIn("WOW_INTERVAL_COUNT", WOW)
+        self.assertIn("2000000", WOW)
+        self.assertIn("3000000", WOW)
+        self.assertIn("4000000", WOW)
+        self.assertNotIn("500000", WOW)
+        self.assertNotIn("1000000", WOW)
 
     def test_micro_wake_uses_timer_wakeup_apis(self):
         self.assertIn("esp_sleep_enable_timer_wakeup", WOW)
@@ -41,12 +45,12 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER)", WOW)
         self.assertIn("esp_deep_sleep_start", WOW)
 
-    def test_micro_wake_restores_80mhz_clock(self):
-        self.assertIn("setCpuFrequencyMhz(80)", WOW)
+    def test_micro_wake_downclocks_to_minimum_clock(self):
+        self.assertIn("setCpuFrequencyMhz(20)", WOW)
+        self.assertNotIn("setCpuFrequencyMhz(80)", WOW)
         self.assertNotIn("setCpuFrequencyMhz(240)", WOW)
-        self.assertNotIn(" 240", WOW.replace("0x", ""))
 
-    def test_feature_never_touches_nvs_or_battery_in_micro_path(self):
+    def test_micro_wake_never_touches_nvs_or_battery(self):
         self.assertNotIn("storageGet", WOW)
         self.assertNotIn("Preferences", WOW)
         self.assertNotIn("analogRead", WOW)
@@ -68,6 +72,8 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("wowCaptureBaselineForSleep();", POWER)
         self.assertIn("wowArmSleepTimer();", POWER)
         self.assertLess(POWER.index("wowCaptureBaselineForSleep();"),
+                        POWER.index("wowArmSleepTimer();"))
+        self.assertLess(POWER.index("wowArmSleepTimer();"),
                         POWER.index("scale.powerDown();"))
         self.assertLess(POWER.index("esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER)"),
                         POWER.index("wowArmSleepTimer();"))
@@ -85,9 +91,13 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("CALIBRATION_VALUE_DEFAULT", baseline)
         self.assertIn("validSamples <= 0", baseline)
         self.assertIn("smoothedValue", baseline)
+        self.assertIn("fabsf(f_calibration_value)", baseline)
+        self.assertIn("wowRtc.intervalUs = wowIntervalUs", baseline)
 
     def test_micro_wakeup_gates(self):
         micro = body(WOW_ADS, "void wowMicroWakeOrContinue()")
+        self.assertIn("getCpuFrequencyMhz()", micro)
+        self.assertIn("setCpuFrequencyMhz(bootFreqMhz)", micro)
         self.assertIn("ESP_SLEEP_WAKEUP_TIMER", micro)
         self.assertIn("WOW_RTC_MAGIC", micro)
         self.assertIn("gpio_hold_dis", micro)
@@ -95,8 +105,8 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("digitalWrite(PWR_CTRL, HIGH)", micro)
         self.assertIn("wowAdc.begin()", micro)
         self.assertIn("wowAdc.powerDown()", micro)
-        self.assertIn("dataOutOfRange", micro)
-        self.assertIn("wowRtc.intervalUs", micro)
+        self.assertIn("!outOfRange", micro)
+        self.assertIn("esp_sleep_enable_timer_wakeup(wowRtc.intervalUs)", micro)
 
     def test_boot_interceptor_slots_in_setup(self):
         self.assertLess(FIRMWARE.index("wowMicroWakeOrContinue();"),
@@ -105,8 +115,6 @@ class WakeOnWeightContractTests(unittest.TestCase):
                         FIRMWARE.index("pinMode(PWR_CTRL, OUTPUT)"))
         self.assertLess(FIRMWARE.index("storageGetInt(KEY_WOW_INTERVAL, 0)"),
                         FIRMWARE.index("esp32_sleep();"))
-
-    def test_setting_loaded_before_any_sleep_path(self):
         self.assertLess(FIRMWARE.index("i_wow_interval = storageGetInt(KEY_WOW_INTERVAL, 0)"),
                         FIRMWARE.index("releaseWakePinsFromRtcMode();"))
 
@@ -118,7 +126,6 @@ class WakeOnWeightContractTests(unittest.TestCase):
 
     def test_menu_row_and_cycle_action(self):
         self.assertIn("menuWakeOnWeight", MENU)
-        self.assertIn("\"Wake: Off\"", MENU)
         self.assertIn("menuWakeOnWeightLabel, cycleWakeOnWeight, NULL, &menuPower", MENU)
         self.assertIn("&menuWakeOnWeight", body(MENU, "powerMenu[]"))
         cycle = body(MENU, "void cycleWakeOnWeight()")
@@ -126,6 +133,14 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("storagePutInt(KEY_WOW_INTERVAL, next)", cycle)
         self.assertIn("i_wow_interval = next", cycle)
         self.assertIn("updateWakeOnWeightLabel()", cycle)
+
+    def test_menu_label_uses_cycle_pattern(self):
+        self.assertIn("char menuWakeOnWeightLabel[20] = \"Wake: Off\"", MENU)
+        labels = body(MENU, "void updateWakeOnWeightLabel()")
+        self.assertIn("\"Off\"", labels)
+        self.assertIn("\"2s\"", labels)
+        self.assertIn("\"3s\"", labels)
+        self.assertIn("\"4s\"", labels)
 
     def test_refresh_menu_rows_updates_label(self):
         refresh = body(MENU, "void refreshMenuRows()")
@@ -144,8 +159,9 @@ class WakeOnWeightContractTests(unittest.TestCase):
     def test_docs_state_machine(self):
         self.assertIn("10 SPS", DOCS)
         self.assertIn("50 g", DOCS)
-        self.assertIn("0.5 s", DOCS)
         self.assertIn("2 s", DOCS)
+        self.assertIn("3 s", DOCS)
+        self.assertIn("4 s", DOCS)
         self.assertIn("defaults to off", DOCS)
 
 

--- a/tools/test_wake_on_weight_contract.py
+++ b/tools/test_wake_on_weight_contract.py
@@ -1,0 +1,153 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WOW = (ROOT / "include" / "wake_on_weight.h").read_text(encoding="utf-8")
+POWER = (ROOT / "include" / "power.h").read_text(encoding="utf-8")
+STORAGE = (ROOT / "include" / "storage.h").read_text(encoding="utf-8")
+MENU = (ROOT / "include" / "menu.h").read_text(encoding="utf-8")
+PARAMETER = (ROOT / "include" / "parameter.h").read_text(encoding="utf-8")
+FIRMWARE = (ROOT / "src" / "hds.ino").read_text(encoding="utf-8")
+DOCS = (ROOT / "docs" / "wake-on-weight.md").read_text(encoding="utf-8")
+WOW_ADS = WOW[:WOW.index("#else")]
+
+
+def body(source, signature):
+    start = source.rindex(signature)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1:index]
+    raise AssertionError(signature)
+
+
+class WakeOnWeightContractTests(unittest.TestCase):
+    def test_feature_header_exists_with_rtc_state(self):
+        self.assertIn("RTC_DATA_ATTR", WOW)
+        self.assertIn("WOW_RTC_MAGIC", WOW)
+        self.assertIn("wowIntervalUs", WOW)
+        self.assertIn("WOW_TRIGGER_GRAMS", WOW)
+
+    def test_micro_wake_uses_timer_wakeup_apis(self):
+        self.assertIn("esp_sleep_enable_timer_wakeup", WOW)
+        self.assertIn("esp_sleep_get_wakeup_cause", WOW)
+        self.assertIn("esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER)", WOW)
+        self.assertIn("esp_deep_sleep_start", WOW)
+
+    def test_micro_wake_restores_80mhz_clock(self):
+        self.assertIn("setCpuFrequencyMhz(80)", WOW)
+        self.assertNotIn("setCpuFrequencyMhz(240)", WOW)
+        self.assertNotIn(" 240", WOW.replace("0x", ""))
+
+    def test_feature_never_touches_nvs_or_battery_in_micro_path(self):
+        self.assertNotIn("storageGet", WOW)
+        self.assertNotIn("Preferences", WOW)
+        self.assertNotIn("analogRead", WOW)
+        self.assertNotIn("ADS1115", WOW)
+
+    def test_micro_path_stays_in_polling_mode(self):
+        self.assertNotIn("beginTask", WOW)
+
+    def test_no_marketing_language(self):
+        self.assertNotIn("premium", WOW.lower())
+
+    def test_rtc_attribute_lives_only_in_wow_header(self):
+        for name, text in (("power.h", POWER), ("parameter.h", PARAMETER),
+                           ("menu.h", MENU), ("hds.ino", FIRMWARE),
+                           ("storage.h", STORAGE)):
+            self.assertNotIn("RTC_DATA_ATTR", text, name)
+
+    def test_sleep_chain_order_in_power_h(self):
+        self.assertIn("wowCaptureBaselineForSleep();", POWER)
+        self.assertIn("wowArmSleepTimer();", POWER)
+        self.assertLess(POWER.index("wowCaptureBaselineForSleep();"),
+                        POWER.index("scale.powerDown();"))
+        self.assertLess(POWER.index("esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER)"),
+                        POWER.index("wowArmSleepTimer();"))
+        self.assertLess(POWER.index("wowArmSleepTimer();"),
+                        POWER.index("esp_sleep_enable_ext1_wakeup_io"))
+
+    def test_exactly_two_deep_sleep_call_sites(self):
+        for name, text in (("POWER", POWER), ("WOW", WOW)):
+            self.assertEqual(text.count("esp_deep_sleep_start()"), 1, name)
+
+    def test_baseline_capture_gates(self):
+        baseline = body(WOW_ADS, "void wowCaptureBaselineForSleep()")
+        self.assertIn("i_wow_interval <= 0", baseline)
+        self.assertIn("i_lowBatteryCount > 0", baseline)
+        self.assertIn("CALIBRATION_VALUE_DEFAULT", baseline)
+        self.assertIn("validSamples <= 0", baseline)
+        self.assertIn("smoothedValue", baseline)
+
+    def test_micro_wakeup_gates(self):
+        micro = body(WOW_ADS, "void wowMicroWakeOrContinue()")
+        self.assertIn("ESP_SLEEP_WAKEUP_TIMER", micro)
+        self.assertIn("WOW_RTC_MAGIC", micro)
+        self.assertIn("gpio_hold_dis", micro)
+        self.assertIn("gpio_deep_sleep_hold_dis()", micro)
+        self.assertIn("digitalWrite(PWR_CTRL, HIGH)", micro)
+        self.assertIn("wowAdc.begin()", micro)
+        self.assertIn("wowAdc.powerDown()", micro)
+        self.assertIn("dataOutOfRange", micro)
+        self.assertIn("wowRtc.intervalUs", micro)
+
+    def test_boot_interceptor_slots_in_setup(self):
+        self.assertLess(FIRMWARE.index("wowMicroWakeOrContinue();"),
+                        FIRMWARE.index("storageInit()"))
+        self.assertLess(FIRMWARE.index("wowMicroWakeOrContinue();"),
+                        FIRMWARE.index("pinMode(PWR_CTRL, OUTPUT)"))
+        self.assertLess(FIRMWARE.index("storageGetInt(KEY_WOW_INTERVAL, 0)"),
+                        FIRMWARE.index("esp32_sleep();"))
+
+    def test_setting_loaded_before_any_sleep_path(self):
+        self.assertLess(FIRMWARE.index("i_wow_interval = storageGetInt(KEY_WOW_INTERVAL, 0)"),
+                        FIRMWARE.index("releaseWakePinsFromRtcMode();"))
+
+    def test_storage_key_in_all_three_paths(self):
+        self.assertIn("KEY_WOW_INTERVAL = \"wow_interval\"", STORAGE)
+        self.assertIn("KEY_WOW_INTERVAL", body(STORAGE, "bool storageHasAllSettings()"))
+        self.assertIn("KEY_WOW_INTERVAL", body(STORAGE, "bool storageEnsureDefaults()"))
+        self.assertIn("KEY_WOW_INTERVAL", body(STORAGE, "bool storageMigrateLegacyEeprom()"))
+
+    def test_menu_row_and_cycle_action(self):
+        self.assertIn("menuWakeOnWeight", MENU)
+        self.assertIn("\"Wake: Off\"", MENU)
+        self.assertIn("menuWakeOnWeightLabel, cycleWakeOnWeight, NULL, &menuPower", MENU)
+        self.assertIn("&menuWakeOnWeight", body(MENU, "powerMenu[]"))
+        cycle = body(MENU, "void cycleWakeOnWeight()")
+        self.assertIn("WOW_INTERVAL_COUNT", cycle)
+        self.assertIn("storagePutInt(KEY_WOW_INTERVAL, next)", cycle)
+        self.assertIn("i_wow_interval = next", cycle)
+        self.assertIn("updateWakeOnWeightLabel()", cycle)
+
+    def test_refresh_menu_rows_updates_label(self):
+        refresh = body(MENU, "void refreshMenuRows()")
+        self.assertIn("updateWakeOnWeightLabel()", refresh)
+
+    def test_globals_live_in_parameter_h(self):
+        self.assertIn("int i_wow_interval = 0", PARAMETER)
+        self.assertIn("int i_lowBatteryCount = 0", PARAMETER)
+        self.assertIn("int i_lowBatteryCountTotal = 0", PARAMETER)
+
+    def test_low_battery_increment_stays_in_power_h(self):
+        sample = POWER[POWER.index("bool processNewBatterySample()"):]
+        self.assertIn("i_lowBatteryCount++;", sample)
+        self.assertIn("EnergyRuntimePolicy::lowBatteryConfirmed(i_lowBatteryCount)", sample)
+
+    def test_docs_state_machine(self):
+        self.assertIn("10 SPS", DOCS)
+        self.assertIn("50 g", DOCS)
+        self.assertIn("0.5 s", DOCS)
+        self.assertIn("2 s", DOCS)
+        self.assertIn("defaults to off", DOCS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_wake_on_weight_contract.py
+++ b/tools/test_wake_on_weight_contract.py
@@ -10,7 +10,7 @@ MENU = (ROOT / "include" / "menu.h").read_text(encoding="utf-8")
 PARAMETER = (ROOT / "include" / "parameter.h").read_text(encoding="utf-8")
 FIRMWARE = (ROOT / "src" / "hds.ino").read_text(encoding="utf-8")
 DOCS = (ROOT / "docs" / "wake-on-weight.md").read_text(encoding="utf-8")
-WOW_ADS = WOW[:WOW.index("#else")]
+WOW_ADS = WOW[:WOW.index("#else  // !ADS1232ADC")]
 
 
 def body(source, signature):
@@ -29,7 +29,7 @@ def body(source, signature):
 
 class WakeOnWeightContractTests(unittest.TestCase):
     def test_feature_header_exists_with_rtc_state(self):
-        self.assertIn("RTC_DATA_ATTR", WOW)
+        self.assertIn("RTC_DATA_ATTR WowRtcState wowRtc", PARAMETER)
         self.assertIn("WOW_RTC_MAGIC", WOW)
         self.assertIn("WOW_TRIGGER_GRAMS", WOW)
         self.assertIn("WOW_INTERVAL_COUNT", WOW)
@@ -46,9 +46,12 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("esp_deep_sleep_start", WOW)
 
     def test_micro_wake_downclocks_to_minimum_clock(self):
-        self.assertIn("setCpuFrequencyMhz(20)", WOW)
+        self.assertIn("wowSetCpuFrequencyMhz(20)", WOW)
         self.assertNotIn("setCpuFrequencyMhz(80)", WOW)
         self.assertNotIn("setCpuFrequencyMhz(240)", WOW)
+        clock = body(WOW_ADS, "static void wowSetCpuFrequencyMhz(")
+        self.assertIn("#ifdef CONFIG_PM_ENABLE", clock)
+        self.assertNotIn("setCpuFrequencyMhz(", clock[:clock.index("#else")])
 
     def test_micro_wake_never_touches_nvs_or_battery(self):
         self.assertNotIn("storageGet", WOW)
@@ -62,8 +65,8 @@ class WakeOnWeightContractTests(unittest.TestCase):
     def test_no_marketing_language(self):
         self.assertNotIn("premium", WOW.lower())
 
-    def test_rtc_attribute_lives_only_in_wow_header(self):
-        for name, text in (("power.h", POWER), ("parameter.h", PARAMETER),
+    def test_rtc_attribute_lives_only_in_parameter_header(self):
+        for name, text in (("power.h", POWER), ("wake_on_weight.h", WOW),
                            ("menu.h", MENU), ("hds.ino", FIRMWARE),
                            ("storage.h", STORAGE)):
             self.assertNotIn("RTC_DATA_ATTR", text, name)
@@ -97,7 +100,7 @@ class WakeOnWeightContractTests(unittest.TestCase):
     def test_micro_wakeup_gates(self):
         micro = body(WOW_ADS, "void wowMicroWakeOrContinue()")
         self.assertIn("getCpuFrequencyMhz()", micro)
-        self.assertIn("setCpuFrequencyMhz(bootFreqMhz)", micro)
+        self.assertIn("wowSetCpuFrequencyMhz(bootFreqMhz)", micro)
         self.assertIn("ESP_SLEEP_WAKEUP_TIMER", micro)
         self.assertIn("WOW_RTC_MAGIC", micro)
         self.assertIn("gpio_hold_dis", micro)
@@ -109,6 +112,8 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("esp_sleep_enable_timer_wakeup(wowRtc.intervalUs)", micro)
 
     def test_boot_interceptor_slots_in_setup(self):
+        setup = body(FIRMWARE, "void setup()")
+        self.assertLess(setup.index("wowMicroWakeOrContinue();"), setup.index("Serial.begin"))
         self.assertLess(FIRMWARE.index("wowMicroWakeOrContinue();"),
                         FIRMWARE.index("storageInit()"))
         self.assertLess(FIRMWARE.index("wowMicroWakeOrContinue();"),
@@ -163,6 +168,29 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("3 s", DOCS)
         self.assertIn("4 s", DOCS)
         self.assertIn("defaults to off", DOCS)
+
+    def test_button_polling_and_latched_boot(self):
+        for signature in ("static bool wowWaitForRail()", "static bool wowReadOneSample("):
+            self.assertIn("wowPhysicalWakeRequested()", body(WOW_ADS, signature))
+        micro = body(WOW_ADS, "void wowMicroWakeOrContinue()")
+        self.assertGreaterEqual(micro.count("wowPhysicalWakeRequested()"), 3)
+        self.assertIn("rtc_gpio_get_level", WOW)
+        self.assertIn("if (wowButtonWake) break;", body(FIRMWARE, "void setup()"))
+        self.assertNotIn("Serial.", WOW)
+
+    def test_adc_cleanup_precedes_decision(self):
+        micro = body(WOW_ADS, "void wowMicroWakeOrContinue()")
+        self.assertLess(micro.index("wowAdc.powerDown()"), micro.index("wowAdc.end()"))
+        self.assertLess(micro.index("wowAdc.end()"), micro.index("if (gotSample"))
+
+    def test_session_fallbacks_and_sleep_interval(self):
+        self.assertIn("WOW_MAX_TICKS = 900", WOW)
+        self.assertIn("WOW_MAX_FAILURES = 5", WOW)
+        self.assertIn("wowRtc.consecutiveFailures = 0", WOW)
+        self.assertIn("if (wowRtc.armed) esp_sleep_enable_timer_wakeup", WOW)
+        self.assertIn('"Sleep 2s", "Sleep 3s", "Sleep 4s"', MENU)
+        self.assertIn("sleep intervals", DOCS)
+        self.assertIn("900-tick", DOCS)
 
 
 if __name__ == "__main__":

--- a/tools/test_wake_on_weight_contract.py
+++ b/tools/test_wake_on_weight_contract.py
@@ -135,12 +135,12 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("updateWakeOnWeightLabel()", cycle)
 
     def test_menu_label_uses_cycle_pattern(self):
-        self.assertIn("char menuWakeOnWeightLabel[20] = \"Wake: Off\"", MENU)
+        self.assertIn("char menuWakeOnWeightLabel[24] = \"WakeOnWeight o\"", MENU)
         labels = body(MENU, "void updateWakeOnWeightLabel()")
-        self.assertIn("\"Off\"", labels)
-        self.assertIn("\"2s\"", labels)
-        self.assertIn("\"3s\"", labels)
-        self.assertIn("\"4s\"", labels)
+        self.assertIn("\"o\"", labels)
+        self.assertIn("\"2\"", labels)
+        self.assertIn("\"3\"", labels)
+        self.assertIn("\"4\"", labels)
 
     def test_refresh_menu_rows_updates_label(self):
         refresh = body(MENU, "void refreshMenuRows()")

--- a/tools/test_wake_on_weight_contract.py
+++ b/tools/test_wake_on_weight_contract.py
@@ -97,6 +97,16 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertIn("fabsf(f_calibration_value)", baseline)
         self.assertIn("wowRtc.intervalUs = wowIntervalUs", baseline)
 
+    def test_baseline_rejects_invalid_snapshot_before_arming(self):
+        baseline = body(WOW_ADS, "void wowCaptureBaselineForSleep()")
+        guard = "if (info.validSamples <= 0 || info.dataOutOfRange || info.signalTimeout) return;"
+        self.assertEqual(baseline.count("scale.getDebugInfo()"), 1)
+        self.assertIn("const auto info = scale.getDebugInfo();", baseline)
+        self.assertIn("wowRtc.baselineRaw = info.smoothedValue;", baseline)
+        self.assertLess(baseline.index("wowRtc.armed = 0;"), baseline.index(guard))
+        self.assertLess(baseline.index(guard), baseline.index("wowRtc.armed = 1;"))
+        self.assertLess(baseline.index(guard), baseline.index("wowRtc.baselineRaw ="))
+
     def test_micro_wakeup_gates(self):
         micro = body(WOW_ADS, "void wowMicroWakeOrContinue()")
         self.assertIn("getCpuFrequencyMhz()", micro)

--- a/tools/test_wake_on_weight_runtime.py
+++ b/tools/test_wake_on_weight_runtime.py
@@ -43,8 +43,9 @@ struct DebugInfo {
   int32_t smoothedValue = 1000;
   int32_t rawValue = 1000;
   bool dataOutOfRange = false;
+  bool signalTimeout = false;
 };
-struct Scale { DebugInfo getDebugInfo() { return {}; } } scale;
+struct Scale { DebugInfo info; DebugInfo getDebugInfo() { return info; } } scale;
 unsigned long millis() { return nowMs; }
 void delay(unsigned long ms) { nowMs += ms; }
 unsigned long getCpuFrequencyMhz() { return cpuMhz; }
@@ -111,6 +112,17 @@ bool tick() {
 void arm() { wowCaptureBaselineForSleep(); assert(wowRtc.armed); }
 int main() {
   static_assert(sizeof(WowRtcState) == 20);
+  for (bool outOfRange : {false, true}) {
+    for (bool timeout : {false, true}) {
+      resetBoot(); arm();
+      scale.info.dataOutOfRange = outOfRange;
+      scale.info.signalTimeout = timeout;
+      wowCaptureBaselineForSleep();
+      assert(bool(wowRtc.armed) == (!outOfRange && !timeout));
+      scale.info = {};
+      arm();
+    }
+  }
   for (bool missing : {false, true}) {
     for (int pin : {BUTTON_CIRCLE, BUTTON_SQUARE, BATTERY_CHARGING}) {
       for (unsigned long start = 0; start <= (missing ? 998UL : 500UL); start += 2) {

--- a/tools/test_wake_on_weight_runtime.py
+++ b/tools/test_wake_on_weight_runtime.py
@@ -1,0 +1,209 @@
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+HARNESS = r"""
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <climits>
+#include <cstdio>
+#include "calibration_validation.h"
+using std::max;
+using std::isfinite;
+#define ADS1232ADC
+#define RTC_DATA_ATTR
+constexpr int LOW = 0, HIGH = 1, INPUT = 0, OUTPUT = 1;
+constexpr int BUTTON_CIRCLE = 1, BUTTON_SQUARE = 2, BATTERY_CHARGING = 10;
+constexpr int SCALE_DOUT = 11, SCALE_SCLK = 12, SCALE_PDWN = 13, SCALE_A0 = -1, PWR_CTRL = 3;
+constexpr int ESP_SLEEP_WAKEUP_TIMER = 1, ESP_SLEEP_WAKEUP_EXT1 = 2, ESP_EXT1_WAKEUP_ANY_LOW = 0;
+constexpr uint64_t PIN_BITMASK = (1ULL << 1) | (1ULL << 2) | (1ULL << 10);
+constexpr float lowBatteryThreshold = 3.2f;
+using gpio_num_t = int;
+int i_wow_interval = 1, i_lowBatteryCount = 0, GPIO_power_on_with = -1;
+float f_calibration_value = 10, f_batteryVoltage = 4;
+unsigned long nowMs = 0, cpuMhz = 240, readyAt = 500, pressAt = ULONG_MAX;
+unsigned long pressDuration = 500;
+int pressPin = BUTTON_CIRCLE, wakeCause = ESP_SLEEP_WAKEUP_TIMER;
+int liveAdcs = 0, endedAdcs = 0, begunAdcs = 0;
+bool badSample = false, sampleAvailable = true, ext1 = false, pressOnRearm = false;
+uint64_t timerUs = 0;
+bool holds[64] = {};
+int levels[64] = {};
+int32_t sampleRaw = 1000;
+struct DebugInfo {
+  int validSamples = 1;
+  int32_t smoothedValue = 1000;
+  int32_t rawValue = 1000;
+  bool dataOutOfRange = false;
+};
+struct Scale { DebugInfo getDebugInfo() { return {}; } } scale;
+unsigned long millis() { return nowMs; }
+void delay(unsigned long ms) { nowMs += ms; }
+unsigned long getCpuFrequencyMhz() { return cpuMhz; }
+bool setCpuFrequencyMhz(unsigned long mhz) {
+#ifdef CONFIG_PM_ENABLE
+  assert(false && "WoW must not change the clock outside ESP-IDF PM");
+#endif
+  cpuMhz = mhz;
+  return true;
+}
+int esp_sleep_get_wakeup_cause() { return wakeCause; }
+int rtc_gpio_get_level(int pin) {
+  return pin == pressPin && nowMs >= pressAt && nowMs - pressAt < pressDuration ? LOW : HIGH;
+}
+int digitalRead(int pin) { assert(pin == SCALE_DOUT); return sampleAvailable && nowMs >= readyAt ? LOW : HIGH; }
+void pinMode(int, int) {}
+void digitalWrite(int pin, int value) { levels[pin] = value; }
+void gpio_hold_en(int pin) { holds[pin] = true; }
+void gpio_hold_dis(int pin) { holds[pin] = false; }
+void gpio_deep_sleep_hold_en() {}
+void gpio_deep_sleep_hold_dis() {}
+void configureWakePinsForDeepSleep() {}
+void esp_sleep_enable_ext1_wakeup_io(uint64_t mask, int) {
+  assert(mask == PIN_BITMASK);
+  ext1 = true;
+  if (pressOnRearm) pressAt = nowMs;
+}
+void esp_sleep_enable_timer_wakeup(uint64_t us) { timerUs = us; }
+void esp_sleep_disable_wakeup_source(int cause) { assert(cause == ESP_SLEEP_WAKEUP_TIMER); timerUs = 0; }
+struct Sleep {};
+void esp_deep_sleep_start() { throw Sleep{}; }
+struct ADS1232_ADC {
+  bool poweredDown = false;
+  ADS1232_ADC(int, int, int, int) { liveAdcs++; }
+  void begin() { begunAdcs++; }
+  bool update() { return true; }
+  DebugInfo getDebugInfo() { return {1, 1000, sampleRaw, badSample}; }
+  void powerDown() { poweredDown = true; }
+  void end() { assert(poweredDown); liveAdcs--; endedAdcs++; }
+};
+"""
+
+CHECKS = r"""
+void resetBoot() {
+  nowMs = 0; cpuMhz = 240; timerUs = 0; ext1 = false;
+  GPIO_power_on_with = -1; wowButtonWake = false; wowTimerArmedThisBoot = false;
+  liveAdcs = 0; endedAdcs = 0; begunAdcs = 0;
+  pressAt = ULONG_MAX; pressOnRearm = false; pressPin = BUTTON_CIRCLE;
+  readyAt = 500; sampleAvailable = true; badSample = false; sampleRaw = 1000;
+  wakeCause = ESP_SLEEP_WAKEUP_TIMER;
+  for (int pin = 0; pin < 64; pin++) { holds[pin] = true; levels[pin] = LOW; }
+}
+bool tick() {
+  try { wowMicroWakeOrContinue(); }
+  catch (const Sleep &) {
+    assert(liveAdcs == 0 && begunAdcs == endedAdcs && ext1);
+    for (int pin : {SCALE_SCLK, SCALE_PDWN, SCALE_DOUT, PWR_CTRL}) assert(holds[pin]);
+    assert(levels[PWR_CTRL] == LOW);
+    return false;
+  }
+  assert(liveAdcs == 0 && begunAdcs == endedAdcs && cpuMhz == 240);
+  return true;
+}
+void arm() { wowCaptureBaselineForSleep(); assert(wowRtc.armed); }
+int main() {
+  static_assert(sizeof(WowRtcState) == 20);
+  for (bool missing : {false, true}) {
+    for (int pin : {BUTTON_CIRCLE, BUTTON_SQUARE, BATTERY_CHARGING}) {
+      for (unsigned long start = 0; start <= (missing ? 998UL : 500UL); start += 2) {
+        resetBoot(); arm(); pressAt = start; pressPin = pin; sampleAvailable = !missing;
+        assert(tick());
+        assert(GPIO_power_on_with == pin && !wowRtc.armed);
+        assert(wowButtonWake == (pin != BATTERY_CHARGING));
+        assert(nowMs <= start + 2);
+      }
+    }
+  }
+  resetBoot(); arm(); pressOnRearm = true;
+  assert(tick() && wowButtonWake && !wowRtc.armed);
+  resetBoot(); arm(); pressOnRearm = true; wowRtc.tickCount = WOW_MAX_TICKS - 1;
+  assert(tick() && wowButtonWake && timerUs == 0);
+  resetBoot(); arm(); pressOnRearm = true; badSample = true;
+  wowRtc.consecutiveFailures = WOW_MAX_FAILURES - 1;
+  assert(tick() && wowButtonWake && timerUs == 0);
+  for (int32_t raw : {499, 1501, INT32_MIN, INT32_MAX}) {
+    resetBoot(); arm(); sampleRaw = raw;
+    assert(tick() && !wowRtc.armed && GPIO_power_on_with == -1);
+  }
+  for (int32_t raw : {500, 1000, 1500}) {
+    resetBoot(); arm(); sampleRaw = raw;
+    assert(!tick() && wowRtc.armed && timerUs == 2000000);
+  }
+  for (bool missing : {false, true}) {
+    resetBoot(); arm();
+    for (int failure = 1; failure <= WOW_MAX_FAILURES; failure++) {
+      resetBoot(); sampleAvailable = !missing; badSample = !missing;
+      assert(!tick());
+      assert(wowRtc.consecutiveFailures == failure);
+      assert(bool(wowRtc.armed) == (failure < WOW_MAX_FAILURES));
+      assert((timerUs != 0) == bool(wowRtc.armed));
+    }
+  }
+  resetBoot(); arm();
+  for (int i = 0; i < 4; i++) { resetBoot(); badSample = true; assert(!tick()); }
+  resetBoot(); assert(!tick() && wowRtc.consecutiveFailures == 0);
+  resetBoot(); badSample = true; assert(!tick() && wowRtc.consecutiveFailures == 1);
+  for (int interval = 1; interval <= 3; interval++) {
+    resetBoot(); i_wow_interval = interval; arm();
+    for (int count = 1; count <= WOW_MAX_TICKS; count++) {
+      resetBoot(); assert(!tick());
+      assert(wowRtc.tickCount == count);
+      assert(bool(wowRtc.armed) == (count < WOW_MAX_TICKS));
+      assert(timerUs == (wowRtc.armed ? wowIntervalUs[interval] : 0));
+    }
+  }
+  for (int interval : {-1, 0, 4, 100}) {
+    resetBoot(); i_wow_interval = interval; wowCaptureBaselineForSleep();
+    wowArmSleepTimer(); assert(!wowRtc.armed && timerUs == 0 && tick());
+  }
+  i_wow_interval = 1;
+  resetBoot(); arm(); wowArmSleepTimer(); assert(timerUs == 2000000);
+  i_wow_interval = 0; wowCaptureBaselineForSleep(); wowArmSleepTimer();
+  assert(!wowRtc.armed && timerUs == 0);
+  i_wow_interval = 1;
+  for (float calibration : {CALIBRATION_VALUE_DEFAULT, 0.0f, 0.1f, NAN, INFINITY, 1e30f}) {
+    f_calibration_value = calibration; wowCaptureBaselineForSleep(); assert(!wowRtc.armed);
+  }
+  f_calibration_value = -10;
+  resetBoot(); arm(); assert(wowRtc.thresholdRaw == 500);
+  f_batteryVoltage = 3.1f; wowCaptureBaselineForSleep(); assert(!wowRtc.armed);
+  f_batteryVoltage = 4; i_lowBatteryCount = 1;
+  wowCaptureBaselineForSleep(); assert(!wowRtc.armed);
+  i_lowBatteryCount = 0;
+  resetBoot(); arm(); wakeCause = ESP_SLEEP_WAKEUP_EXT1;
+  assert(tick() && begunAdcs == 0 && !wowButtonWake);
+  resetBoot(); arm(); wowRtc.magic = 0;
+  assert(tick() && begunAdcs == 0);
+  std::puts("WoW runtime checks passed: button sweep, charging, cleanup, failures, recovery, cap, gates");
+}
+"""
+
+
+def main():
+    compiler = os.environ.get("CXX") or shutil.which("g++") or shutil.which("clang++")
+    if not compiler:
+        raise SystemExit("A C++ compiler is required (g++, clang++, or CXX).")
+    parameter = (ROOT / "include/parameter.h").read_text(encoding="utf-8")
+    state = parameter[parameter.index("struct WowRtcState {"):]
+    state = state[:state.index("#endif")]
+    wow = (ROOT / "include/wake_on_weight.h").read_text(encoding="utf-8")
+    source = HARNESS + state + re.sub(r"^#include[^\n]*", "", wow, flags=re.MULTILINE) + CHECKS
+    with tempfile.TemporaryDirectory(prefix="wow-test-") as directory:
+        cpp = Path(directory) / "wow.cpp"
+        binary = Path(directory) / "wow-test.exe"
+        cpp.write_text(source, encoding="utf-8")
+        for flags in ([], ["-DCONFIG_PM_ENABLE=1"]):
+            subprocess.run([compiler, "-std=c++17", "-Wall", "-Wextra", "-Werror", *flags, "-I", str(ROOT / "include"), str(cpp), "-o", str(binary)], check=True)
+            subprocess.run([str(binary)], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the optional Wake-on-Weight mode from #173: after deep sleep, an
RTC timer wakes the scale for a brief load-cell check and either goes back
to sleep (nothing placed) or continues into a full normal boot (weight
placed).

## Design (as validated on hardware)

- **User setting**: Power menu row `WakeOnWeight o/2/3/4` (o = off; 2/3/4 =
  detection interval in seconds), NVS key `wow_interval`, defaults to off.
- **Tick**: every interval the chip wakes from deep sleep (RTC timer,
  coexists with the existing EXT1 button/charging wake), downclocks to the
  20 MHz minimum, raises the main switched rail (`PWR_CTRL`), reads **one**
  raw ADS1232 conversion at 10 SPS, and compares |raw − baseline| against a
  50 g-equivalent threshold stored in `RTC_DATA_ATTR` at sleep entry.
- **Measured bring-up facts** (V8.1, two units): the first DRDY after rail
  power arrives ~415 ms, so a tick costs ~850 ms end to end (≈300 ms boot +
  100 ms settle + ~415 ms read). 0.5/1 s intervals are physically wasteful;
  the menu therefore offers 2/3/4 s.
- **Safety**: never arms on low battery, inert until calibrated (signed
  calibration factors handled via `fabsf`), charging allowed, ticks never
  touch NVS or read the battery, and on weight detection the boot frequency
  is restored before continuing the normal `setup()` flow (boot tare zeroes
  whatever was placed).
- New file `include/wake_on_weight.h` holds the micro-wake, baseline capture
  and timer arming; `power.h`'s `esp32_sleep()` gained two hooks. First use
  of `RTC_DATA_ATTR` in the repo.
- Contract test `tools/test_wake_on_weight_contract.py` pins the source
  structure; docs in `docs/wake-on-weight.md` (incl. estimated power budget
  pending ammeter measurement).

## Testing

- Builds: `esp32s3`, `esp32s3-grinder`, `esp32s3-energy-menu` all green.
- Contract suite + regressions (menu/storage/energy/soft-sleep/charging
  contracts) all green.
- Hardware bench on two V8.1 units: sleep → tick → empty-scale drift stays
  well under threshold; placing a weight wakes the scale into a normal full
  boot; button wake coexists with ticks; no crashes.
