### PR TITLE
Free-tier budgets and safe main-build retention

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -88,6 +88,7 @@ jobs:
           node --test cloudflare/custom-build-worker/test/configurator.test.mjs
           node --test cloudflare/custom-build-worker/test/worker.test.mjs
           node --test cloudflare/custom-build-worker/test/fleet.test.mjs
+          node --test cloudflare/custom-build-worker/test/retention.test.mjs
           node --check docs/custom-build/fleet.js
       - name: Detect changed patch plugins
         id: plugins
@@ -277,6 +278,7 @@ jobs:
           node --test cloudflare/custom-build-worker/test/configurator.test.mjs
           node --test cloudflare/custom-build-worker/test/worker.test.mjs
           node --test cloudflare/custom-build-worker/test/fleet.test.mjs
+          node --test cloudflare/custom-build-worker/test/retention.test.mjs
           node --check docs/custom-build/fleet.js
       - name: Mark custom build as running
         if: >-

--- a/cloudflare/custom-build-worker/src/build-coordinator.mjs
+++ b/cloudflare/custom-build-worker/src/build-coordinator.mjs
@@ -300,6 +300,15 @@ export class BuildCoordinator {
         failure_code: "dispatch_failed",
         attempt_id: reservation.record.attempt_id,
       });
+      if (error instanceof BudgetError && failed) {
+        await this.state.storage.transaction(async transaction => {
+          const key = `build:${hash}`;
+          const current = await transaction.get(key);
+          if (current?.attempt_id !== failed.attempt_id || current.state !== "failed") return;
+          await transaction.put(key, {state: "missing", combination_hash: hash,
+            attempts: Math.max(0, failed.attempts - 1), updated_at: failed.updated_at});
+        });
+      }
       return Response.json(error instanceof BudgetError ? {error: error.code} : failed || {error: "dispatch_failed"}, {status: 503});
     }
   }

--- a/cloudflare/custom-build-worker/src/build-coordinator.mjs
+++ b/cloudflare/custom-build-worker/src/build-coordinator.mjs
@@ -1,4 +1,5 @@
 import {cleanupFleetExpirations, FleetError, fleetExpirations, handleFleetRequest} from "./fleet.mjs";
+import {BudgetError, guardedBucket, reserveBudget, reserveBuild, retentionBatch} from "./build-retention.mjs";
 
 const hashPattern = /^[0-9a-f]{64}$/;
 const trustedRepository = "decentespresso/openscale";
