### PR TITLE
Enable tagged Preview 3 custom builds

### DIFF
--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -71,7 +71,8 @@ test("ships 3.1.14 compatibility while main remains the cutover default", async 
   const shipped = JSON.parse(await readFile(
     new URL("../../../docs/custom-build/catalog.json", import.meta.url), "utf8",
   ));
-  assert.deepEqual(shipped.firmware_refs, ["v3.1.14", "main"]);
+  assert.deepEqual(shipped.firmware_refs, ["v3.1.14", "v3.1.14-preview.3", "main"]);
+  assert.equal(firmwareRefLabel(shipped.firmware_refs[1]), "3.1.14-preview.3 (preview)");
   assert.equal(firmwareRefLabel(defaultSelection(shipped).firmware_ref), "main (development)");
   assert.equal(firmwareRefLabel(shipped.firmware_refs[0]), "3.1.14 (stable)");
 });

--- a/cloudflare/custom-build-worker/wrangler.toml
+++ b/cloudflare/custom-build-worker/wrangler.toml
@@ -5,7 +5,7 @@ workers_dev = true
 
 [vars]
 ALLOWED_ORIGIN = "https://decentespresso.github.io"
-ALLOWED_FIRMWARE_REFS = "main,v3.1.14"
+ALLOWED_FIRMWARE_REFS = "main,v3.1.14,v3.1.14-preview.3"
 BUILDER_REF = "main"
 GITHUB_REPOSITORY = "decentespresso/openscale"
 GITHUB_WORKFLOW = "custom-build.yml"

--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -49,6 +49,8 @@ Do not add an environment merely because it exists. Changes limited to ADS1232 b
 
 ## Enabling a Stable Custom Base
 
+`v3.1.14-preview.3` is an explicitly allowed immutable custom-build source for tag-based validation. Its custom firmware reports `3.1.14-preview.3-custom`, even though the tagged source header still defaults to `3.1.14`. The builder derives tagged versions from the tag rather than that header. Keep `main` as the configurator default until the stable cutover. Custom preview builds receive their own signed manifests and combination hashes; the separately published non-custom preview ZIP has no signed rollback manifest and is not a custom OTA baseline.
+
 In the release-preparation pull request, add the prospective `vX.Y.Z` tag to `FIRMWARE_REFS`, compatible plugin manifests, and the Worker's `ALLOWED_FIRMWARE_REFS` without removing `main` or making the tag the default. Regenerate both custom-build catalogs. When the tag does not exist, pull-request jobs may create a temporary local tag at the candidate commit and must pass its resolved commit explicitly when compiling the stable custom build. Do not create or push the real tag before the pre-tag gate passes. After the catalog commit reaches the trusted builder branch and the real tag exists, deploy the overlapping Worker configuration, then switch the configurator and build defaults to `vX.Y.Z` in a follow-up commit. After the stable path is live and before publishing the release, remove `main` from the catalog and Worker allow-list so development builds cannot consume production build quota. The configurator displays `vX.Y.Z` as `X.Y.Z (stable)`, and the resulting firmware reports `X.Y.Z-custom`.
 
 ## Focused Checks

