### PR TITLE
Show custom build identity and trigger assigned OTA over BLE/USB

### DIFF
--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -264,6 +264,16 @@ test("fleet options expand without copy-hash controls", async () => {
   assert.equal(html.includes("copy-hash"), false);
 });
 
+test("fleet build identity stays separate from editable names", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  assert.ok(source.includes('`${labelForBuild(hash)} · ${shortHash(hash, 8)}`'));
+  assert.ok(source.includes('new Option(identityForBuild(build.combination_hash)'));
+  assert.ok(source.includes('label.value = labelForBuild(build.combination_hash)'));
+  assert.ok(source.includes('row.querySelector(".build-hash").textContent = shortHash(build.combination_hash, 8)'));
+  assert.ok(source.includes('identityForBuild(scale.installed_combination)'));
+  assert.ok(source.includes('identityForBuild(scale.desired_combination)'));
+});
+
 test("fleet names save on change without separate save actions", async () => {
   const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
   assert.equal(source.includes("save-build"), false);
@@ -273,6 +283,15 @@ test("fleet names save on change without separate save actions", async () => {
     assert.ok(source.includes(`if (event.key === "Enter") ${field}.blur()`));
     assert.ok(source.includes(`${field}.value = previous;`));
   }
+});
+
+test("fleet assignment uses only the explicit scale selection", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  const html = await readFile(new URL("../../../docs/custom-build/index.html", import.meta.url), "utf8");
+  assert.equal(source.includes("assignAll"), false);
+  assert.equal(html.includes('id="assign-all"'), false);
+  assert.ok(html.includes('type="checkbox"> Select all'));
+  assert.ok(source.includes("{device_ids: [...selectedDeviceIds]}"));
 });
 
 

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -41,6 +41,10 @@ Fleet build references, scale lists, bulk assignment, and deployment history sta
 Worker/browser. Firmware must not fetch a fleet build list, add fleet-sized collections, persist a
 short hash, add background check-ins, or increase `HDS_OTA_TASK_STACK_BYTES` without measurement.
 OLED identity uses an uppercase 8-character prefix for display only.
+About also shows the installed custom combination as `Build: XXXXXXXX`, without
+network access. Official firmware keeps the version, date, and Git revision display.
+The reserved remote OTA target `0.0.0` starts the assigned custom build unattended;
+the menu retains its local install confirmation. Remote requests never initiate pairing.
 
 ## Release Assets
 

--- a/docs/AI_PROTOCOL_NOTES.md
+++ b/docs/AI_PROTOCOL_NOTES.md
@@ -55,11 +55,24 @@ Every byte of a started payload must stay biased. An unbiased byte resynchronize
 
 The bias is what lets one request form serve every scale. `processUsbRxBuffer()` enters the binary resolver only when the buffer's first byte is `0x03`, so firmware predating the payload frames `03 1B` as two bytes, starts its picker, and then discards the trailing bytes through the text path. A client never has to know the scale's firmware version or negotiate a capability.
 
-The client supplies a version number and nothing else. Every asset URL, size, and hash used for an install comes from the scale's own signature-verified catalog fetch. See `docs/AI_OTA_NOTES.md`.
+The reserved target `0.0.0`, encoded as `03 1B 80 80 80`, requests an unattended
+installation of the currently assigned Custom Build instead of an official release.
+It uses the same BLE and USB queue and five-byte framing. No individual version bit
+is repurposed. A missing pairing or assignment never starts an installation or pairing.
+An already installed combination never downloads again. Older firmware does not
+support this target: it either rejects the unsupported version or opens its legacy picker.
+
+The client supplies no asset URLs. Official assets come from the signature-verified
+catalog; custom assets come from the authenticated assignment and verified custom
+manifest, with the same mandatory LittleFS and rollback checks. See `docs/AI_OTA_NOTES.md`.
 
 The `/snapshot` WebSocket carries the same request as a `wifi_update` control command, accepted bare, as `wifi_update <version>`, and as `{"command":"wifi_update","action":"<version>"}`. The version is dotted `major.minor.patch` with an optional leading `v`. The command is compiled out when `HDS_FEATURE_PULL_OTA` is disabled and then answers `unknown_command`. A JSON `action` that is present but not a string answers `invalid_action`: an omitted action means the bare form, so a boolean, number, or object must not silently collapse into it.
 
 ADS debug responses are separate fixed formats: the debug packet is 41 bytes and the reset response is 5 bytes. Keep their Python helpers, decoder, and firmware builders aligned.
