### PR TITLE
Add guided custom build wizard

### DIFF
--- a/cloudflare/custom-build-worker/test/wizard.test.mjs
+++ b/cloudflare/custom-build-worker/test/wizard.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import {readFile} from "node:fs/promises";
+import {test} from "node:test";
+import {runInNewContext} from "node:vm";
+
+test("wizard navigates WiFi and USB steps without performing build actions", async () => {
+  const elements = new Map();
+  const element = key => {
+    if (!elements.has(key)) {
+      const classes = new Set();
+      elements.set(key, {
+        events: {}, attributes: {},
+        classList: {add: value => classes.add(value), remove: value => classes.delete(value)},
+        setAttribute(name, value) { this.attributes[name] = value; },
+        addEventListener(name, handler) { this.events[name] = handler; },
+        prepend(child) { this.child = child; },
+        append() {},
+        closest() { return element(`${key}-panel`); },
+        querySelector: element,
+        focus() { document.activeElement = this; },
+        scrollIntoView() {},
+      });
+    }
+    return elements.get(key);
+  };
+  const radio = element("radio");
+  radio.value = "wifi";
+  const document = {
+    body: element("body"),
+    querySelector: selector => selector.includes(":checked") ? radio : element(selector),
+    querySelectorAll: () => [radio],
+    getElementById: element,
+    createElement: name => element(`created-${name}`),
+    addEventListener: (name, handler) => element("document").addEventListener(name, handler),
+  };
+  const source = await readFile(new URL("../../../docs/custom-build/wizard.js", import.meta.url), "utf8");
+  runInNewContext(source, {document});
+  const click = selector => element(selector).events.click();
+  const progress = element(".wizard-progress");
+  const guide = element("created-div");
+  click("#start-wizard");
+  for (let step = 1; step <= 5; step++) {
+    assert.equal(progress.textContent, `Step ${step} of 5`);
+    click('[data-action="next"]');
+  }
+  assert.equal(guide.hidden, true);
+  assert.equal(document.activeElement, element("#start-wizard"));
+  radio.value = "usb";
+  click("#start-wizard");
+  click('[data-action="next"]');
+  click('[data-action="back"]');
+  assert.equal(progress.textContent, "Step 1 of 4");
+  radio.value = "wifi";
+  radio.events.change();
+  assert.equal(progress.textContent, "Step 1 of 5");
+  for (let step = 1; step < 5; step++) click('[data-action="next"]');
+  radio.value = "usb";
+  radio.events.change();
+  assert.equal(progress.textContent, "Step 4 of 4");
+  assert.equal(element('[data-action="next"]').textContent, "Finish");
+  element("document").events.keydown({key: "Escape"});
+  assert.equal(guide.hidden, true);
+  assert.equal(element("#start-wizard").attributes["aria-expanded"], "false");
+});

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -25,6 +25,7 @@
   </script>
   <link rel="stylesheet" href="styles.css?v=17">
   <link rel="stylesheet" href="fleet.css?v=7">
+  <link rel="stylesheet" href="wizard.css?v=1">
 </head>
 <body>
   <header class="topbar">
@@ -34,6 +35,10 @@
         <h1 class="brand-name">HDS custom build</h1>
       </div>
       <div class="topbar-actions">
+        <button id="start-wizard" class="workflow-link" type="button" aria-label="Wizard" title="Wizard" aria-expanded="false" aria-controls="build-wizard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+          <span>Wizard</span>
+        </button>
         <nav class="topbar-links" aria-label="Related tools">
           <a id="hds-updater-link" class="workflow-link" href="https://decentespresso.github.io/hds-updater/" target="_blank" rel="noreferrer" aria-label="Open HDS Updater">
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M10 14 21 3M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
@@ -86,7 +91,6 @@
                 <h3 id="firmware-heading">Firmware version</h3>
                 <p class="panel-note">Choose the release to build from.</p>
               </div>
-              <span class="count-pill">Step 1</span>
             </div>
             <label class="field-label" for="firmware-ref">Firmware version</label>
             <div class="firmware-row">
@@ -294,5 +298,6 @@
   </dialog>
 
   <script type="module" src="app.js?v=27"></script>
+  <script type="module" src="wizard.js?v=1"></script>
 </body>
 </html>

--- a/docs/custom-build/wizard.css
+++ b/docs/custom-build/wizard.css
@@ -1,0 +1,29 @@
+.wizard-step-number {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: .75rem;
+  font-weight: 600;
+}
+.wizard-active { outline: 2px solid var(--green); outline-offset: 3px; }
+.wizard-guide {
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--green-line);
+  background: var(--green-soft);
+  color: var(--ink);
+  scroll-margin-top: 90px;
+}
+.wizard-guide[hidden] { display: none; }
+.wizard-guide:not([hidden]) + .fleet-head { margin-top: 24px; }
+.wizard-progress { margin: 0; font-weight: 700; }
+.wizard-explanation { margin: 10px 0 16px; font-size: .875rem; line-height: 1.6; }
+.wizard-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+#start-wizard { flex-shrink: 0; border: 0; padding: 0; cursor: pointer; }
+@media (min-width: 641px) {
+  #start-wizard { background: transparent; }
+}
+@media (max-width: 600px) {
+  .topbar-inner { height: auto; min-height: 72px; flex-wrap: wrap; gap: 10px; padding-block: 10px; }
+  .topbar-actions { flex-wrap: wrap; }
+  .wizard-guide { padding: 16px; scroll-margin-top: 150px; }
+}

