### PR TITLE
Fix catalog validation for preview custom builds

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -223,8 +223,8 @@ jobs:
           ref: ${{ inputs.builder_commit || github.sha }}
           fetch-depth: 0
           persist-credentials: false
-      - name: Create prospective release tag for main validation
-        if: inputs.firmware_ref == 'main'
+      - name: Create prospective release tag for development validation
+        if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3'
         run: |
           if ! git show-ref --verify --quiet refs/tags/v3.1.14; then
             git tag v3.1.14 "${{ github.sha }}"

--- a/tools/test_plugin_ci_contract.py
+++ b/tools/test_plugin_ci_contract.py
@@ -51,7 +51,7 @@ def main():
     assert "compile-matrix:" not in customWorkflow
     dispatchBuild = customWorkflow.split("\n  build:\n", 1)[1]
     assert dispatchBuild.lstrip().startswith("if: github.event_name == 'workflow_dispatch'")
-    assert "if: inputs.firmware_ref == 'main'" in dispatchBuild
+    assert "if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3'" in dispatchBuild
     assert 'git tag v3.1.14 "${{ github.sha }}"' in dispatchBuild
 
     assert "dependency-build:" not in otaWorkflow


### PR DESCRIPTION
The first production Preview 3 custom build exposed a dispatch-only failure: the full catalog test reads prospective v3.1.14 metadata, but the workflow created its temporary local validation tag only for main requests. Include the explicitly allowed Preview 3 ref in that same validation-only condition. Real stable requests still require the real tag; nothing pushes a prospective tag.

The source remains the exact Preview 3 commit supplied by the Worker. Signing, expected combination hash, builder checks and quota limits are unchanged. Added the corresponding workflow contract assertion; local contract and diff checks passed.

Production run 34134269924 failed before compilation. This PR fixes its root cause; the failed attempt will not be reset or bypassed.