### PR TITLE
Improve custom build installation status reporting

### DIFF
--- a/.github/workflows/custom-build-configurator.yml
+++ b/.github/workflows/custom-build-configurator.yml
@@ -35,3 +35,4 @@ jobs:
           node --check docs/custom-build/app.js
           node --check docs/custom-build/fleet.js
           node --test cloudflare/custom-build-worker/test/configurator.test.mjs
+          node --test cloudflare/custom-build-worker/test/fleet-polling.test.mjs

--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -223,8 +223,8 @@ jobs:
           ref: ${{ inputs.builder_commit || github.sha }}
           fetch-depth: 0
           persist-credentials: false
-      - name: Create prospective release tag for main validation
-        if: inputs.firmware_ref == 'main'
+      - name: Create prospective release tag for development validation
+        if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3'
         run: |
           if ! git show-ref --verify --quiet refs/tags/v3.1.14; then
             git tag v3.1.14 "${{ github.sha }}"

--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -88,6 +88,7 @@ jobs:
           node --test cloudflare/custom-build-worker/test/configurator.test.mjs
           node --test cloudflare/custom-build-worker/test/worker.test.mjs
           node --test cloudflare/custom-build-worker/test/fleet.test.mjs
+          node --test cloudflare/custom-build-worker/test/fleet-polling.test.mjs
           node --test cloudflare/custom-build-worker/test/retention.test.mjs
           node --check docs/custom-build/fleet.js
       - name: Detect changed patch plugins
@@ -278,6 +279,7 @@ jobs:
           node --test cloudflare/custom-build-worker/test/configurator.test.mjs
           node --test cloudflare/custom-build-worker/test/worker.test.mjs
           node --test cloudflare/custom-build-worker/test/fleet.test.mjs
+          node --test cloudflare/custom-build-worker/test/fleet-polling.test.mjs
           node --test cloudflare/custom-build-worker/test/retention.test.mjs
           node --check docs/custom-build/fleet.js
       - name: Mark custom build as running

