### PR TITLE
Fix pairing screen timeout and simplify fleet editing

### DIFF
--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -264,6 +264,17 @@ test("fleet options expand without copy-hash controls", async () => {
   assert.equal(html.includes("copy-hash"), false);
 });
 
+test("fleet names save on change without separate save actions", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  assert.equal(source.includes("save-build"), false);
+  assert.equal(source.includes("save-scale"), false);
+  for (const field of ["label", "name"]) {
+    assert.ok(source.includes(`${field}.addEventListener("change", async () =>`));
+    assert.ok(source.includes(`if (event.key === "Enter") ${field}.blur()`));
+    assert.ok(source.includes(`${field}.value = previous;`));
+  }
+});
+
 
 test("theme follows the system until a saved preference overrides it", async () => {
   const html = await readFile(new URL("../../../docs/custom-build/index.html", import.meta.url), "utf8");

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=8";
+import {initFleet} from "./fleet.js?v=9";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
 
 (async () => {

--- a/docs/custom-build/fleet.css
+++ b/docs/custom-build/fleet.css
@@ -352,7 +352,7 @@
 
   .fleet-table tr {
     display: grid;
-    grid-template-columns: 24px minmax(0, 1fr) auto;
+    grid-template-columns: 24px minmax(0, 1fr);
     gap: 8px 10px;
     padding: 14px 0;
     border-bottom: 1px solid var(--line);
@@ -366,7 +366,6 @@
 
   .fleet-table .scale-select { grid-column: 1; grid-row: 1; padding-top: 10px; }
   .fleet-table .scale-identity { grid-column: 2; grid-row: 1; }
-  .fleet-table td:last-child { grid-column: 3; grid-row: 1; }
 
   .fleet-table td[data-label] {
     grid-column: 2 / -1;

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -214,25 +214,41 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
         <div class="fleet-build-version"><strong></strong><details><summary>Options</summary><span></span></details></div>
         <span class="deployment-state"></span>
         <div class="fleet-row-actions">
-          <button class="ghost-bordered-button save-build" type="button">Save</button>
           <button class="ghost-button remove-build" type="button">Remove</button>
         </div>`;
-      row.querySelector(".build-label").value = labelForBuild(build.combination_hash);
+      const label = row.querySelector(".build-label");
+      label.value = labelForBuild(build.combination_hash);
+      label.addEventListener("keydown", event => { if (event.key === "Enter") label.blur(); });
       row.querySelector(".fleet-build-version strong").textContent = build.firmware_version;
       row.querySelector(".fleet-build-version span").textContent = buildSummary(build);
       const state = row.querySelector(".deployment-state");
       state.textContent = build.state === "ready" ? "Ready" : "Unavailable";
       state.dataset.state = build.state;
-      row.querySelector(".save-build").addEventListener("click", async () => {
+      label.addEventListener("change", async () => {
+        const previous = labelForBuild(build.combination_hash);
+        const next = label.value.trim();
+        if (!next || next === previous) { label.value = previous; return; }
+        label.disabled = true;
         try {
           await api(`/api/v1/fleet/builds/${build.combination_hash}`, {
             method: "PATCH",
-            body: JSON.stringify({label: row.querySelector(".build-label").value.trim()}),
+            body: JSON.stringify({label: next}),
+          });
+          if (!row.isConnected) return;
+          builds = builds.map(item => item.combination_hash === build.combination_hash ? {...item, label: next} : item);
+          label.value = next;
+          renderControls();
+          scales.forEach((scale, index) => {
+            const scaleRow = scaleRows.children[index];
+            if (scale.installed_combination === build.combination_hash) scaleRow.querySelector(".scale-build span").textContent = next;
+            if (scale.desired_combination === build.combination_hash) scaleRow.querySelector(".desired-build strong").textContent = next;
           });
           showToast("Build label saved");
-          await loadFleet();
         } catch (error) {
+          label.value = previous;
           showApiError(error);
+        } finally {
+          label.disabled = false;
         }
       });
       row.querySelector(".remove-build").addEventListener("click", async () => {
@@ -259,8 +275,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
         <td class="scale-build" data-label="Installed"><strong></strong><span></span></td>
         <td class="scale-build desired-build" data-label="Desired"><strong></strong></td>
         <td data-label="Deployment"><span class="deployment-state"></span></td>
-        <td class="last-seen" data-label="Last seen"></td>
-        <td><button class="ghost-bordered-button save-scale" type="button">Save</button></td>`;
+        <td class="last-seen" data-label="Last seen"></td>`;
       const checkbox = row.querySelector('[type="checkbox"]');
       checkbox.checked = selectedDeviceIds.has(scale.device_id);
       checkbox.setAttribute("aria-label", `Select ${scale.name}`);
@@ -271,7 +286,9 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
         renderControls();
       });
       const name = row.querySelector(".scale-name");
+      name.setAttribute("aria-label", "Scale name");
       name.value = scale.name;
+      name.addEventListener("keydown", event => { if (event.key === "Enter") name.blur(); });
       row.querySelector(".scale-hint").textContent = scale.serial_hint;
       const installed = row.querySelector(".scale-build");
       installed.querySelector("strong").textContent = scale.firmware_version || "Unknown";
@@ -284,16 +301,26 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       state.textContent = deploymentState(scale, buildStates);
       state.dataset.state = state.textContent.toLowerCase().replaceAll(" ", "-");
       row.querySelector(".last-seen").textContent = lastSeenLabel(scale.last_seen_at);
-      row.querySelector(".save-scale").addEventListener("click", async () => {
+      name.addEventListener("change", async () => {
+        const previous = scales.find(item => item.device_id === scale.device_id)?.name || scale.name;
+        const next = name.value.trim();
+        if (!next || next === previous) { name.value = previous; return; }
+        name.disabled = true;
         try {
           await api(`/api/v1/fleet/scales/${scale.device_id}`, {
             method: "PATCH",
-            body: JSON.stringify({name: name.value.trim()}),
+            body: JSON.stringify({name: next}),
           });
+          if (!row.isConnected) return;
+          scales = scales.map(item => item.device_id === scale.device_id ? {...item, name: next} : item);
+          name.value = next;
+          checkbox.setAttribute("aria-label", `Select ${next}`);
           showToast("Scale name saved");
-          await loadFleet();
         } catch (error) {
+          name.value = previous;
           showApiError(error);
+        } finally {
+          name.disabled = false;
         }
       });
       return row;

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -23,8 +23,8 @@
       document.querySelector("#theme-color").content = dark ? "#111413" : "#0d6b4f";
     })();
   </script>
-  <link rel="stylesheet" href="styles.css?v=16">
-  <link rel="stylesheet" href="fleet.css?v=4">
+  <link rel="stylesheet" href="styles.css?v=17">
+  <link rel="stylesheet" href="fleet.css?v=5">
 </head>
 <body>
   <header class="topbar">
@@ -258,7 +258,6 @@
                   <th>Desired</th>
                   <th>Deployment</th>
                   <th>Last seen</th>
-                  <th><span class="sr-only">Actions</span></th>
                 </tr>
               </thead>
               <tbody id="fleet-scale-rows"></tbody>
@@ -296,6 +295,6 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=24"></script>
+  <script type="module" src="app.js?v=25"></script>
 </body>
 </html>

--- a/docs/custom-build/styles.css
+++ b/docs/custom-build/styles.css
@@ -315,13 +315,41 @@
       content: "";
       position: absolute;
       right: 17px;
-      top: 18px;
+      top: 50%;
       width: 8px;
       height: 8px;
       border-right: 1.5px solid var(--ink);
       border-bottom: 1.5px solid var(--ink);
-      transform: rotate(45deg);
+      transform: translateY(-70%) rotate(45deg);
       pointer-events: none;
+    }
+
+    @supports (appearance: base-select) {
+      select, select::picker(select) { appearance: base-select; }
+      select { display: inline-flex; align-items: center; }
+      select::picker-icon { display: none; }
+      select::picker(select) {
+        color: var(--ink);
+        background: var(--surface);
+        border: 1px solid var(--line-strong);
+        border-radius: 8px;
+        padding: 4px;
+      }
+      select option {
+        padding: 10px 12px;
+        border-radius: 4px;
+        color: var(--ink);
+        background: var(--surface);
+      }
+      html[data-theme] select option:checked,
+      html[data-theme] select option:hover,
+      html[data-theme] select option:focus {
+        color: var(--ink);
+        background: var(--surface-soft);
+        outline: 1px solid var(--green);
+        outline-offset: -1px;
+      }
+      select option::checkmark { color: var(--green); }
     }
 
     .options-grid {

--- a/include/custom_build_ota.h
+++ b/include/custom_build_ota.h
@@ -219,9 +219,9 @@ bool customBuildWaitForHold(uint8_t pin, unsigned long timeoutMs, int cancelPin 
 }
 
 void customBuildWaitForDismiss(unsigned long timeoutMs) {
-  pullOtaWaitForRelease(1000);
+  while (!pullOtaWaitForRelease(1000)) delay(20);
   const unsigned long startedAt = millis();
-  while (millis() - startedAt < timeoutMs) {
+  while (timeoutMs == 0 || millis() - startedAt < timeoutMs) {
     if (digitalRead(BUTTON_CIRCLE) == LOW || digitalRead(BUTTON_SQUARE) == LOW) {
       pullOtaWaitForRelease(1000);
       return;
@@ -247,8 +247,8 @@ bool customBuildPairScale(bool requireConfirmation) {
   customBuildSerialHint(serialHint);
   snprintf(pairCode, sizeof(pairCode), "%s-%06lu", serialHint, (unsigned long)customBuildPairPin());
   if (!customBuildRegisterPairCode(pairCode)) return pullOtaFail("Pairing failed");
-  pullOtaDraw("Pair code", pairCode, "Valid 12 hours");
-  customBuildWaitForDismiss(HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS);
+  pullOtaDraw("Pair code", pairCode, "O back  Sq back");
+  customBuildWaitForDismiss(0);
   return true;
 }
 
@@ -327,12 +327,12 @@ bool customBuildFetchManifest(
 
 bool customBuildConfirmRelink() {
   if (!pullOtaWaitForRelease(3000)) return false;
-  pullOtaDraw("Relink scale?", "", "Sq back Hold O");
+  pullOtaDraw("Relink scale?", "", "Hold O  Sq back");
   return customBuildWaitForHold(BUTTON_CIRCLE, HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS, BUTTON_SQUARE);
 }
 
 void customBuildShowStatus(const char *line1, const char *line2) {
-  pullOtaDraw(line1, line2, "Sq back");
+  pullOtaDraw(line1, line2, "O back  Sq back");
   customBuildWaitForDismiss(HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS);
 }
 
@@ -342,7 +342,7 @@ bool customBuildConfirmInstall(
   char hashPrefix[9];
   customBuildHashPrefix(combinationHash, hashPrefix);
   pullOtaWaitForRelease(1000);
-  pullOtaDraw(manifest.version.c_str(), hashPrefix, "Hold Sq O back");
+  pullOtaDraw(manifest.version.c_str(), hashPrefix, "O back  Hold Sq");
   const unsigned long startedAt = millis();
   unsigned long squareHeldSince = 0;
   while (millis() - startedAt < HDS_OTA_CONFIRM_TIMEOUT_MS) {

--- a/tools/test_custom_build_ota_contract.py
+++ b/tools/test_custom_build_ota_contract.py
@@ -31,7 +31,7 @@ def main():
     require("include/custom_build_ota.h", "pullOtaVerifyManifestSignatureWithKeys")
     require("include/custom_build_ota.h", "HDS_CUSTOM_OTA_MANIFEST_PUBLIC_KEY_1_PEM")
     require("include/custom_build_ota.h", "HDS_CUSTOM_OTA_MANIFEST_PUBLIC_KEY_2_PEM")
-    require("include/custom_build_ota.h", 'pullOtaDraw("Pair code", pairCode, "Valid 12 hours")')
+    require("include/custom_build_ota.h", 'pullOtaDraw("Pair code", pairCode, "O back  Sq back")')
     require("include/custom_build_ota.h", 'String(HDS_CUSTOM_BUILD_SERVICE_URL) + "/v1/" + combinationHash')
     require("include/custom_build_ota.h", "customBuildFetchManifest(rollbackCombinationHash, rollbackManifest)")
     require("include/custom_build_ota.h", 'customBuildRequest("/api/v1/device/check-in", "POST"')
@@ -46,11 +46,12 @@ def main():
     assert hold.index("cancelPin >= 0") < hold.index("digitalRead(pin)")
     status = function_body(header, "void customBuildShowStatus(")
     wait = "customBuildWaitForHold(BUTTON_CIRCLE, HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS, BUTTON_SQUARE)"
-    assert 'pullOtaDraw(line1, line2, "Sq back")' in status
+    assert 'pullOtaDraw(line1, line2, "O back  Sq back")' in status
     assert "customBuildWaitForDismiss(HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS)" in status
     assert "customBuildPairScale" not in status
     assert "Relink" not in status
     confirmation = function_body(header, "bool customBuildConfirmRelink()")
+    assert '"Hold O  Sq back"' in confirmation
     assert "if (!pullOtaWaitForRelease(3000)) return false;" in confirmation
     assert confirmation.index("pullOtaWaitForRelease(3000)") < confirmation.index('pullOtaDraw("Relink scale?"')
     assert confirmation.index('pullOtaDraw("Relink scale?"') < confirmation.index(wait)
@@ -62,6 +63,7 @@ def main():
     assert "customBuildStart(true);" in function_body(header, "void customBuildRelinkMenu()")
     assert "customBuildStart(false);" in function_body(header, "void customBuildMenu()")
     install_prompt = function_body(header, "bool customBuildConfirmInstall(")
+    assert '"O back  Hold Sq"' in install_prompt
     assert "relink" not in install_prompt.lower()
     require("include/custom_build_ota.h", 'pullOtaDraw(manifest.version.c_str(), hashPrefix')
     require("include/custom_build_ota.h", "assignment.combinationHash,")
@@ -90,6 +92,11 @@ def main():
     assert registration.index('!= pairCode) return false;') < registration.index('putBool("pair_init", true) == 1')
     assert 'return stored;' in registration
     pairing = function_body(header, "bool customBuildPairScale(")
+    assert "customBuildWaitForDismiss(0);" in pairing
+    assert "HDS_CUSTOM_BUILD_SCREEN_TIMEOUT_MS" not in pairing
+    dismiss = function_body(header, "void customBuildWaitForDismiss(")
+    assert "timeoutMs == 0 || millis() - startedAt < timeoutMs" in dismiss
+    assert "while (!pullOtaWaitForRelease(1000)) delay(20);" in dismiss
     assert pairing.index("customBuildRegisterPairCode(pairCode)") < pairing.index('pullOtaDraw("Pair code"')
     assert 'pullOtaDraw("Custom Build", "Pair scale?", "Hold square")' in pairing
     rejected = function_body(run, "if (assignment.identityRejected)")

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,9 +254,9 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=24"' in indexPage
-    assert 'href="styles.css?v=16"' in indexPage
-    assert 'href="fleet.css?v=4"' in indexPage
+    assert 'type="module" src="app.js?v=25"' in indexPage
+    assert 'href="styles.css?v=17"' in indexPage
+    assert 'href="fleet.css?v=5"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage
     assert 'fetch("catalog.json"' in appScript
@@ -271,7 +271,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=8' in appScript
+    assert 'fleet.js?v=9' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" not in fleetScript
     assert "localStorage.setItem(storageKey" in fleetScript


### PR DESCRIPTION
Preview preparation fixes: keep the pair code visible until an explicit button press, wait for held buttons to release, and order Circle/Square hints left-to-right like the hardware. Fleet names autosave on change or Enter without Save buttons; failed saves restore the previous name, dependent labels update without rebuilding focused inputs. Center select arrows for both control heights and theme supported native customizable selects, retaining native fallback for older browsers. Bump Pages asset versions. Validation: OTA contract passed, 14 configurator tests passed, and local Chrome desktop/mobile checks passed for autosave, focus preservation, error rollback and dropdown layout. Firmware hardware validation remains pending. No install-status telemetry changes, Worker deployment, firmware flash, release or tag included. This PR is not auto-merged.