+
+Because WebSocket OTA uses the same target dispatcher, `wifi_update 0.0.0` also
+requests the assigned Custom Build. Ordinary release versions and the bare picker
+command retain their existing behavior.
 
 ## Runtime Effects
 

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=9";
+import {initFleet} from "./fleet.js?v=10";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
 
 (async () => {

--- a/docs/custom-build/fleet.css
+++ b/docs/custom-build/fleet.css
@@ -74,6 +74,13 @@
   box-shadow: 0 0 0 3px rgba(13, 121, 85, .13);
 }
 
+.build-hash {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font: .72rem/1.4 monospace;
+}
+
 .fleet-build-version strong,
 .fleet-build-version span {
   display: block;
@@ -158,7 +165,7 @@
 
 .deployment-toolbar {
   display: grid;
-  grid-template-columns: auto minmax(180px, 1fr) auto auto auto auto auto;
+  grid-template-columns: auto minmax(180px, 1fr) auto auto auto auto;
   align-items: center;
   gap: 8px;
   margin-bottom: 14px;
@@ -272,9 +279,8 @@
 .scale-build strong,
 .scale-build span {
   display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .scale-build strong {
@@ -381,4 +387,6 @@
     font-size: .65rem;
     font-weight: 720;
   }
+
+  .scale-build span { grid-column: 2; }
 }

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -1,4 +1,4 @@
-import {buildLabel, buildSummary, deploymentState, lastSeenLabel} from "./fleet-state.mjs?v=2";
+import {buildLabel, buildSummary, deploymentState, lastSeenLabel, shortHash} from "./fleet-state.mjs?v=2";
 
 const storageKey = "hds-custom-build-fleet-v2";
 const legacyStorageKey = "hds-custom-build-fleet-v1";
@@ -80,7 +80,6 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   const selectedCount = document.querySelector("#selected-scale-count");
   const addBuild = document.querySelector("#add-fleet-build");
   const assignSelected = document.querySelector("#assign-selected");
-  const assignAll = document.querySelector("#assign-all");
   const clearSelected = document.querySelector("#clear-selected");
   const pairInput = document.querySelector("#pair-code");
   const existingInput = document.querySelector("#existing-fleet-key");
@@ -140,6 +139,8 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     return index < 0 ? "Custom build" : buildLabel(builds[index], index);
   };
 
+  const identityForBuild = hash => `${labelForBuild(hash)} · ${shortHash(hash, 8)}`;
+
   const showApiError = error => {
     const messages = {
       build_assigned: "Clear this build from assigned scales before removing it",
@@ -156,14 +157,13 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     const readyBuilds = builds.filter(build => build.state === "ready");
     const previousHash = buildSelect.value;
     buildSelect.replaceChildren(...readyBuilds.map(build =>
-      new Option(labelForBuild(build.combination_hash), build.combination_hash)));
+      new Option(identityForBuild(build.combination_hash), build.combination_hash)));
     if (readyBuilds.some(build => build.combination_hash === previousHash)) {
       buildSelect.value = previousHash;
     }
     buildSelect.disabled = !readyBuilds.length;
     selectedCount.textContent = `${selected} selected`;
     assignSelected.disabled = !selected || !readyBuilds.length;
-    assignAll.disabled = !scales.length || !readyBuilds.length;
     clearSelected.disabled = !selected;
     selectAll.checked = Boolean(scales.length) && selected === scales.length;
     selectAll.indeterminate = selected > 0 && selected < scales.length;
@@ -210,7 +210,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       const row = document.createElement("li");
       row.className = "fleet-build-row";
       row.innerHTML = `
-        <div class="fleet-build-name"><input class="build-label" maxlength="40" aria-label="Build label"></div>
+        <div class="fleet-build-name"><input class="build-label" maxlength="40" aria-label="Build label"><span class="build-hash"></span></div>
         <div class="fleet-build-version"><strong></strong><details><summary>Options</summary><span></span></details></div>
         <span class="deployment-state"></span>
         <div class="fleet-row-actions">
@@ -218,6 +218,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
         </div>`;
       const label = row.querySelector(".build-label");
       label.value = labelForBuild(build.combination_hash);
+      row.querySelector(".build-hash").textContent = shortHash(build.combination_hash, 8);
       label.addEventListener("keydown", event => { if (event.key === "Enter") label.blur(); });
       row.querySelector(".fleet-build-version strong").textContent = build.firmware_version;
       row.querySelector(".fleet-build-version span").textContent = buildSummary(build);
@@ -240,8 +241,8 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
           renderControls();
           scales.forEach((scale, index) => {
             const scaleRow = scaleRows.children[index];
-            if (scale.installed_combination === build.combination_hash) scaleRow.querySelector(".scale-build span").textContent = next;
-            if (scale.desired_combination === build.combination_hash) scaleRow.querySelector(".desired-build strong").textContent = next;
+            if (scale.installed_combination === build.combination_hash) scaleRow.querySelector(".scale-build span").textContent = identityForBuild(build.combination_hash);
+            if (scale.desired_combination === build.combination_hash) scaleRow.querySelector(".desired-build strong").textContent = identityForBuild(build.combination_hash);
           });
           showToast("Build label saved");
         } catch (error) {
@@ -293,10 +294,10 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       const installed = row.querySelector(".scale-build");
       installed.querySelector("strong").textContent = scale.firmware_version || "Unknown";
       installed.querySelector("span").textContent = scale.installed_combination
-        ? labelForBuild(scale.installed_combination) : (scale.last_seen_at ? "Official" : "Unknown");
+        ? identityForBuild(scale.installed_combination) : (scale.last_seen_at ? "Official" : "Unknown");
       const desired = row.querySelector(".desired-build");
       desired.querySelector("strong").textContent = scale.desired_combination
-        ? labelForBuild(scale.desired_combination) : "None";
+        ? identityForBuild(scale.desired_combination) : "None";
       const state = row.querySelector(".deployment-state");
       state.textContent = deploymentState(scale, buildStates);
       state.dataset.state = state.textContent.toLowerCase().replaceAll(" ", "-");
@@ -437,7 +438,6 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   assignSelected.addEventListener("click", () => assign(
     {device_ids: [...selectedDeviceIds]}, buildSelect.value, "Assign",
   ));
-  assignAll.addEventListener("click", () => assign({all: true}, buildSelect.value, "Assign to"));
   clearSelected.addEventListener("click", () => assign(
     {device_ids: [...selectedDeviceIds]}, null, "Clear assignment for",
   ));

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -24,7 +24,7 @@
     })();
   </script>
   <link rel="stylesheet" href="styles.css?v=17">