--- a/cloudflare/custom-build-worker/test/fleet-polling.test.mjs
+++ b/cloudflare/custom-build-worker/test/fleet-polling.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import {test} from "node:test";
+import {readFile} from "node:fs/promises";
+import {runInNewContext} from "node:vm";
+import {startFleetPolling} from "../../../docs/custom-build/fleet-polling.mjs";
+
+test("polling pauses, waits for completion and stops requesting once inactive", async () => {
+  let active = false;
+  let calls = 0;
+  let finish;
+  const scheduled = [];
+  startFleetPolling(() => active, () => {
+    calls += 1;
+    return new Promise(resolve => { finish = resolve; });
+  }, (callback, delay) => {
+    assert.equal(delay, 30000);
+    scheduled.push(callback);
+  });
+  await scheduled.shift()();
+  assert.equal(calls, 0);
+  active = true;
+  const pending = scheduled.shift()();
+  assert.equal(calls, 1);
+  assert.equal(scheduled.length, 0);
+  active = false;
+  finish();
+  await pending;
+  await scheduled.shift()();
+  assert.equal(calls, 1);
+  assert.equal(scheduled.length, 1);
+});
+
+test("fleet polling requires a visible idle page and an outstanding assignment", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  const registration = source.slice(source.indexOf("  startFleetPolling("), source.indexOf("\n\n  setMode(Boolean(fleetKey))"));
+  let eligible;
+  let editing = false;
+  const context = {
+    fleetKey: "present",
+    document: {hidden: false},
+    activeRequests: 0,
+    scales: [{desired_combination: "b", installed_combination: "a"}],
+    editingFleet: () => editing,
+    loadFleet: () => {},
+    startFleetPolling: callback => { eligible = callback; },
+  };
+  runInNewContext(registration, context);
+  assert.equal(eligible(), true);
+  context.document.hidden = true;
+  assert.equal(eligible(), false);
+  context.document.hidden = false;
+  editing = true;
+  assert.equal(eligible(), false);
+  editing = false;
+  context.activeRequests = 1;
+  assert.equal(eligible(), false);
+  context.activeRequests = 0;
+  context.scales = [{desired_combination: "b", installed_combination: "b"}];
+  assert.equal(eligible(), false);
+  context.scales = [{desired_combination: null, installed_combination: "b"}];
+  assert.equal(eligible(), false);
+});

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=11";
+import {initFleet} from "./fleet.js?v=12";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
 
 (async () => {

--- a/docs/custom-build/fleet-polling.mjs
+++ b/docs/custom-build/fleet-polling.mjs
@@ -1,0 +1,10 @@
+export function startFleetPolling(isActive, refresh, schedule = setTimeout) {
+  const poll = async () => {
+    try {
+      if (isActive()) await refresh();
+    } finally {
+      schedule(poll, 30000);
+    }
+  };
+  schedule(poll, 30000);
+}

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -1,4 +1,5 @@
 import {buildLabel, buildSummary, deploymentState, lastSeenLabel, shortHash} from "./fleet-state.mjs?v=2";
+import {startFleetPolling} from "./fleet-polling.mjs";
 
 const storageKey = "hds-custom-build-fleet-v2";
 const legacyStorageKey = "hds-custom-build-fleet-v1";
@@ -92,6 +93,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   let buildStates = {};
   let selectedDeviceIds = new Set();
   let savingBuild = false;
+  let activeRequests = 0;
 
   const setSettingsOpen = open => {
     settings.hidden = !open;
@@ -99,20 +101,27 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   };
 
   const api = async (path, options = {}) => {
-    const response = await fetch(`${apiBase}${path}`, {
-      ...options,
-      headers: {
-        Authorization: `Bearer ${fleetKey}`,
-        ...(options.body ? {"Content-Type": "application/json"} : {}),
-      },
-    });
-    const result = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      const error = new Error(result.error || `request failed: ${response.status}`);
-      error.code = result.error;
-      throw error;
+    activeRequests += 1;
+    if (options.method && options.method !== "GET") generation += 1;
+    try {
+      const response = await fetch(`${apiBase}${path}`, {
+        ...options,
+        cache: "no-store",
+        headers: {
+          Authorization: `Bearer ${fleetKey}`,
+          ...(options.body ? {"Content-Type": "application/json"} : {}),
+        },
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const error = new Error(result.error || `request failed: ${response.status}`);
+        error.code = result.error;
+        throw error;
+      }
+      return result;
+    } finally {
+      activeRequests -= 1;
     }
-    return result;
   };
 
   const setMode = linked => {
@@ -176,13 +185,20 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     addBuild.title = !scales.length ? "Link a scale first" : "";
   };
 
-  const loadFleet = async () => {
+  const editingFleet = () => Boolean(consoleRoot.querySelector("input:not([type=checkbox]):focus, select:focus")) ||
+    Boolean(consoleRoot.querySelector("input:disabled, details[open]")) ||
+    confirmDialog.open || forgetDialog.open;
+
+  const loadFleet = async (background = false) => {
     const currentGeneration = ++generation;
-    fleetStatus.textContent = "Loading scales";
-    buildStatus.textContent = "";
+    if (!background) {
+      fleetStatus.textContent = "Loading scales";
+      buildStatus.textContent = "";
+    }
     try {
       const result = await api("/api/v1/fleet/overview");
       if (currentGeneration !== generation) return;
+      if (background && (document.hidden || editingFleet())) return;
       scales = Array.isArray(result.scales) ? result.scales : [];
       builds = Array.isArray(result.builds) ? result.builds : [];
       buildStates = result.build_states || {};
@@ -465,6 +481,12 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     {device_ids: [...selectedDeviceIds]}, null, "Clear assignment for",
   ));
   document.addEventListener("openscale-build-status", renderControls);
+  startFleetPolling(
+    () => Boolean(fleetKey) && !document.hidden && !activeRequests && !editingFleet() &&
+      scales.some(scale => scale.desired_combination &&
+        scale.desired_combination !== scale.installed_combination),
+    () => loadFleet(true),
+  );
 
   setMode(Boolean(fleetKey));
   renderControls();

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -297,7 +297,7 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=27"></script>
+  <script type="module" src="app.js?v=28"></script>
   <script type="module" src="wizard.js?v=2"></script>
 </body>
 </html>

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,7 +254,7 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=27"' in indexPage
+    assert 'type="module" src="app.js?v=28"' in indexPage
     assert 'href="styles.css?v=17"' in indexPage
     assert 'href="fleet.css?v=7"' in indexPage
     assert 'id="request-build"' in indexPage
@@ -271,7 +271,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=11' in appScript
+    assert 'fleet.js?v=12' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" not in fleetScript
     assert "localStorage.setItem(storageKey" in fleetScript

--- a/tools/test_plugin_ci_contract.py
+++ b/tools/test_plugin_ci_contract.py
@@ -51,7 +51,7 @@ def main():
     assert "compile-matrix:" not in customWorkflow
     dispatchBuild = customWorkflow.split("\n  build:\n", 1)[1]
     assert dispatchBuild.lstrip().startswith("if: github.event_name == 'workflow_dispatch'")
-    assert "if: inputs.firmware_ref == 'main'" in dispatchBuild
+    assert "if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3'" in dispatchBuild
     assert 'git tag v3.1.14 "${{ github.sha }}"' in dispatchBuild
 
     assert "dependency-build:" not in otaWorkflow


### PR DESCRIPTION
## Implemented
- Poll Fleet overview every 30 seconds while an assignment remains unconfirmed.
- Pause requests for hidden tabs, active edits and in-flight requests; stop when installed and desired hashes match.
- Prevent stale background responses from overwriting newer changes and explicitly bypass the browser request cache.

## Still required before review
- Add download-progress reporting, clearly separate from confirmed installation. ZIP/USB downloads must not imply that a particular scale installed the build.
- Add an automatic installed-build check-in after successful firmware and LittleFS boot, including USB installs when the paired scale has WiFi connectivity.
- Keep offline installations unconfirmed until actual device confirmation arrives.
- Add focused tests and complete firmware validation for those additions.

## Validation so far
- 17 existing configurator tests and 2 polling tests passed locally.
- Diff whitespace check passed.
- New polling has not been deployed; firmware/download reporting is not implemented yet.

Do not merge automatically. User requested review before merging.