### PR TITLE
Simplify Save build and My scales workflow

### DIFF
--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -285,6 +285,23 @@ test("fleet names save on change without separate save actions", async () => {
   }
 });
 
+test("ready WiFi builds save next to the build action and navigate without assignment", async () => {
+  const html = await readFile(new URL("../../../docs/custom-build/index.html", import.meta.url), "utf8");
+  const app = await readFile(new URL("../../../docs/custom-build/app.js", import.meta.url), "utf8");
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  assert.equal(html.match(/id="add-fleet-build"/g).length, 1);
+  assert.ok(html.indexOf('id="add-fleet-build"') < html.indexOf('id="fleet-panel"'));
+  assert.ok(html.includes('>Saved builds</h4>'));
+  assert.equal(/>[^<]*fleet[^<]*</i.test(html), false);
+  assert.ok(app.includes('installMethod === "wifi" && currentBuildState === "ready"'));
+  const save = source.slice(source.indexOf('addBuild.addEventListener("click"'), source.indexOf('selectAll.addEventListener("change"'));
+  assert.ok(save.includes('buildSelect.value = combinationHash'));
+  assert.ok(save.includes('scrollIntoView'));
+  assert.ok(save.includes('if (await loadFleet() && getReadyHash() === combinationHash) showScales()'));
+  assert.equal(save.includes('/assignments'), false);
+  assert.ok(save.includes('savingBuild = true'));
+});
+
 test("fleet assignment uses only the explicit scale selection", async () => {
   const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
   const html = await readFile(new URL("../../../docs/custom-build/index.html", import.meta.url), "utf8");

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=10";
+import {initFleet} from "./fleet.js?v=11";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
 
 (async () => {
@@ -475,7 +475,7 @@ import {buildEstimate} from "./build-estimate.mjs?v=1";
 
   initFleet({
     apiBase,
-    getReadyHash: () => currentBuildState === "ready" ? currentCombinationHash : "",
+    getReadyHash: () => installMethod === "wifi" && currentBuildState === "ready" ? currentCombinationHash : "",
     showToast,
   });
   render();

--- a/docs/custom-build/fleet.css
+++ b/docs/custom-build/fleet.css
@@ -1,4 +1,7 @@
+#add-fleet-build[hidden] { display: none; }
+
 .fleet-section {
+  scroll-margin-top: 90px;
   min-width: 0;
   padding: 22px 0;
   border-top: 1px solid var(--line);

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -91,6 +91,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   let builds = [];
   let buildStates = {};
   let selectedDeviceIds = new Set();
+  let savingBuild = false;
 
   const setSettingsOpen = open => {
     settings.hidden = !open;
@@ -145,11 +146,11 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     const messages = {
       build_assigned: "Clear this build from assigned scales before removing it",
       build_not_ready: "Only ready custom builds can be added or assigned",
-      cross_fleet_device: "One or more scales belong to another fleet",
+      cross_fleet_device: "One or more scales are linked elsewhere",
       device_not_found: "One or more scales are no longer linked",
       empty_target_set: "Select at least one scale",
     };
-    showToast(messages[error.code] || "Fleet change could not be saved");
+    showToast(messages[error.code] || "Change could not be saved");
   };
 
   const renderControls = () => {
@@ -169,13 +170,15 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     selectAll.indeterminate = selected > 0 && selected < scales.length;
     const readyHash = getReadyHash();
     const alreadyAdded = builds.some(build => build.combination_hash === readyHash);
-    addBuild.disabled = !scales.length || !readyHash || alreadyAdded;
-    addBuild.textContent = alreadyAdded ? "Build added" : "Add current build";
+    addBuild.hidden = !readyHash;
+    addBuild.disabled = !scales.length || !readyHash || savingBuild;
+    addBuild.textContent = savingBuild ? "Saving..." : alreadyAdded ? "My scales" : "Save build";
+    addBuild.title = !scales.length ? "Link a scale first" : "";
   };
 
   const loadFleet = async () => {
     const currentGeneration = ++generation;
-    fleetStatus.textContent = "Loading fleet";
+    fleetStatus.textContent = "Loading scales";
     buildStatus.textContent = "";
     try {
       const result = await api("/api/v1/fleet/overview");
@@ -191,9 +194,11 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
         ? `${scales.length} scale${scales.length === 1 ? "" : "s"}` : "No scales linked yet";
       buildStatus.textContent = builds.length
         ? `${builds.length} saved build${builds.length === 1 ? "" : "s"}` : "No saved builds";
+      return true;
     } catch {
       if (currentGeneration !== generation) return;
-      fleetStatus.textContent = "Fleet could not be loaded";
+      fleetStatus.textContent = "Scales could not be loaded";
+      return false;
     }
   };
 
@@ -201,7 +206,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     if (!builds.length) {
       const empty = document.createElement("li");
       empty.className = "fleet-empty-row";
-      empty.textContent = "Add the ready build shown above to use it for deployments.";
+      empty.textContent = "No saved builds";
       buildList.replaceChildren(empty);
       renderControls();
       return;
@@ -256,7 +261,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
         if (!(await confirm("Remove saved build?", `${labelForBuild(build.combination_hash)} will remain available to existing installations.`, "Remove"))) return;
         try {
           await api(`/api/v1/fleet/builds/${build.combination_hash}`, {method: "DELETE"});
-          showToast("Build removed from fleet");
+          showToast("Saved build removed");
           await loadFleet();
         } catch (error) {
           showApiError(error);
@@ -352,11 +357,11 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   const activateKey = key => {
     fleetKey = normalizedFleetKey(key);
     if (!fleetPattern.test(fleetKey)) {
-      showToast("Enter a valid fleet recovery key");
+      showToast("Enter a valid recovery key");
       return false;
     }
     if (!saveKey(fleetKey)) {
-      showToast("Fleet access could not be saved. Allow browser storage and try again.");
+      showToast("Scale access could not be saved. Allow browser storage and try again.");
       return false;
     }
     setMode(true);
@@ -377,9 +382,9 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   document.querySelector("#copy-fleet-key").addEventListener("click", async () => {
     try {
       await navigator.clipboard.writeText(formattedFleetKey(fleetKey));
-      showToast("Fleet recovery key copied");
+      showToast("Recovery key copied");
     } catch {
-      showToast("Fleet key could not be copied");
+      showToast("Recovery key could not be copied");
     }
   });
   document.querySelector("#forget-fleet").addEventListener("click", () => forgetDialog.showModal());
@@ -396,6 +401,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     buildList.replaceChildren();
     scaleRows.replaceChildren();
     setMode(false);
+    renderControls();
   });
   document.querySelector("#pair-scale").addEventListener("submit", async event => {
     event.preventDefault();
@@ -418,16 +424,33 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   });
   addBuild.addEventListener("click", async () => {
     const combinationHash = getReadyHash();
-    if (!combinationHash) return;
+    if (!combinationHash || !scales.length || savingBuild) return;
+    const showScales = () => {
+      buildSelect.value = combinationHash;
+      document.querySelector(".fleet-scales-section").scrollIntoView({
+        behavior: matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth",
+        block: "start",
+      });
+      buildSelect.focus({preventScroll: true});
+    };
+    if (builds.some(build => build.combination_hash === combinationHash)) {
+      showScales();
+      return;
+    }
+    savingBuild = true;
+    renderControls();
     try {
       await api("/api/v1/fleet/builds", {
         method: "POST",
         body: JSON.stringify({combination_hash: combinationHash}),
       });
-      showToast("Build added to fleet");
-      await loadFleet();
+      showToast("Build saved");
+      if (await loadFleet() && getReadyHash() === combinationHash) showScales();
     } catch (error) {
       showApiError(error);
+    } finally {
+      savingBuild = false;
+      renderControls();
     }
   });
   selectAll.addEventListener("change", () => {
@@ -444,5 +467,6 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   document.addEventListener("openscale-build-status", renderControls);
 
   setMode(Boolean(fleetKey));
+  renderControls();
   if (fleetKey) loadFleet();
 }

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -24,7 +24,7 @@
     })();
   </script>
   <link rel="stylesheet" href="styles.css?v=17">
-  <link rel="stylesheet" href="fleet.css?v=6">
+  <link rel="stylesheet" href="fleet.css?v=7">
 </head>
 <body>
   <header class="topbar">
@@ -159,6 +159,7 @@
             <div id="downloads" class="downloads" aria-label="Build downloads"></div>
             <div class="actions">
               <button id="request-build" class="primary-button" type="button" disabled>Request build</button>
+              <button id="add-fleet-build" class="primary-button" type="button" hidden disabled>Save build</button>
             </div>
           </div>
         </section>
@@ -176,31 +177,30 @@
       <div class="fleet-head">
         <div>
           <h3 id="fleet-heading">My scales</h3>
-          <p>Add scales using the temporary codes shown on their OLED. Adding the first scale creates a fleet.</p>
         </div>
-        <button id="fleet-settings-toggle" class="icon-button" type="button" title="Fleet settings" aria-label="Fleet settings" aria-expanded="false" aria-controls="fleet-settings">
+        <button id="fleet-settings-toggle" class="icon-button" type="button" title="Scale settings" aria-label="Scale settings" aria-expanded="false" aria-controls="fleet-settings">
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
         </button>
       </div>
 
       <div id="fleet-settings" class="fleet-settings" hidden>
         <form id="use-fleet" class="existing-fleet-form">
-          <label class="field-label" for="existing-fleet-key">Use existing fleet</label>
+          <label class="field-label" for="existing-fleet-key">Recovery key</label>
           <div class="inline-form">
             <input id="existing-fleet-key" type="text" inputmode="text" autocomplete="off" spellcheck="false" placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX">
-            <button class="ghost-bordered-button" type="submit">Open fleet</button>
+            <button class="ghost-bordered-button" type="submit">Restore access</button>
           </div>
         </form>
         <div id="fleet-recovery" class="recovery-row" hidden>
           <div class="recovery-key">
-            <label class="field-label" for="fleet-recovery-key">Fleet recovery key</label>
+            <label class="field-label" for="fleet-recovery-key">Recovery key</label>
             <input id="fleet-recovery-key" type="text" readonly>
           </div>
           <div class="icon-actions">
-            <button id="copy-fleet-key" class="icon-button" type="button" title="Copy fleet recovery key" aria-label="Copy fleet recovery key">
+            <button id="copy-fleet-key" class="icon-button" type="button" title="Copy recovery key" aria-label="Copy recovery key">
               <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
             </button>
-            <button id="forget-fleet" class="ghost-button" type="button">Forget in this tab</button>
+            <button id="forget-fleet" class="ghost-button" type="button">Forget on this browser</button>
           </div>
         </div>
       </div>
@@ -221,10 +221,9 @@
         <section class="fleet-section" aria-labelledby="fleet-builds-heading">
           <div class="fleet-section-head">
             <div>
-              <h4 id="fleet-builds-heading">Fleet builds</h4>
+              <h4 id="fleet-builds-heading">Saved builds</h4>
               <p id="fleet-build-status" class="fleet-status" role="status" aria-live="polite"></p>
             </div>
-            <button id="add-fleet-build" class="primary-button" type="button" disabled>Add current build</button>
           </div>
           <div class="fleet-build-labels" aria-hidden="true">
             <span>Label</span><span>Firmware and options</span><span>Availability</span><span></span>
@@ -235,7 +234,7 @@
         <section class="fleet-section fleet-scales-section" aria-labelledby="fleet-scales-heading">
           <div class="fleet-section-head">
             <div>
-              <h4 id="fleet-scales-heading">Scales</h4>
+              <h4 id="fleet-scales-heading">My scales</h4>
               <p id="fleet-status" class="fleet-status" role="status" aria-live="polite"></p>
             </div>
           </div>
@@ -274,18 +273,18 @@
 
   <dialog id="forget-fleet-dialog" class="confirm-dialog" aria-labelledby="forget-fleet-heading" aria-describedby="forget-fleet-description">
     <form method="dialog">
-      <h3 id="forget-fleet-heading">Forget fleet in this tab?</h3>
-      <p id="forget-fleet-description">Linked scales will not be deleted. You will need the recovery key to open this fleet again.</p>
+      <h3 id="forget-fleet-heading">Forget access on this browser?</h3>
+      <p id="forget-fleet-description">Linked scales and saved builds will not be deleted. You will need the recovery key to restore access.</p>
       <div class="dialog-actions">
         <button class="ghost-bordered-button" type="submit" value="cancel" autofocus>Cancel</button>
-        <button class="danger-button" type="submit" value="confirm">Forget fleet</button>
+        <button class="danger-button" type="submit" value="confirm">Forget access</button>
       </div>
     </form>
   </dialog>
 
   <dialog id="fleet-confirm-dialog" class="confirm-dialog" aria-labelledby="fleet-confirm-heading" aria-describedby="fleet-confirm-description">
     <form method="dialog">
-      <h3 id="fleet-confirm-heading">Confirm fleet change</h3>
+      <h3 id="fleet-confirm-heading">Confirm change</h3>
       <p id="fleet-confirm-description"></p>
       <div class="dialog-actions">
         <button class="ghost-bordered-button" type="submit" value="cancel" autofocus>Cancel</button>
@@ -294,6 +293,6 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=26"></script>
+  <script type="module" src="app.js?v=27"></script>
 </body>
 </html>

--- a/tools/test_custom_build_execution.py
+++ b/tools/test_custom_build_execution.py
@@ -493,7 +493,7 @@ def main():
     assert "catalogRevisionChanged(fetch, catalog.catalog_revision)" in configurator
     assert "await checkStatus(selection, generation)" in configurator
     assert "navigator.clipboard.writeText(currentCombinationHash)" not in configurator
-    assert 'getReadyHash: () => currentBuildState === "ready" ? currentCombinationHash : ""' in configurator
+    assert 'getReadyHash: () => installMethod === "wifi" && currentBuildState === "ready" ? currentCombinationHash : ""' in configurator
     assert "expectedHash" not in configurator
     configuratorWorkflow = (
         customBuild.SCRIPT_ROOT / ".github" / "workflows" / "custom-build-configurator.yml"

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,9 +254,9 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=26"' in indexPage
+    assert 'type="module" src="app.js?v=27"' in indexPage
     assert 'href="styles.css?v=17"' in indexPage
-    assert 'href="fleet.css?v=6"' in indexPage
+    assert 'href="fleet.css?v=7"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage
     assert 'fetch("catalog.json"' in appScript
@@ -271,7 +271,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=10' in appScript
+    assert 'fleet.js?v=11' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" not in fleetScript
     assert "localStorage.setItem(storageKey" in fleetScript


### PR DESCRIPTION
## Changes
- Put Save build next to Request build for ready WiFi builds; remove the duplicate lower action.
- After a successful save, scroll to My scales and select the saved build. Already saved builds show My scales and navigate without another POST.
- Never automatically assign a build or start installation. Disable saves until a scale is linked and while a save is pending.
- Replace user-facing Fleet wording with My scales, Saved builds and Recovery key, including dialogs and notifications. Keep API identifiers and persisted recovery keys unchanged.
- Respect reduced motion, focus the build selector and prevent hidden buttons being exposed by existing CSS.

## Validation
- 17 configurator tests passed.
- Isolated browser harness passed autosave, failed save recovery, save/navigation, fixed identity, duplicate-save prevention and hidden non-ready state.
- Desktop and mobile screenshots inspected.
- No firmware changes, hardware flash, Worker deployment or release tags.