-  <link rel="stylesheet" href="fleet.css?v=5">
+  <link rel="stylesheet" href="fleet.css?v=6">
 </head>
 <body>
   <header class="topbar">
@@ -242,10 +242,9 @@
           <div class="deployment-toolbar">
             <label for="fleet-build-select">Build</label>
             <div class="select-wrap"><select id="fleet-build-select" disabled></select></div>
-            <label class="select-all-control"><input id="select-all-scales" type="checkbox"> All scales</label>
+            <label class="select-all-control"><input id="select-all-scales" type="checkbox"> Select all</label>
             <span id="selected-scale-count" class="selection-count">0 selected</span>
             <button id="assign-selected" class="primary-button" type="button" disabled>Assign to selected</button>
-            <button id="assign-all" class="ghost-bordered-button" type="button" disabled>Assign to all</button>
             <button id="clear-selected" class="ghost-button" type="button" disabled>Clear assignment</button>
           </div>
           <div class="fleet-table-wrap">
@@ -295,6 +294,6 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=25"></script>
+  <script type="module" src="app.js?v=26"></script>
 </body>
 </html>

--- a/include/custom_build_ota.h
+++ b/include/custom_build_ota.h
@@ -361,7 +361,7 @@ bool customBuildConfirmInstall(
   return false;
 }
 
