### PR TITLE
Fix custom-to-release OTA rollback manifest lookup

### DIFF
--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -45,6 +45,10 @@ About also shows the installed custom combination as `Build: XXXXXXXX`, without
 network access. Official firmware keeps the version, date, and Git revision display.
 The reserved remote OTA target `0.0.0` starts the assigned custom build unattended;
 the menu retains its local install confirmation. Remote requests never initiate pairing.
+When installing an official release from custom firmware, the rollback manifest must
+come from the installed full combination hash and pass custom signature verification.
+Both remote and interactive release installs retain that hash in the LittleFS rollback
+transaction. Official firmware continues to resolve its rollback manifest by version.
 
 ## Release Assets
 

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -168,6 +168,8 @@ struct PullOtaManifest {
   PullOtaAsset littlefs;
 };
 
+bool customBuildFetchManifest(const String &combinationHash, PullOtaManifest &manifest);
+
 struct PullOtaReleaseList {
   PullOtaManifest releases[HDS_OTA_MAX_RELEASE_CHOICES];
   uint8_t count = 0;
@@ -1571,8 +1573,14 @@ void pullOtaRunUpdate(const PullOtaTargetVersion &target) {
     delay(2000);
     return;
   }
-  rollbackFound = pullOtaFindCurrentRelease(catalog, rollbackManifest);
-  if (!rollbackFound && !pullOtaFetchCurrentReleaseManifest(rollbackManifest)) {
+  const String rollbackCombinationHash = pullOtaCurrentCombinationHash();
+  if (rollbackCombinationHash.length() > 0) {
+    rollbackFound = customBuildFetchManifest(rollbackCombinationHash, rollbackManifest);
+  } else {
+    rollbackFound = pullOtaFindCurrentRelease(catalog, rollbackManifest);
+    if (!rollbackFound) rollbackFound = pullOtaFetchCurrentReleaseManifest(rollbackManifest);
+  }
+  if (!rollbackFound) {
     pullOtaFail("Rollback missing");
     return;
   }
@@ -1583,7 +1591,7 @@ void pullOtaRunUpdate(const PullOtaTargetVersion &target) {
       return;
     }
     PullOtaManifest manifest = std::move(catalog.releases[selectedCatalogIndex]);
-    pullOtaInstall(manifest, rollbackManifest);
+    pullOtaInstall(manifest, rollbackManifest, "", rollbackCombinationHash);
     return;
   }
   if (!pullOtaHasNewerRelease(catalog, selection)) {
@@ -1597,7 +1605,7 @@ void pullOtaRunUpdate(const PullOtaTargetVersion &target) {
   if (!pullOtaConfirmInstall(manifest)) {
     return;
   }
-  pullOtaInstall(manifest, rollbackManifest);
+  pullOtaInstall(manifest, rollbackManifest, "", rollbackCombinationHash);
 }
 
 void pullOtaStoreRequestedTarget(const PullOtaTargetVersion &target) {

--- a/tools/test_pull_ota_contract.py
+++ b/tools/test_pull_ota_contract.py
@@ -100,7 +100,7 @@ def main():
     assert_before(
         PULL_OTA_HEADER,
         "rollbackFound = pullOtaFindCurrentRelease(catalog, rollbackManifest)",
-        "!rollbackFound && !pullOtaFetchCurrentReleaseManifest(rollbackManifest)",
+        "if (!rollbackFound) rollbackFound = pullOtaFetchCurrentReleaseManifest(rollbackManifest)",
     )
     assert_contains(PULL_OTA_HEADER, "wifi_init();")
     assert_contains(PULL_OTA_HEADER, "pullOtaStorePendingLittleFs")
@@ -180,12 +180,20 @@ def main():
     targeted = run[targeted_start:run.index("if (!pullOtaHasNewerRelease(catalog, selection)) {")]
     if "pullOtaPickRelease" in targeted or "pullOtaConfirmInstall" in targeted:
         raise AssertionError("an unattended install must not open the picker or the confirm prompt")
-    if "pullOtaInstall(manifest, rollbackManifest);" not in targeted:
+    if 'pullOtaInstall(manifest, rollbackManifest, "", rollbackCombinationHash);' not in targeted:
         raise AssertionError("an unattended install must reuse pullOtaInstall")
     if run.index("pullOtaFindCurrentRelease(catalog, rollbackManifest)") > targeted_start:
         raise AssertionError("the rollback manifest must be resolved before an unattended install")
 
     interactive = run[run.index("if (!pullOtaHasNewerRelease(catalog, selection)) {"):]
+    assert "const String rollbackCombinationHash = pullOtaCurrentCombinationHash();" in run
+    custom_start = run.index("if (rollbackCombinationHash.length() > 0) {")
+    custom_branch = run[custom_start:run.index("} else {", custom_start)]
+    assert "customBuildFetchManifest(rollbackCombinationHash, rollbackManifest)" in custom_branch
+    assert "pullOtaFindCurrentRelease" not in custom_branch
+    assert "pullOtaFetchCurrentReleaseManifest" not in custom_branch
+    assert 'pullOtaInstall(manifest, rollbackManifest, "", rollbackCombinationHash);' in interactive
+    assert run.index('pullOtaFail("Rollback missing")') < targeted_start
     if "pullOtaPickRelease(catalog, selection, &selectedCatalogIndex)" not in interactive:
         raise AssertionError("the interactive picker must remain on the no-target path")
     if "pullOtaConfirmInstall(manifest)" not in interactive:


### PR DESCRIPTION
## Reproduced failure
On signed custom build BEE2A51A, USB target 03 1B 83 81 8E reached official release OTA but returned Rollback missing. The release path searched only official version manifests for the currently installed custom firmware.

## Fix
- Resolve the rollback manifest using the installed full combination hash and the existing custom signature verifier.
- Keep the official version lookup for non-custom firmware.
- Preserve the custom rollback combination in both interactive and unattended official-release LittleFS transactions.
- Do not bypass missing-manifest, signature, hash, or rollback checks.

## Validation
- Local esp32s3 build passed.
- Pull OTA, custom OTA and rollback contract tests passed, including both release entry paths and custom identity propagation.
- Hardware retest on a signed merged build remains open.
- Controlled rollback testing remains deferred, not passed. No stable tag or release created.