--- a/docs/custom-build/wizard.js
+++ b/docs/custom-build/wizard.js
@@ -1,0 +1,69 @@
+const start = document.querySelector("#start-wizard");
+const steps = [
+  ["firmware-heading", "Choose a firmware version and WiFi or USB installation. main contains development changes; a release uses that published version."],
+  ["features-heading", "Choose the features you need. Required dependencies are selected automatically and cannot be removed while another selection needs them."],
+  ["plugins-heading", "Choose optional approved plugins. Only plugins compatible with your firmware version are available."],
+  ["summary-heading", "Review your selection and request the build when ready. Wait for it to finish, then download the ZIP for USB or save the build for your scales."],
+  ["fleet-heading", "Add your scale using its pairing code and keep your recovery key safe. Save the ready build, select your scale and assign the build. On the scale, open Custom Build to confirm installation."]
+].map(([id, description], index) => {
+  const heading = document.getElementById(id);
+  const number = document.createElement("span");
+  number.className = "wizard-step-number";
+  number.textContent = `Step ${index + 1}`;
+  heading.prepend(number);
+  return {heading, description, panel: heading.closest("section.panel")};
+});
+const guide = document.createElement("div");
+guide.id = "build-wizard";
+guide.className = "wizard-guide";
+guide.hidden = true;
+guide.setAttribute("role", "region");
+guide.setAttribute("aria-label", "Build wizard");
+guide.innerHTML = `<p class="wizard-progress" tabindex="-1"></p>
+  <p class="wizard-explanation"></p>
+  <div class="wizard-actions">
+    <button type="button" class="ghost-bordered-button" data-action="back">Back</button>
+    <button type="button" class="primary-button" data-action="next">Next</button>
+    <button type="button" class="ghost-button" data-action="close">Close</button>
+  </div>`;
+document.body.append(guide);
+const progress = guide.querySelector(".wizard-progress");
+const explanation = guide.querySelector(".wizard-explanation");
+const back = guide.querySelector('[data-action="back"]');
+const next = guide.querySelector('[data-action="next"]');
+let current = -1;
+const stepCount = () => document.querySelector('[name="install-method"]:checked')?.value === "usb" ? 4 : 5;
+const show = index => {
+  steps.forEach(step => step.panel.classList.remove("wizard-active"));
+  current = Math.min(index, stepCount() - 1);
+  const step = steps[current];
+  step.panel.classList.add("wizard-active");
+  step.panel.prepend(guide);
+  guide.hidden = false;
+  start.setAttribute("aria-expanded", "true");
+  progress.textContent = `Step ${current + 1} of ${stepCount()}`;
+  explanation.textContent = step.description;
+  back.disabled = current === 0;
+  next.textContent = current === stepCount() - 1 ? "Finish" : "Next";
+  progress.focus({preventScroll: true});
+  guide.scrollIntoView({block: "start", behavior: "instant"});
+};
+const close = () => {
+  current = -1;
+  guide.hidden = true;
+  steps.forEach(step => step.panel.classList.remove("wizard-active"));
+  start.setAttribute("aria-expanded", "false");
+  start.focus();
+};
+start.addEventListener("click", () => current < 0 ? show(0) : close());
+back.addEventListener("click", () => show(current - 1));
+next.addEventListener("click", () => current === stepCount() - 1 ? close() : show(current + 1));
+guide.querySelector('[data-action="close"]').addEventListener("click", close);
+document.addEventListener("keydown", event => {
+  if (event.key === "Escape" && current >= 0) close();
+});
+document.querySelectorAll('[name="install-method"]').forEach(input => {
+  input.addEventListener("change", () => {
+    if (current >= 0) show(current);
+  });
+});


### PR DESCRIPTION
## Summary
- Add an optional Wizard beside HDS Updater using matching navigation styling.
- Number and highlight Firmware, Features, Approved plugins and Build summary; include My scales only for WiFi.
- Add inline explanations, Back/Next/Finish/Close controls, Escape dismissal and focus restoration.
- Keep build requests, saving, assignment and installation explicitly user-controlled.
- Include the locally reviewed Step 5 spacing fix. No firmware or Worker runtime changes.

## Validation
- 18 Node tests passed, including a new wizard navigation regression test.
- Local Playwright checks passed at 1280px and 390px: WiFi/USB traversal, mode switching, Back, Escape, focus restoration, Step 5 spacing and horizontal overflow.
- Browser API responses were mocked; no production writes or hardware operations.
- User reviewed the local UI and approved creating this PR.
- git diff --check passed.