--- a/docs/custom-build/catalog.json
+++ b/docs/custom-build/catalog.json
@@ -1,8 +1,9 @@
 {
-  "catalog_revision": "6cc29f6843a071e97e9a816ed7d36e33abc4e5d340b396788f7d7c04dfe5677d",
+  "catalog_revision": "9c45e0a71081cb3c7cddbd8e579df671dccbb71492b657c48c15fd8fb830d04a",
   "custom_ota_signing_key_generation": 1,
   "firmware_refs": [
     "v3.1.14",
+    "v3.1.14-preview.3",
     "main"
   ],
   "features": [
@@ -14,6 +15,7 @@
       "requires": [],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "default": true
@@ -28,6 +30,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "default": true
@@ -42,6 +45,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "default": true
@@ -57,6 +61,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "default": true
@@ -69,6 +74,7 @@
       "requires": [],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "default": true
@@ -84,6 +90,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "default": true
@@ -98,6 +105,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "default": true
@@ -113,6 +121,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "hidden": true
@@ -125,6 +134,7 @@
       "requires": [],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     }
@@ -138,6 +148,7 @@
       "version": "1.0.0",
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "requires": [
@@ -161,6 +172,7 @@
       "version": "1.0.0",
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "requires": [
@@ -188,6 +200,7 @@
       "version": "1.0.0",
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "requires": [],

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -89,7 +89,7 @@
             <div class="panel-head">
               <div class="panel-title-wrap">
                 <h3 id="firmware-heading">Firmware version</h3>
-                <p class="panel-note">Choose the release to build from.</p>
+                <p class="panel-note">Choose the source version for your custom firmware.</p>
               </div>
             </div>
             <label class="field-label" for="firmware-ref">Firmware version</label>
@@ -298,6 +298,6 @@
   </dialog>
 
   <script type="module" src="app.js?v=27"></script>
-  <script type="module" src="wizard.js?v=1"></script>
+  <script type="module" src="wizard.js?v=2"></script>
 </body>
 </html>

--- a/docs/custom-build/service-catalog.json
+++ b/docs/custom-build/service-catalog.json
@@ -1,15 +1,23 @@
 {
   "schema": 2,
   "custom_ota_signing_key_generation": 1,
-  "catalog_revision": "6cc29f6843a071e97e9a816ed7d36e33abc4e5d340b396788f7d7c04dfe5677d",
+  "catalog_revision": "9c45e0a71081cb3c7cddbd8e579df671dccbb71492b657c48c15fd8fb830d04a",
   "firmware_refs": [
     "v3.1.14",
+    "v3.1.14-preview.3",
     "main"
   ],
   "platformio_environment": "esp32s3-custom",
   "firmware": {
     "v3.1.14": {
       "custom_version": "3.1.14-custom",
+      "partition_schema": {
+        "path": "partitions/default_8MB.csv",
+        "sha256": "ab2f33c14eb855054613fd3a4ba85457ae281c6f371c25931ccc763bc79cb0e2"
+      }
+    },
+    "v3.1.14-preview.3": {
+      "custom_version": "3.1.14-preview.3-custom",
       "partition_schema": {
         "path": "partitions/default_8MB.csv",
         "sha256": "ab2f33c14eb855054613fd3a4ba85457ae281c6f371c25931ccc763bc79cb0e2"
@@ -28,6 +36,7 @@
       "requires": [],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -37,6 +46,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -46,6 +56,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -56,6 +67,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -63,6 +75,7 @@
       "requires": [],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -73,6 +86,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -82,6 +96,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -92,6 +107,7 @@
       ],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     },
@@ -99,6 +115,7 @@
       "requires": [],
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ]
     }
@@ -108,6 +125,7 @@
       "version": "1.0.0",
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "requires": [
@@ -229,6 +247,7 @@
       "version": "1.0.0",
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "requires": [
@@ -254,6 +273,7 @@
       "version": "1.0.0",
       "firmware_refs": [
         "v3.1.14",
+        "v3.1.14-preview.3",
         "main"
       ],
       "requires": [],
@@ -271,6 +291,9 @@
           "sha256": "e873624cbdae73d844d6c77dcf4d03001e35c4406fbee3ae0b3cf8c5d6b0db6c"
         },
         "v3.1.14": {
+          "sha256": "e873624cbdae73d844d6c77dcf4d03001e35c4406fbee3ae0b3cf8c5d6b0db6c"
+        },
+        "v3.1.14-preview.3": {
           "sha256": "e873624cbdae73d844d6c77dcf4d03001e35c4406fbee3ae0b3cf8c5d6b0db6c"
         }
       },

--- a/docs/custom-build/wizard.js
+++ b/docs/custom-build/wizard.js
@@ -1,6 +1,6 @@
 const start = document.querySelector("#start-wizard");
 const steps = [
-  ["firmware-heading", "Choose a firmware version and WiFi or USB installation. main contains development changes; a release uses that published version."],
+  ["firmware-heading", "Choose the source version for your custom firmware, then choose WiFi or USB installation. Your build includes the features and plugins you select, not necessarily everything in the official firmware. For everyday use, choose a stable release as the starting point. main is unfinished development code: it may contain untested changes or bugs and is intended for testing only."],
   ["features-heading", "Choose the features you need. Required dependencies are selected automatically and cannot be removed while another selection needs them."],
   ["plugins-heading", "Choose optional approved plugins. Only plugins compatible with your firmware version are available."],
   ["summary-heading", "Review your selection and request the build when ready. Wait for it to finish, then download the ZIP for USB or save the build for your scales."],

--- a/plugins/default-web-apps/plugin.json
+++ b/plugins/default-web-apps/plugin.json
@@ -5,7 +5,7 @@
   "description": "Install the bundled on-device dashboard and scale tools.",
   "tooltip": "Adds the dashboard, Weigh Save, Dosing Assistant, and Quality Control Assistant. LittleFS, WebSocket, the web server, and WiFi are included automatically.",
   "version": "1.0.0",
-  "firmware_refs": ["v3.1.14", "main"],
+  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "main"],
   "requires": ["littlefs", "websocket"],
   "depends_on": [],
   "conflicts": [],

--- a/plugins/grind-by-weight/plugin.json
+++ b/plugins/grind-by-weight/plugin.json
@@ -5,7 +5,7 @@
   "description": "Stop a supported grinder automatically at the target dose.",
   "tooltip": "Enables the built-in grind-by-weight integration. Its recommended setup also selects Wifi Pull OTA and the default web apps.",
   "version": "1.0.0",
-  "firmware_refs": ["v3.1.14", "main"],
+  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "main"],
   "requires": ["grinder"],
   "depends_on": [],
   "conflicts": ["pressensor"],

--- a/plugins/pressensor/plugin.json
+++ b/plugins/pressensor/plugin.json
@@ -5,10 +5,11 @@
   "description": "Show Pressensor pressure, weight, flow, and shot time on the scale.",
   "tooltip": "Connects to a selected Pressensor over BLE and adds pressure-aware shot timing without requiring WiFi or runtime LittleFS.",
   "version": "1.0.0",
-  "firmware_refs": ["v3.1.14", "main"],
+  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "main"],
   "requires": [],
   "conflicts": ["grind-by-weight"],
   "patches": {
+    "v3.1.14-preview.3": "patches/main.patch",
     "v3.1.14": "patches/main.patch",
     "main": "patches/main.patch"
   },

--- a/tools/configure_custom_build.py
+++ b/tools/configure_custom_build.py
@@ -13,12 +13,12 @@ SCRIPT_ROOT = Path(globals().get("__file__", Path.cwd() / "tools" / "configure_c
 ROOT = Path(os.environ.get("HDS_CUSTOM_BUILD_CATALOG_ROOT", SCRIPT_ROOT)).resolve()
 ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 PATH_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
-STABLE_FIRMWARE_REF_PATTERN = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+)$")
+TAGGED_FIRMWARE_REF_PATTERN = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+(?:-[a-z0-9]+(?:[.-][a-z0-9]+)*)?)$")
 DEFAULT_FIRMWARE_VERSION_PATTERN = re.compile(
     r'^\s*#define\s+HDS_FIRMWARE_VERSION\s+"([0-9]+\.[0-9]+\.[0-9]+(?:-[a-z0-9]+(?:[.-][a-z0-9]+)*)?)"\s*$',
     re.MULTILINE,
 )
-FIRMWARE_REFS = ("v3.1.14", "main")
+FIRMWARE_REFS = ("v3.1.14", "v3.1.14-preview.3", "main")
 FEATURES = {
     "wifi": ("HDS_FEATURE_WIFI", (), FIRMWARE_REFS),
     "mdns": ("HDS_FEATURE_MDNS", ("wifi",), FIRMWARE_REFS),
@@ -635,9 +635,9 @@ def firmwareFileBytes(firmwareRef, relativePath, sourceRoot=ROOT):
 
 
 def customFirmwareVersion(firmwareRef, configHeader):
-    stable = STABLE_FIRMWARE_REF_PATTERN.fullmatch(firmwareRef)
-    if stable:
-        return f"{stable.group(1)}-custom"
+    tagged = TAGGED_FIRMWARE_REF_PATTERN.fullmatch(firmwareRef)
+    if tagged:
+        return f"{tagged.group(1)}-custom"
     match = DEFAULT_FIRMWARE_VERSION_PATTERN.search(configHeader)
     if not match:
         raise ValueError("selected firmware has no valid HDS_FIRMWARE_VERSION")

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -237,7 +237,7 @@ def main():
     assert pageCatalog["catalog_revision"] == serviceCatalog["catalog_revision"]
     assert len(pageCatalog["catalog_revision"]) == 64
     assert generatedCatalog["firmware_refs"] == list(customBuild.FIRMWARE_REFS)
-    assert customBuild.FIRMWARE_REFS == ("v3.1.14", "main")
+    assert customBuild.FIRMWARE_REFS == ("v3.1.14", "v3.1.14-preview.3", "main")
     assert pageCatalog["custom_ota_signing_key_generation"] == 1
     assert serviceCatalog["custom_ota_signing_key_generation"] == 1
     assert all(
@@ -301,6 +301,10 @@ def main():
         "plugins": ["default-web-apps"],
     }
     assert customBuild.customFirmwareVersion("v3.1.14", "") == "3.1.14-custom"
+    assert customBuild.customFirmwareVersion(
+        "v3.1.14-preview.3", '#define HDS_FIRMWARE_VERSION "3.1.14"'
+    ) == "3.1.14-preview.3-custom"
+    assert serviceCatalog["firmware"]["v3.1.14-preview.3"]["custom_version"] == "3.1.14-preview.3-custom"
     assert customBuild.customFirmwareVersion(
         "main", '#define HDS_FIRMWARE_VERSION "3.1.14"'
     ) == "3.1.14-custom"

--- a/tools/test_plugin_ci_contract.py
+++ b/tools/test_plugin_ci_contract.py
@@ -63,9 +63,10 @@ def main():
     assert "#ifdef HDS_CUSTOM_BUILD" not in patch
     assert manifest["patches"] == {
         "v3.1.14": "patches/main.patch",
+        "v3.1.14-preview.3": "patches/main.patch",
         "main": "patches/main.patch",
     }
-    assert workerConfig["vars"]["ALLOWED_FIRMWARE_REFS"] == "main,v3.1.14"
+    assert workerConfig["vars"]["ALLOWED_FIRMWARE_REFS"] == "main,v3.1.14,v3.1.14-preview.3"
     assert workerConfig["vars"]["BUILDER_REF"] == "main"
     assert changedPlugins.changedPluginIds([
         "plugins/pressensor/plugin.json",
@@ -77,6 +78,7 @@ def main():
     ]) == [
         {"plugin": "pressensor", "firmware_ref": "main"},
         {"plugin": "pressensor", "firmware_ref": "v3.1.14"},
+        {"plugin": "pressensor", "firmware_ref": "v3.1.14-preview.3"},
     ]
     assert changedPlugins.changedPluginMatrix([
         "plugins/default-web-apps/assets/index.html"


### PR DESCRIPTION
## Summary
- Explicitly allow v3.1.14-preview.3 in the builder, Worker and compatible plugin catalogs.
- Derive custom preview versions from the exact tag, not the default source header: 3.1.14-preview.3-custom.
- Regenerate browser/service catalogs and retain main as default.
- Include the locally reviewed wizard source-version clarification.
- No signing, rollback, retention or free-tier guard changes.

## Validation
- 38 Worker/Fleet/configurator/retention tests passed locally.
- Plugin catalog tests passed using current main metadata for the prospective unpublished stable ref only; no stable tag created.
- Preview tag resolves to bcafebe648ab6a74d9c3e732a050de56b2c2b6e1.
- Pressensor patch passes git apply --check on the actual Preview 3 checkout.
- AI documentation contract and git diff --check passed.
- Production tag-based USB baseline and custom-to-custom WiFi hardware tests follow deployment; not yet claimed as passed.