@@ -150,13 +151,33 @@ export class BuildCoordinator {
 
   async fetch(request) {
     const url = new URL(request.url);
+    if (this.env.FREE_TIER_GUARDS === "true" && url.pathname === "/budget" && request.method === "POST") {
+      try {
+        await reserveBudget(this.state.storage, await request.json());
+        return new Response(null, {status: 204});
+      } catch (error) {
+        return Response.json({error: error instanceof BudgetError ? error.code : "budget_unavailable"}, {status: 503});
+      }
+    }
+    if (this.env.FREE_TIER_GUARDS === "true" && url.pathname === "/maintenance" && request.method === "POST") {
+      const report = await this.state.blockConcurrencyWhile(() => retentionBatch(
+        this.state.storage, this.env.BUILDS, Date.now(), this.env.RETENTION_DRY_RUN !== "false",
+      ));
+      console.log(JSON.stringify({event: "build-retention", ...report}));
+      return Response.json(report);
+    }
     if (url.pathname.startsWith("/device/") || url.pathname.startsWith("/fleet/")) {
       let response;
       try {
-        const result = await handleFleetRequest(request, this.state.storage, this.env);
+        const env = this.env.FREE_TIER_GUARDS === "true" ? {...this.env,
+          BUILDS: guardedBucket(this.env.BUILDS, options => reserveBudget(this.state.storage, options)),
+        } : this.env;
+        const result = await handleFleetRequest(request, this.state.storage, env);
         response = Response.json(result);
       } catch (error) {
-        const failure = error instanceof FleetError ? error : new FleetError(500, "internal_error");
+        const failure = error instanceof FleetError ? error : new FleetError(
+          error instanceof BudgetError ? 503 : 500, error instanceof BudgetError ? error.code : "internal_error",
+        );
         response = Response.json(
           {error: failure.code},
           {
@@ -217,6 +238,7 @@ export class BuildCoordinator {
       if (effectiveCurrent && ["queued", "building"].includes(effectiveCurrent.state)) {
         return {record: effectiveCurrent};
       }
+      if (effectiveCurrent?.state === "expired") return {record: effectiveCurrent, terminal: true};
       if (effectiveCurrent?.state === "failed" && effectiveCurrent.attempts >= maxAttempts) {
         return {record: effectiveCurrent, terminal: true};
       }
@@ -267,15 +289,18 @@ export class BuildCoordinator {
     if (!reservation.dispatch) return Response.json(reservation.record);
     await this.scheduleAlarm();
     try {
+      if (this.env.FREE_TIER_GUARDS === "true") {
+        await reserveBuild(this.state.storage, hash, build.configuration.firmware_ref);
+      }
       await dispatchBuild(this.env, {...build, attemptId: reservation.record.attempt_id});
       return Response.json(reservation.record, {status: 202});
-    } catch {
+    } catch (error) {
       const failed = await this.updateAttempt(hash, {
         state: "failed",
         failure_code: "dispatch_failed",
         attempt_id: reservation.record.attempt_id,
       });
-      return Response.json(failed || {error: "dispatch_failed"}, {status: 503});
+      return Response.json(error instanceof BudgetError ? {error: error.code} : failed || {error: "dispatch_failed"}, {status: 503});
     }
   }
 

--- a/cloudflare/custom-build-worker/src/build-retention.mjs
+++ b/cloudflare/custom-build-worker/src/build-retention.mjs
@@ -1,0 +1,160 @@
+const dayMs = 86400000;
+export const entryBytes = 12 * 1024 * 1024;
+const storageBudget = 4_000_000_000;
+const hashPattern = /^[0-9a-f]{64}$/;
+const batchSize = 10;
+const assetNames = ["build-manifest.json", "HDS_FW_custom.zip", "dependencies.txt", "firmware.bin",
+  "littlefs.bin", "ota-manifest.json", "ota-manifest.sig"];
+
+export class BudgetError extends Error {
+  constructor(code) {
+    super(code);
+    this.code = code;
+  }
+}
+
+export async function reserveBudget(storage, {write = false, hash = null, pin = false, reserve = false, filename = null, bytes = 0} = {}, now = Date.now()) {
+  return storage.transaction(async transaction => {
+    const day = Math.floor(now / dayMs);
+    const month = new Date(now).toISOString().slice(0, 7);
+    const stored = await transaction.get("budget:operations");
+    const daily = stored?.day === day ? stored.daily : 0;
+    const writes = stored?.month === month ? stored.writes : 0;
+    const reads = stored?.month === month ? stored.reads : 0;
+    if (![daily, writes, reads].every(value => Number.isSafeInteger(value) && value >= 0)) {
+      throw new BudgetError("budget_unavailable");
+    }
+    if (daily >= 10000 || writes + Number(write) > 100000 || reads + Number(!write) > 250000) {
+      throw new BudgetError("free_tier_operation_budget");
+    }
+    if (hash !== null) {
+      if (!hashPattern.test(hash)) throw new BudgetError("invalid_combination_hash");
+      const key = `retention:${hash}`;
+      const record = await transaction.get(key);
+      if (record?.expired) throw new BudgetError("build_expired");
+      const sizes = filename ? {...record?.sizes, [filename]: Math.max(record?.sizes?.[filename] || 0, bytes)} : record?.sizes;
+      if (filename && (!Number.isSafeInteger(bytes) || bytes <= 0 ||
+          Object.values(sizes).reduce((sum, size) => sum + size, 0) > entryBytes)) {
+        throw new BudgetError("build_storage_budget");
+      }
+      if (reserve && !record?.reserved) {
+        const inventory = await transaction.get("budget:inventory");
+        if (!inventory?.complete || !Number.isSafeInteger(inventory.bytes) || inventory.bytes < 0) {
+          throw new BudgetError("storage_inventory_pending");
+        }
+        if (inventory.bytes + entryBytes > storageBudget) throw new BudgetError("free_tier_storage_budget");
+        await transaction.put("budget:inventory", {...inventory, bytes: inventory.bytes + entryBytes});
+      }
+      await transaction.put(key, {
+        ...record,
+        createdAt: record?.createdAt ?? now,
+        pinned: Boolean(record?.pinned || pin),
+        reserved: Boolean(record?.reserved || reserve),
+        ...(sizes ? {sizes} : {}),
+      });
+    }
+    await transaction.put("budget:operations", {
+      day, month, daily: daily + 1, writes: writes + Number(write), reads: reads + Number(!write),
+    });
+  });
+}
+
+export function guardedBucket(bucket, gate) {
+  return {
+    async head(key) {
+      await gate({});
+      return bucket.head(key);
+    },
+    async get(key) {
+      const hash = key.split("/")[1];
+      await gate({hash: hashPattern.test(hash || "") ? hash : null, pin: true});
+      return bucket.get(key);
+    },
+    async put(key, body, options) {
+      const hash = key.split("/")[1];
+      await gate({write: true, hash, reserve: true, filename: key.split("/")[2], bytes: body.byteLength});
+      return bucket.put(key, body, options);
+    },
+  };
+}
+
+export async function reserveBuild(storage, hash, firmwareRef) {
+  await reserveBudget(storage, {hash, reserve: true});
+  await storage.transaction(async transaction => {
+    const key = `retention:${hash}`;
+    const record = await transaction.get(key);
+    await transaction.put(key, {...record, firmwareRef});
+  });
+}
+
+export async function inventoryBatch(storage, bucket) {
+  const inventory = await storage.get("budget:inventory") || {bytes: 0, complete: false};
+  if (inventory.complete) return inventory;
+  await reserveBudget(storage, {write: true});
+  const page = await bucket.list({limit: 100, ...(inventory.cursor ? {cursor: inventory.cursor} : {})});
+  const total = page.objects.reduce((sum, object) => sum + object.size, 0);
+  for (const object of page.objects) {
+    const hash = object.key.split("/")[1];
+    if (!hashPattern.test(hash || "")) continue;
+    await storage.transaction(async transaction => {
+      const key = `retention:${hash}`;
+      const record = await transaction.get(key);
+      await transaction.put(key, {...record, pinned: true, legacy: true});
+    });
+  }
+  const next = {bytes: inventory.bytes + total, complete: !page.truncated, cursor: page.cursor || null};
+  await storage.put("budget:inventory", next);
+  return next;
+}
+
+function eligible(record, now) {
+  return record?.reserved && !record.pinned && !record.legacy && !record.released && record.firmwareRef === "main" &&
+    Number.isFinite(record.createdAt) && now - record.createdAt >= 30 * dayMs;
+}
+
+async function expireBuild(storage, bucket, hash, now) {
+  await reserveBudget(storage);
+  const marked = await storage.transaction(async transaction => {
+    const key = `retention:${hash}`;
+    const record = await transaction.get(key);
+    const build = await transaction.get(`build:${hash}`);
+    if (!eligible(record, now) || ["queued", "building"].includes(build?.state)) return false;
+    await transaction.put(key, {...record, expired: true});
+    return true;
+  });
+  if (!marked) return false;
+  await bucket.delete(assetNames.map(name => `v1/${hash}/${name}`));
+  await storage.transaction(async transaction => {
+    const key = `retention:${hash}`;
+    const record = await transaction.get(key);
+    if (record.released) return;
+    const inventory = await transaction.get("budget:inventory");
+    await transaction.put({
+      [key]: {...record, released: true},
+      "budget:inventory": {...inventory, bytes: inventory.bytes - entryBytes},
+      [`build:${hash}`]: {state: "expired", combination_hash: hash, updated_at: new Date(now).toISOString()},
+    });
+  });
+  return true;
+}
+
+export async function retentionBatch(storage, bucket, now = Date.now(), dryRun = true) {
+  const inventory = await inventoryBatch(storage, bucket);
+  if (!inventory.complete) return {mode: "inventory", ...inventory};
+  const cursor = await storage.get("retention:cursor");
+  const records = await storage.list({prefix: "retention:", limit: batchSize, ...(cursor ? {startAfter: cursor} : {})});
+  const candidates = [];
+  for (const [key, record] of records) {
+    const hash = key.slice("retention:".length);
+    if (!hashPattern.test(hash) || !eligible(record, now)) continue;
+    const build = await storage.get(`build:${hash}`);
+    if (["queued", "building"].includes(build?.state)) continue;
+    candidates.push(hash);
+    if (!dryRun) await expireBuild(storage, bucket, hash, now);
+  }
+  await storage.put("retention:cursor", records.size === batchSize ? [...records.keys()].at(-1) : "");
+  const report = {mode: dryRun ? "dry-run" : "delete", checkedAt: new Date(now).toISOString(), checked: records.size, candidates,
+    reservedCandidateBytes: candidates.length * entryBytes, reservedStorageBytes: inventory.bytes};
+  await storage.put("budget:last-report", report);
+  return report;
+}

--- a/cloudflare/custom-build-worker/src/fleet.mjs
+++ b/cloudflare/custom-build-worker/src/fleet.mjs
@@ -1,3 +1,5 @@
+import {reserveBudget} from "./build-retention.mjs";
+
 const deviceIdPattern = /^[0-9a-f]{32}$/;
 const hashPattern = /^[0-9a-f]{64}$/;
 const pairCodePattern = /^[0-9A-F]{6}-[0-9]{6}$/;
@@ -544,7 +546,7 @@ async function deviceAssignment(request, storage) {
   return deviceAssignmentPayload(authenticated.device);
 }
 
-async function deviceCheckIn(request, storage) {
+async function deviceCheckIn(request, storage, env) {
   const body = requireObject(
     await readJson(request),
     ["firmware_version", "installed_combination"],
@@ -555,6 +557,9 @@ async function deviceCheckIn(request, storage) {
   }
   const firmwareVersion = normalizedFirmwareVersion(body.firmware_version);
   const authenticated = await authenticatedDevice(request, storage);
+  if (env.FREE_TIER_GUARDS === "true" && body.installed_combination) {
+    await reserveBudget(storage, {hash: body.installed_combination, pin: true});
+  }
   return storage.transaction(async transaction => {
     const device = await transaction.get(authenticated.key);
     if (!device || !sameHash(device.secret_hash, authenticated.secretHash)) {
@@ -590,7 +595,7 @@ export async function handleFleetRequest(request, storage, env) {
   const url = new URL(request.url);
   if (url.pathname === "/device/pair" && request.method === "POST") return pairDevice(request, storage);
   if (url.pathname === "/device/assignment" && request.method === "GET") return deviceAssignment(request, storage);
-  if (url.pathname === "/device/check-in" && request.method === "POST") return deviceCheckIn(request, storage);
+  if (url.pathname === "/device/check-in" && request.method === "POST") return deviceCheckIn(request, storage, env);
   if (url.pathname === "/fleet/claim" && request.method === "POST") return claimDevice(request, storage);
   if (url.pathname === "/fleet/scales" && request.method === "GET") return listScales(request, storage, env);
   if (url.pathname === "/fleet/overview" && request.method === "GET") return fleetOverview(request, storage, env);

--- a/cloudflare/custom-build-worker/src/worker.mjs
+++ b/cloudflare/custom-build-worker/src/worker.mjs
@@ -1,5 +1,6 @@
 import {isDeviceApi, isFleetApi} from "./fleet.mjs";
 import {BuildCoordinator, maxAttempts} from "./build-coordinator.mjs";
+import {guardedBucket} from "./build-retention.mjs";
 
 export {BuildCoordinator};
 
@@ -580,8 +581,20 @@ async function fleetApi(request, env) {
 }
 
 export default {
-  async fetch(request, env) {
+  async scheduled(controller, env, context) {
+    if (env.FREE_TIER_GUARDS !== "true") return;
+    context.waitUntil(coordinator(env).fetch("https://coordinator/maintenance", {method: "POST"}).then(response => {
+      if (!response.ok) throw new Error("retention_failed");
+    }));
+  },
+  async fetch(request, originalEnv) {
     const url = new URL(request.url);
+    const env = originalEnv.FREE_TIER_GUARDS === "true" ? {...originalEnv, BUILDS: guardedBucket(originalEnv.BUILDS, async options => {
+      const response = await coordinator(originalEnv).fetch("https://coordinator/budget", {
+        method: "POST", headers: {"Content-Type": "application/json"}, body: JSON.stringify(options),
+      });
+      if (!response.ok) throw new ApiError(503, (await response.json()).error || "budget_unavailable");
+    })} : originalEnv;
     try {
       if (request.method === "OPTIONS") {
         const headers = cors(request, env);

--- a/cloudflare/custom-build-worker/test/retention.test.mjs
+++ b/cloudflare/custom-build-worker/test/retention.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import {test} from "node:test";
+import {entryBytes, guardedBucket, inventoryBatch, reserveBudget, reserveBuild, retentionBatch} from "../src/build-retention.mjs";
+
+class Storage {
+  values = new Map();
+  pending = Promise.resolve();
+  async get(key) { return this.values.get(key); }
+  async put(key, value) {
+    for (const [name, entry] of typeof key === "string" ? [[key, value]] : Object.entries(key)) this.values.set(name, entry);
+  }
+  async list({prefix, startAfter = "", limit}) {
+    return new Map([...this.values].filter(([key]) => key.startsWith(prefix) && key > startAfter)
+      .sort(([a], [b]) => a.localeCompare(b)).slice(0, limit));
+  }
+  transaction(action) {
+    const result = this.pending.then(() => action(this));
+    this.pending = result.catch(() => {});
+    return result;
+  }
+}
+
+const hash = "a".repeat(64);
+const now = Date.now();
+const old = now - 31 * 86400000;
+const bucket = {list: async () => ({objects: [], truncated: false})};
+
+test("inventory blocks writes, counts existing bytes and protects legacy builds", async () => {
+  const storage = new Storage();
+  await assert.rejects(reserveBuild(storage, hash, "main"), /storage_inventory_pending/);
+  const result = await inventoryBatch(storage, {list: async options => {
+    assert.equal(options.limit, 100);
+    return {objects: [{key: `v1/${hash}/firmware.bin`, size: 100}, {key: "unrelated", size: 50}], truncated: false};
+  }});
+  assert.equal(result.bytes, 150);
+  assert.equal(result.complete, true);
+  assert.equal((await storage.get(`retention:${hash}`)).legacy, true);
+  assert.equal((await storage.get(`retention:${hash}`)).pinned, true);
+});
+
+test("concurrent reservations cannot exceed storage cap or double reserve a build", async () => {
+  const storage = new Storage();
+  await storage.put("budget:inventory", {complete: true, bytes: 4_000_000_000 - entryBytes});
+  const results = await Promise.allSettled([reserveBuild(storage, hash, "main"), reserveBuild(storage, "b".repeat(64), "main")]);
+  assert.equal(results.filter(result => result.status === "fulfilled").length, 1);
+  await reserveBuild(storage, hash, "main");
+  assert.equal((await storage.get("budget:inventory")).bytes, 4_000_000_000);
+});
+
+test("partial uploads cannot exceed the reserved entry, and retries do not release bytes", async () => {
+  const storage = new Storage();
+  await inventoryBatch(storage, bucket);
+  await reserveBuild(storage, hash, "main");
+  await reserveBudget(storage, {hash, reserve: true, filename: "firmware.bin", bytes: entryBytes, write: true});
+  await reserveBudget(storage, {hash, reserve: true, filename: "firmware.bin", bytes: 1, write: true});
+  await assert.rejects(reserveBudget(storage, {hash, reserve: true, filename: "littlefs.bin", bytes: 1, write: true}), /build_storage_budget/);
+  assert.equal((await storage.get("budget:inventory")).bytes, entryBytes);
+});
+
+test("operation quotas fail closed before bucket calls and reset on UTC boundaries", async () => {
+  const storage = new Storage();
+  await reserveBudget(storage, {}, now);
+  const stored = await storage.get("budget:operations");
+  await storage.put("budget:operations", {...stored, daily: 10000});
+  const guarded = guardedBucket({head: () => assert.fail("bucket called after quota exhausted")}, options => reserveBudget(storage, options, now));
+  await assert.rejects(guarded.head("file"), /free_tier_operation_budget/);
+  await storage.put("budget:operations", {...stored, reads: 250000});
+  await assert.rejects(reserveBudget(storage, {}, now), /free_tier_operation_budget/);
+  await storage.put("budget:operations", {...stored, writes: 100000});
+  await assert.rejects(reserveBudget(storage, {write: true}, now), /free_tier_operation_budget/);
+  await reserveBudget(storage, {write: true}, Date.UTC(2027, 0, 1));
+  assert.equal((await storage.get("budget:operations")).writes, 1);
+});
+
+test("dry run excludes stable, pinned, recent, unknown, legacy and active builds", async () => {
+  const storage = new Storage();
+  await inventoryBatch(storage, bucket);
+  const cases = [
+    {firmwareRef: "main"}, {firmwareRef: "v3.1.14"}, {firmwareRef: "main", pinned: true},
+    {firmwareRef: "main", createdAt: now}, {}, {firmwareRef: "main", legacy: true}, {firmwareRef: "main"},
+  ];
+  for (const [index, record] of cases.entries()) {
+    const id = String(index).repeat(64);
+    await storage.put(`retention:${id}`, {reserved: true, createdAt: old, ...record});
+    if (index === 6) await storage.put(`build:${id}`, {state: "building"});
+  }
+  const report = await retentionBatch(storage, {delete: () => assert.fail("dry run deleted an object")}, now);
+  assert.deepEqual(report.candidates, ["0".repeat(64)]);
+  assert.equal(report.mode, "dry-run");
+});
+
+test("downloads permanently protect rollback assets; deletion is idempotent and expires the identity", async () => {
+  const storage = new Storage();
+  await inventoryBatch(storage, bucket);
+  await reserveBuild(storage, hash, "main");
+  const key = `retention:${hash}`;
+  await storage.put(key, {...await storage.get(key), createdAt: old});
+  const guarded = guardedBucket({get: async () => ({size: 1})}, options => reserveBudget(storage, options));
+  await guarded.get(`v1/${hash}/firmware.bin`);
+  assert.deepEqual((await retentionBatch(storage, bucket, now)).candidates, []);
+  const other = "b".repeat(64);
+  await reserveBuild(storage, other, "main");
+  await storage.put(`retention:${other}`, {...await storage.get(`retention:${other}`), createdAt: old});
+  const deleted = [];
+  const liveBucket = {delete: async keys => {deleted.push(...keys);}};
+  await retentionBatch(storage, liveBucket, now, false);
+  assert.equal(deleted.length, 7);
+  assert.equal((await storage.get("budget:inventory")).bytes, entryBytes);
+  await retentionBatch(storage, liveBucket, now, false);
+  assert.equal(deleted.length, 7);
+  await assert.rejects(reserveBuild(storage, other, "main"), /build_expired/);
+  await assert.rejects(reserveBudget(storage, {hash: other, pin: true}), /build_expired/);
+});
+
+test("failed deletion retains reservation and resumes without reviving expired downloads", async () => {
+  const storage = new Storage();
+  await inventoryBatch(storage, bucket);
+  await reserveBuild(storage, hash, "main");
+  await storage.put(`retention:${hash}`, {...await storage.get(`retention:${hash}`), createdAt: old});
+  await assert.rejects(retentionBatch(storage, {delete: async () => {throw new Error("offline");}}, now, false), /offline/);
+  assert.equal((await storage.get("budget:inventory")).bytes, entryBytes);
+  await assert.rejects(reserveBudget(storage, {hash, pin: true}), /build_expired/);
+  await retentionBatch(storage, {delete: async () => {}}, now, false);
+  assert.equal((await storage.get("budget:inventory")).bytes, 0);
+});

--- a/cloudflare/custom-build-worker/test/worker.test.mjs
+++ b/cloudflare/custom-build-worker/test/worker.test.mjs
@@ -599,3 +599,18 @@ test("expires stale build attempts", async () => {
   assert.equal(Object.hasOwn(record, "lease_expires_at"), false);
   assert.deepEqual(await storage.get("pending"), {});
 });
+
+test("inventory and storage budget failures do not consume build attempts", async () => {
+  const storage = new Storage();
+  const coordinator = new BuildCoordinator({storage}, {FREE_TIER_GUARDS: "true"});
+  const hash = "d".repeat(64);
+  for (let index = 0; index < 3; index += 1) {
+    const response = await coordinator.fetch(new Request(`https://coordinator/build/${hash}`, {
+      method: "POST", body: JSON.stringify({configuration: {firmware_ref: "main"}, clientKey: "test"}),
+    }));
+    assert.equal(response.status, 503);
+    assert.equal((await response.json()).error, "storage_inventory_pending");
+    assert.equal((await storage.get(`build:${hash}`)).state, "missing");
+    assert.equal((await storage.get(`build:${hash}`)).attempts, 0);
+  }
+});

--- a/cloudflare/custom-build-worker/test/worker.test.mjs
+++ b/cloudflare/custom-build-worker/test/worker.test.mjs
@@ -556,6 +556,26 @@ test("publishes immutable cache entries and deduplicates public builds", async (
 });
 
 
+test("production budget guards cover public downloads and authenticated uploads", async () => {
+  const env = {BUILDS: new Bucket(), UPLOAD_TOKEN: token, FREE_TIER_GUARDS: "true"};
+  env.COORDINATOR = new CoordinatorNamespace(env);
+  const storage = env.COORDINATOR.coordinator.state.storage;
+  await storage.put("budget:inventory", {complete: true, bytes: 0});
+  const hash = "c".repeat(64);
+  assert.equal((await put(env, hash, "firmware.bin", "firmware")).status, 201);
+  await env.BUILDS.put(`v1/${hash}/build-manifest.json`, encoder.encode("{}"), {});
+  const response = await worker.fetch(new Request(`https://example.test/v1/${hash}/firmware.bin`), env);
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "firmware");
+  assert.equal((await storage.get(`retention:${hash}`)).pinned, true);
+  const budget = await storage.get("budget:operations");
+  assert.equal(budget.writes, 1);
+  await storage.put("budget:operations", {...budget, daily: 10000});
+  const refused = await worker.fetch(new Request(`https://example.test/v1/${hash}/firmware.bin`), env);
+  assert.equal(refused.status, 503);
+  assert.equal((await refused.json()).error, "free_tier_operation_budget");
+});
+
 test("expires stale build attempts", async () => {
   const storage = new Storage();
   const coordinator = new BuildCoordinator({storage}, {});

--- a/cloudflare/custom-build-worker/wrangler.toml
+++ b/cloudflare/custom-build-worker/wrangler.toml
@@ -10,6 +10,11 @@ BUILDER_REF = "main"
 GITHUB_REPOSITORY = "decentespresso/openscale"
 GITHUB_WORKFLOW = "custom-build.yml"
 PUBLIC_BASE_URL = "https://openscale-custom-builds.odevstudio.workers.dev"
+FREE_TIER_GUARDS = "true"
+RETENTION_DRY_RUN = "true"
+
+[triggers]
+crons = ["17 * * * *"]
 
 [[r2_buckets]]
 binding = "BUILDS"

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -44,6 +44,39 @@ OLED identity uses an uppercase 8-character prefix for display only.
 
 ## Release Assets
 
+### Custom Build Retention
+
+The Worker uses one hourly Cron Trigger for bounded R2 inventory and retention work.
+`FREE_TIER_GUARDS=true` enables a serialized R2 operation budget in the existing SQLite
+Durable Object: 10,000 budgeted operations per UTC day, 100,000 writes/list operations
+and 250,000 reads per calendar month. Reservations and protection updates also consume
+this conservative operation allowance. Failures stop before the R2 operation.
+The service reserves 12 MiB per new build before dispatch, caps total inventory plus
+reservations at 4,000,000,000 bytes, and rejects cumulative partial uploads above 12 MiB.
+Reservations are not refunded on build failure or smaller retries.
+
+Inventory processes at most 100 objects per invocation and blocks new reservations
+until complete. Existing objects are permanently protected. Retention examines at
+most 10 records per invocation. Only reserved main builds at least 30 days old,
+never served or referenced, and not queued/building are candidates. Reads of build
+artifacts, Fleet references/assignments, and installed-hash check-ins permanently
+protect their identities, including potential rollback assets and USB downloads.
+This deliberately retains more than the currently installed build: firmware does
+not report its complete rollback-slot history. Stable and unknown refs are never
+automatically removed.
+
+`RETENTION_DRY_RUN=true` is the deployment default: candidates are logged, not deleted.
+Live mode requires an explicit change to false after reviewing the inventory/report.
+Deletion first expires the identity transactionally, blocking racing reads/uploads,
+then removes its seven objects and releases the reservation once. Failed deletions
+are retried. Expired identities must not be rebuilt in place.
+
+These are service-local safeguards, not an account-wide billing lock. Other Workers,
+direct R2 clients, earlier usage and administrative operations are outside these counters.
+Recheck Cloudflare account usage before enabling guards on another account or adding
+other workloads. Workers and SQLite Durable Objects also retain their platform free
+limits; no paid plan or R2 Infrequent Access transition is enabled by this feature.
+
 Release builds publish WiFi OTA assets at the GitHub Release root:
 
 - `firmware.bin`

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -164,6 +164,7 @@ import {buildEstimate} from "./build-estimate.mjs?v=1";
     };
     const messages = {
       missing: "This combination has not been built yet.",
+      expired: "This development build has expired. Select the current main revision for a new build.",
       queued: "",
       building: "The firmware and filesystem images are being built.",
       ready: "The build archive is ready to download.",

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -296,6 +296,6 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=23"></script>
+  <script type="module" src="app.js?v=24"></script>
 </body>
 </html>

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,7 +254,7 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=23"' in indexPage
+    assert 'type="module" src="app.js?v=24"' in indexPage
     assert 'href="styles.css?v=16"' in indexPage
     assert 'href="fleet.css?v=4"' in indexPage
     assert 'id="request-build"' in indexPage


### PR DESCRIPTION
Adds bounded hourly retention with dry-run deployment default. Serializes R2 operation quotas and 12 MiB build reservations under a 4 GB service budget, blocks writes until paged inventory completes, and preserves stable/legacy/ever-served/referenced/installed builds for rollback safety. Only unused main builds older than 30 days qualify; live deletion is opt-in and expires identities before removing objects. No firmware, signing, stable tag, paid plan, or storage-class change. Service-local counters are not an account-wide billing lock. Account inspection: one Standard bucket, 80.4 MB / 82 objects; September R2 analytics show 55 puts and 563 gets/heads plus one bucket listing. Validation: 33 Node tests pass, including budgets, partial uploads, serialized reservations, retention exclusions, failed deletion retry, and production download/upload guards; Wrangler dry-run bundles successfully. First production pass must remain dry-run and be reviewed before enabling deletion.