### PR TITLE
fix: persist browser fleet access across sessions

### DIFF
--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -207,6 +207,31 @@ test("fleet browser consumes the aggregated overview without per-scale status re
   assert.equal(source.includes('/api/v1/status/'), false);
 });
 
+test("fleet access survives new sessions and migrates only after successful persistence", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  const helpers = source.slice(source.indexOf("const storageKey"), source.indexOf("export function initFleet"));
+  const storage = () => {
+    const data = new Map();
+    return {getItem: key => data.get(key) ?? null, setItem: (key, value) => data.set(key, value), removeItem: key => data.delete(key)};
+  };
+  const localStorage = storage();
+  const sessionStorage = storage();
+  const key = "A".repeat(32);
+  const storageKey = "hds-custom-build-fleet-v2";
+  sessionStorage.setItem(storageKey, JSON.stringify({version: 2, key}));
+  const load = (local, session) => runInNewContext(`${helpers}\nloadStoredKey()`, {localStorage: local, sessionStorage: session});
+  assert.equal(load({...localStorage, setItem: () => {throw new Error("blocked");}}, sessionStorage), key);
+  assert.notEqual(sessionStorage.getItem(storageKey), null);
+  assert.equal(load(localStorage, sessionStorage), key);
+  assert.equal(sessionStorage.getItem(storageKey), null);
+  assert.equal(load(localStorage, storage()), key);
+  localStorage.setItem(storageKey, "invalid json");
+  assert.equal(load(localStorage, storage()), "");
+  localStorage.setItem("hds-custom-build-fleet-v1", JSON.stringify({version: 1, key}));
+  assert.equal(load(localStorage, storage()), key);
+  assert.equal(localStorage.getItem("hds-custom-build-fleet-v1"), null);
+});
+
 test("build labels hide generated hashes without replacing user labels", () => {
   assert.equal(buildLabel({label: "Build 462465C2997F"}, 0), "Build 1");
   assert.equal(buildLabel({label: "Kitchen scale"}, 1), "Kitchen scale");

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=7";
+import {initFleet} from "./fleet.js?v=8";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
 
 (async () => {

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -44,17 +44,22 @@ const removeStoredKey = (storage, key) => {
 
 const saveKey = key => {
   try {
-    sessionStorage.setItem(storageKey, JSON.stringify({version: 2, key}));
+    localStorage.setItem(storageKey, JSON.stringify({version: 2, key}));
+    return true;
   } catch {
+    return false;
   }
 };
 
 const loadStoredKey = () => {
-  const current = readStoredKey(sessionStorage, storageKey, 2);
+  const current = readStoredKey(localStorage, storageKey, 2);
   if (current) return current;
-  const legacy = readStoredKey(localStorage, legacyStorageKey, 1);
-  removeStoredKey(localStorage, legacyStorageKey);
-  if (legacy) saveKey(legacy);
+  const legacy = readStoredKey(sessionStorage, storageKey, 2)
+    || readStoredKey(localStorage, legacyStorageKey, 1);
+  if (legacy && saveKey(legacy)) {
+    removeStoredKey(sessionStorage, storageKey);
+    removeStoredKey(localStorage, legacyStorageKey);
+  }
   return legacy;
 };
 
@@ -322,7 +327,10 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       showToast("Enter a valid fleet recovery key");
       return false;
     }
-    saveKey(fleetKey);
+    if (!saveKey(fleetKey)) {
+      showToast("Fleet access could not be saved. Allow browser storage and try again.");
+      return false;
+    }
     setMode(true);
     setSettingsOpen(false);
     loadFleet();
@@ -350,6 +358,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   forgetDialog.addEventListener("close", () => {
     if (forgetDialog.returnValue !== "confirm") return;
     removeStoredKey(sessionStorage, storageKey);
+    removeStoredKey(localStorage, storageKey);
     removeStoredKey(localStorage, legacyStorageKey);
     fleetKey = "";
     generation += 1;

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -296,6 +296,6 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=22"></script>
+  <script type="module" src="app.js?v=23"></script>
 </body>
 </html>

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,7 +254,7 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=22"' in indexPage
+    assert 'type="module" src="app.js?v=23"' in indexPage
     assert 'href="styles.css?v=16"' in indexPage
     assert 'href="fleet.css?v=4"' in indexPage
     assert 'id="request-build"' in indexPage

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -271,10 +271,12 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=7' in appScript
+    assert 'fleet.js?v=8' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
-    assert "sessionStorage.setItem(storageKey" in fleetScript
-    assert "localStorage.setItem(storageKey" not in fleetScript
+    assert "sessionStorage.setItem(storageKey" not in fleetScript
+    assert "localStorage.setItem(storageKey" in fleetScript
+    assert "readStoredKey(sessionStorage, storageKey, 2)" in fleetScript
+    assert "removeStoredKey(localStorage, storageKey)" in fleetScript
     assert "removeStoredKey(localStorage, legacyStorageKey)" in fleetScript
     assert "manifest_url" not in appScript
     energyMenu = next(feature for feature in generatedCatalog["features"] if feature["id"] == "energy-menu")


### PR DESCRIPTION
Preview blocker: fleet access disappeared after browser restart. Persist the fleet key in localStorage, migrate existing session and legacy keys only after successful persistence, clear both stores on Forget fleet, and report blocked storage. Bump Pages asset versions. Regression coverage: 13 Node configurator tests pass, including persistence, migration, corrupt data and blocked writes. Local full catalog test requires the prospective v3.1.14 ref; no stable tag or release was created. This is a Pages-only fix, with no firmware, Worker, signing or catalog changes. Fleet keys remain browser credentials accessible to same-origin scripts; clearing browser data still requires the recovery key.