-void customBuildRun() {
+void customBuildRun(bool interactive = true) {
   String deviceId;
   String deviceSecret;
   bool pairInitialized = false;
@@ -370,7 +370,8 @@ void customBuildRun() {
     return;
   }
   if (!pairInitialized) {
-    customBuildPairScale(true);
+    if (interactive) customBuildPairScale(true);
+    else customBuildShowStatus("Custom Build", "Pair scale first");
     return;
   }
   pullOtaDraw("Custom Build", "Checking");
@@ -416,7 +417,7 @@ void customBuildRun() {
     pullOtaFail("Signature failed");
     return;
   }
-  if (!customBuildConfirmInstall(manifest, assignment.combinationHash)) return;
+  if (interactive && !customBuildConfirmInstall(manifest, assignment.combinationHash)) return;
   const String rollbackCombinationHash = installedCombination;
   const bool rollbackFound = rollbackCombinationHash.length() > 0
       ? customBuildFetchManifest(rollbackCombinationHash, rollbackManifest)
@@ -439,10 +440,10 @@ void customBuildTask(void *args) {
     delay(1);
   }
   if (otaRuntimeIsPaused()) {
-    if (args != nullptr) {
+    if (reinterpret_cast<uintptr_t>(args) == 1) {
       if (customBuildConfirmRelink()) customBuildPairScale(false);
     } else {
-      customBuildRun();
+      customBuildRun(args == nullptr);
     }
   } else {
     pullOtaFail("OTA runtime pause failed");
@@ -457,7 +458,7 @@ void customBuildTask(void *args) {
   vTaskDelete(NULL);
 }
 
-void customBuildStart(bool relink) {
+void customBuildStart(bool relink, bool interactive = true) {
   if (b_pullOtaRunning || b_ota) return;
   setOtaRuntimePaused(false);
   b_pullOtaRunning = true;
@@ -466,7 +467,7 @@ void customBuildStart(bool relink) {
       customBuildTask,
       "Custom OTA",
       HDS_OTA_TASK_STACK_BYTES,
-      reinterpret_cast<void *>(static_cast<uintptr_t>(relink)),
+      reinterpret_cast<void *>(static_cast<uintptr_t>(relink ? 1 : (interactive ? 0 : 2))),
       1,
       NULL);
   if (started != pdPASS) {

--- a/include/menu.h
+++ b/include/menu.h
@@ -1421,7 +1421,11 @@ void wifiUpdate(const PullOtaTargetVersion &target) {
 #ifdef BUZZER
   buzzer.off();
 #endif
-  pullOtaUpdate(target);
+  if (pullOtaTargetIsAssignedCustomBuild(target)) {
+    customBuildStart(false, false);
+  } else {
+    pullOtaUpdate(target);
+  }
   leaveMenu();
 }
 
@@ -1433,6 +1437,15 @@ void wifiUpdate() {
 void showAbout() {
   actionMessage = FIRMWARE_VER;
   actionMessage2 = LINE3;
+  String buildIdentity;
+#ifdef HDS_CUSTOM_BUILD_COMBINATION_HASH
+  const String installedCombination = HDS_CUSTOM_BUILD_COMBINATION_HASH;
+  if (installedCombination.length() == 64) {
+    String hashPrefix = installedCombination.substring(0, 8);
+    hashPrefix.toUpperCase();
+    buildIdentity = String("Build: ") + hashPrefix;
+  }
+#endif
   b_showAbout = true;
   u8g2.setFont(FONT_S);
   invalidateEnergyOledFrame();
@@ -1440,8 +1453,11 @@ void showAbout() {
   do {
     u8g2.setFont(FONT_S);
     u8g2.drawStr(AC(actionMessage.c_str()), AM() - 24, actionMessage.c_str());
-    u8g2.drawStr(AC(actionMessage2.c_str()), AM(), actionMessage2.c_str());
-    u8g2.drawStr(AC(GIT_REV), AM()+ 24, GIT_REV);
+    u8g2.drawStr(AC(actionMessage2.c_str()), AM() - (buildIdentity.length() ? 8 : 0), actionMessage2.c_str());
+    u8g2.drawStr(AC(GIT_REV), AM() + (buildIdentity.length() ? 8 : 24), GIT_REV);
+    if (buildIdentity.length()) {
+      u8g2.drawStr(AC(buildIdentity.c_str()), AM() + 24, buildIdentity.c_str());
+    }
   } while (u8g2.nextPage());
 #ifdef BUZZER
   buzzer.off();

--- a/include/pull_ota_target.h
+++ b/include/pull_ota_target.h
@@ -35,6 +35,10 @@ inline bool pullOtaTargetByteIsBiased(uint8_t value) {
   return (value & HDS_OTA_TARGET_BYTE_BIAS) != 0;
 }
 
+inline bool pullOtaTargetIsAssignedCustomBuild(const PullOtaTargetVersion &target) {
+  return target.present && target.major == 0 && target.minor == 0 && target.patch == 0;
+}
+
 inline bool pullOtaTargetBytesAreBiased(const uint8_t *bytes, size_t count) {
   if (bytes == nullptr) {
     return false;

--- a/tools/test_custom_build_ota_contract.py
+++ b/tools/test_custom_build_ota_contract.py
@@ -78,7 +78,12 @@ def main():
     assert "HDS_OTA_TASK_STACK_BYTES = 24576" in pull_ota
     current_hash = function_body(pull_ota, "String pullOtaCurrentCombinationHash()")
     assert "HDS_CUSTOM_BUILD_COMBINATION_HASH" in current_hash
-    run = function_body(header, "void customBuildRun()")
+    run = function_body(header, "void customBuildRun(bool interactive = true)")
+    assert "if (interactive) customBuildPairScale(true);" in run
+    assert 'else customBuildShowStatus("Custom Build", "Pair scale first");' in run
+    assert "if (interactive && !customBuildConfirmInstall(manifest, assignment.combinationHash)) return;" in run
+    assert run.index("customBuildFetchManifest(assignment.combinationHash, manifest)") < run.index("if (interactive &&")
+    assert "customBuildRun(args == nullptr);" in header
     credentials = function_body(header, "bool customBuildLoadCredentials(")
     assert 'preferences.getBool("pair_init", false)' in credentials
     assert credentials.index('putBool("pair_init", false) == 1') < credentials.index('putString("device_id"')
@@ -145,6 +150,13 @@ def main():
     assert '"/api/v1/fleet/' not in header
     assert "fleet_secret" not in header
     menu = require("include/menu.h", '"Custom Build", customBuildMenu')
+    assert "if (pullOtaTargetIsAssignedCustomBuild(target))" in menu
+    assert "customBuildStart(false, false);" in menu
+    about = function_body(menu, "void showAbout() {")
+    assert "#ifdef HDS_CUSTOM_BUILD_COMBINATION_HASH" in about
+    assert "installedCombination.substring(0, 8)" in about
+    assert "hashPrefix.toUpperCase();" in about
+    assert 'String("Build: ") + hashPrefix' in about
     assert '"Relink", customBuildRelinkMenu' in menu
     assert "getMenuSize(connectionsMenu) - (customBuildRelinkAvailable() ? 0 : 1)" in menu
     assert menu.count("currentMenuSize = connectionsMenuSize();") == 2

--- a/tools/test_ota_reboot_routing_contract.py
+++ b/tools/test_ota_reboot_routing_contract.py
@@ -230,7 +230,8 @@ def main():
         "}",
     )
     assert_contains(MENU_HEADER, "void calibrate() {\n  leaveMenu();")
-    assert_contains(MENU_HEADER, "pullOtaUpdate(target);\n  leaveMenu();")
+    assert_contains(MENU_HEADER, "pullOtaUpdate(target);\n  }\n  leaveMenu();")
+    assert_contains(MENU_HEADER, "if (pullOtaTargetIsAssignedCustomBuild(target)) {\n    customBuildStart(false, false);")
     assert_contains(MENU_HEADER, "b_debug = true;\n  leaveMenu();")
     menu_contents = MENU_HEADER.read_text(encoding="utf-8")
     if menu_contents.count("markMenuRestartRequired();") != 2:

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,9 +254,9 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=25"' in indexPage
+    assert 'type="module" src="app.js?v=26"' in indexPage
     assert 'href="styles.css?v=17"' in indexPage
-    assert 'href="fleet.css?v=5"' in indexPage
+    assert 'href="fleet.css?v=6"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage
     assert 'fetch("catalog.json"' in appScript
@@ -271,7 +271,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=9' in appScript
+    assert 'fleet.js?v=10' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" not in fleetScript
     assert "localStorage.setItem(storageKey" in fleetScript

--- a/tools/test_pull_ota_target_contract.cpp
+++ b/tools/test_pull_ota_target_contract.cpp
@@ -21,6 +21,17 @@ static bool rejects(const char *text) {
 int main() {
   PullOtaTargetVersion absent = pullOtaNoTargetVersion();
   assert(!absent.present);
+  assert(!pullOtaTargetIsAssignedCustomBuild(absent));
+  const uint8_t customRequest[] = {0x03, 0x1B, 0x80, 0x80, 0x80};
+  assert(decentCommandFrameLength(customRequest, sizeof(customRequest), false) == 5);
+  assert(decentCommandFrameLength(customRequest, 3, false) == 0);
+  assert(decentCommandFrameLength(customRequest, 4, false) == 0);
+  const uint8_t customThenCommand[] = {0x03, 0x1B, 0x80, 0x80, 0x80, 0x03, 0x22};
+  assert(decentCommandFrameLength(customThenCommand, sizeof(customThenCommand), false) == 5);
+  assert(decentCommandFrameLength(customThenCommand + 5, 2, false) == 2);
+  assert(pullOtaTargetIsAssignedCustomBuild(pullOtaTargetFromBiasedBytes(customRequest + 2)));
+  assert(!pullOtaTargetIsAssignedCustomBuild(pullOtaMakeTargetVersion(3, 1, 14)));
+  assert(!pullOtaTargetIsAssignedCustomBuild(pullOtaMakeTargetVersion(0, 0, 1)));
 
   char buffer[HDS_OTA_TARGET_VERSION_BUFFER_BYTES];
   assert(!pullOtaFormatTargetVersion(absent, buffer, sizeof(buffer)));


### PR DESCRIPTION
## Changes
- Show the installed eight-character custom build hash in About, including builds without WiFi.
- Keep the editable Fleet name separate from its fixed hash; display both in build selection and installed/desired status. Preserve autosave and wrap mobile status text.
- Remove redundant Assign to all; keep Select all and Assign to selected.
- Reserve target 0.0.0 (03 1B 80 80 80) for unattended installation of the assigned Custom Build through the existing BLE/USB OTA queue. The shared WebSocket target dispatcher supports the same sentinel.
- Preserve normal release targets, interactive menu confirmation, authenticated assignment, signatures, mandatory LittleFS, rollback-asset verification, and the already-installed no-download path. Remote requests never initiate pairing.

## Validation
- ESP32-S3 firmware build passed locally.
- Custom OTA, Decent OTA target (including native C++ framing checks), reboot routing, pull OTA, rollback and AI documentation contract tests passed.
- All 16 configurator tests passed.
- Local browser harness passed autosave, dependent identity updates and error rollback; desktop/mobile screenshots inspected.
- No Worker deployment, firmware flash or release tag performed.

## Hardware validation still open
- After merge, generate a signed main custom build and test About, USB-triggered Custom OTA, negative cases, existing release command compatibility and basic scale functions.
- Verify the web changes on GitHub Pages after deployment.
- BLE OTA hardware validation is explicitly deferred until after Stable 3.1.14 because the required BLE client software is not yet available. It is not considered passed.
- Controlled hardware rollback testing is deferred separately and remains untested. Rollback protections are not bypassed.