### PR TITLE
Improve fast scale-top double and triple tap detection

### DIFF
--- a/docs/AI_FIRMWARE_NOTES.md
+++ b/docs/AI_FIRMWARE_NOTES.md
@@ -66,6 +66,62 @@ Tare averages the current buffer, often one sample in fast mode, so it is noisie
 
 The USB ADS debug packet keeps its 41-byte framing and checksum. Byte 24 is the raw reset reason captured at boot. Bytes 25-37 are zero-filled because the current library does not precompute stats.
 
+## Scale-Top Taps
+
+`include/tap_detector.h` processes the existing `f_current_raw_value` after
+`pureScale()` in the weighing loop. It does not alter ADS polling or filtering.
+The states are Settling, Ready, Rising (including unloading), Valley, and Locked.
+Five stable samples at 100 ms intervals arm the first rise. Subsequent rises use
+their local valley, not the original baseline; rejected rebounds also start a
+new valley so an old undershoot cannot inflate a later peak's prominence.
+
+Thresholds are grouped in `TapDetector`: rises exceed 2 g per observed change.
+The first prominence exceeds 10 g; repeats rise more than 6 g from their local
+valley and their height above the original baseline exceeds 35% of the strongest
+accepted height. Keeping those tests separate admits overlapping taps without
+letting a negative undershoot inflate a small ringing peak. A peak unloading by
+at least 6 g and 45% of its local prominence arms the next valley. Action completion separately requires
+70% unloading of the final peak relative to the original baseline (with a 2 g
+floor). This rejects half-released holds without requiring deep unloading
+between taps. The relative height floor does not shrink after weaker accepted peaks.
+
+Rise onsets must be at least 50 ms apart. Preserve the original 400 ms wait for
+another rise and 600 ms maximum contact duration, including slower gestures.
+The wait starts at the confirmed drop and restarts once at final unloading,
+not on every cached sample or subsequent fluctuation. A double is emitted on
+the first tick beyond that wait, unless another rise is being evaluated. A
+held candidate cancels the sequence rather than falling back to tare. Triple
+is emitted as soon as the third peak satisfies the final unloading condition;
+until then no fourth peak can replace it.
+There is no additional 100 ms action delay: unloading is already confirmed and
+the double decision already reserves the full third-tap window. Local tare/timer
+actions and their enable settings are unchanged, including the existing tare delay.
+
+COM5 hardware capture on 2026-09-09 measured about 10 SPS. A natural double had
+401 ms between observed rises; a triple had about 60% initial unloading and
+7.6 g second prominence. The earlier 300 ms onset window, 200 ms duration,
+70% intermediate unloading, and 10 g repeat floor rejected those signals.
+Captured double/triple/held traces and original slower sequences are native
+regression tests. Observation timestamps can lag ADC acquisition by one debug
+poll interval, so hardware confirmation is still required after changing thresholds.
+
+A later fast series exposed a 48% initial fall and a 7.4 g local repeat rise
+while still above baseline; another light first peak fell only 7.2 g. The
+6 g / 45% drop and separate local-rise / baseline-height tests cover these
+captured traces. A captured 0.64 g second rise remains rejected deliberately:
+counting that as a tap would undermine noise and held-finger rejection.
+
+Cached readings create no extra edges. Recognition still requires distinct ADC
+peaks and valleys: 10 SPS cannot reliably resolve 50 ms taps, and smoothing can
+hide fast taps. Do not change sampling to compensate without a separate hardware
+review. Deep pressure modulation or large object bounces indistinguishable from
+tap traces remain a hardware-validation risk. Serial `tapd on` enables one
+`[TAPRAW] timestamp weight` line per fresh ADC reading in the weighing loop;
+`tapd off` disables it. It defaults off, is not persisted, and does not change
+sampling or filtering. Prefer this stream over repeated USB debug snapshots,
+which can miss intermediate samples. Replay timestamped weight traces in
+`test/test_tap_detector/test_main.cpp`.
+
 ## Async Web Server
 
 - Register handlers before `server.begin()`.
@@ -125,6 +181,8 @@ Run only the checks matching the change:
 ```sh
 python tools/test_calibration_validation.py
 python tools/test_soft_sleep_ads_wake.py
+python tools/test_tap_action_contract.py
+pio test -e native -f test_tap_detector
 pio run -e esp32s3
 ```
 

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -230,6 +230,7 @@ volatile bool b_timeOnTop = false;
 volatile bool b_btnFuncWhileConnected = false;
 bool b_tapTareEnabled = false;
 bool b_tapTimerEnabled = false;
+bool b_tapTraceEnabled = false;
 
 //
 int windowLength = 5;  // default window length

--- a/include/tap_detection.h
+++ b/include/tap_detection.h
@@ -6,12 +6,7 @@
 #include "parameter.h"
 #include "tap_detector.h"
 
-constexpr unsigned long TAP_ACTION_DELAY_MS = 100;
-
 static TapDetector tapDetector;
-static bool tapActionArmed = false;
-static bool tapTripleArmed = false;
-static unsigned long tapActionAtMs = 0;
 static bool tapDetectionGated = true;
 
 static inline void runTapLocalAction(bool tripleTap) {
@@ -42,7 +37,6 @@ void tapDetectTick() {
       || now - t_menuExitTime <= 1000) {
     if (!tapDetectionGated) {
       tapDetector.reset(now, weight);
-      tapActionArmed = false;
       tapDetectionGated = true;
     }
     return;
@@ -59,17 +53,10 @@ void tapDetectTick() {
       event == TapEvent::Triple && b_tapTimerEnabled;
 
   if (doubleTapAction || tripleTapAction) {
-    tapActionArmed = true;
-    tapTripleArmed = tripleTapAction;
-    tapActionAtMs = now;
-    Serial.println(tapTripleArmed ? "[TAP] triple tap -> timer" :
+    Serial.println(tripleTapAction ? "[TAP] triple tap -> timer" :
                                    "[TAP] double tap -> tare");
-  }
-
-  if (tapActionArmed && now - tapActionAtMs >= TAP_ACTION_DELAY_MS) {
-    tapActionArmed = false;
     power_off(-1);
-    runTapLocalAction(tapTripleArmed);
+    runTapLocalAction(tripleTapAction);
 #ifdef BUZZER
     buzzer.beep(1, BUZZER_DURATION);
 #endif

--- a/include/tap_detector.h
+++ b/include/tap_detector.h
@@ -19,57 +19,60 @@ class TapDetector {
     historyIndex = 0;
     historyCount = 0;
     sampleMs = now;
-    steady = false;
+    state = State::Settling;
     baseline = weight;
     previousWeight = weight;
-    rising = false;
-    risingFromSteady = false;
-    tapStartedMs = now;
-    lastReleaseMs = now;
+    valley = weight;
+    peak = weight;
+    riseOrigin = weight;
+    strongestHeight = 0.0f;
+    riseStartedMs = now;
+    lastTapStartedMs = now;
+    lastPeakMs = now;
+    releaseLevel = weight;
+    finalReleased = false;
+    lockedMs = now;
     sequenceCount = 0;
-    needsRelease = false;
-    sequenceLocked = false;
   }
 
   TapEvent tick(unsigned long now, float weight) {
-    if ((rising || needsRelease) && now - tapStartedMs > maxTapDurationMs) {
+    if (!isfinite(weight)) {
+      reset(now, 0.0f);
+      return TapEvent::None;
+    }
+    if (state == State::Locked) {
+      if (now - lockedMs > interTapWindowMs) reset(now, weight);
+      return TapEvent::None;
+    }
+    if ((state == State::Rising && now - riseStartedMs > maxTapDurationMs) ||
+        (state == State::Valley && !finalReleased &&
+         now - lastTapStartedMs > maxTapDurationMs)) {
       reset(now, weight);
       return TapEvent::None;
     }
-
-    if (sequenceLocked) {
-      if (now - lastReleaseMs <= interTapWindowMs) {
-        previousWeight = weight;
-        rising = false;
-        return TapEvent::None;
-      }
-      sequenceLocked = false;
-      sequenceCount = 0;
-    }
-
-    TapEvent event = expireSequence(now);
-
-    if (needsRelease && fabsf(weight - baseline) <= releaseRangeG) {
-      needsRelease = false;
-      lastReleaseMs = now;
-      if (sequenceCount == 3) event = completeTriple();
-    }
-
-    if (weight > previousWeight + peakSlopeG &&
-        !needsRelease && (sequenceCount > 0 || steady)) {
-      if (!rising) {
-        tapStartedMs = now;
-        risingFromSteady = steady;
-        rising = true;
-      }
-    } else if (weight < previousWeight - peakSlopeG && rising) {
-      rising = false;
-      if (previousWeight - baseline > peakHeightG) {
-        event = acceptPeak(now, weight, risingFromSteady);
+    if (state == State::Valley) {
+      const TapEvent event = updateValley(now, weight);
+      if (event != TapEvent::None || sequenceCount == 3) return event;
+      if (now - lastPeakMs > interTapWindowMs &&
+          (finalReleased || weight - previousWeight > peakSlopeG)) {
+        const TapEvent expired = sequenceCount == 2 && finalReleased ?
+            TapEvent::Double : TapEvent::None;
+        reset(now, weight);
+        return expired;
       }
     }
 
-    if (sequenceCount == 0 && !needsRelease && !sequenceLocked && !rising) {
+    TapEvent event = TapEvent::None;
+    if ((state == State::Ready || state == State::Valley) &&
+        weight - previousWeight > peakSlopeG) {
+      riseOrigin = state == State::Ready ? baseline : valley;
+      peak = weight;
+      riseStartedMs = now;
+      state = State::Rising;
+    }
+    if (state == State::Rising) {
+      event = updatePeak(now, weight);
+    } else if (state == State::Settling || state == State::Ready) {
       updateSteadyState(now, weight);
     }
 
@@ -78,29 +81,40 @@ class TapDetector {
   }
 
  private:
-  static constexpr float peakHeightG = 10.0f;
+  enum class State : uint8_t { Settling, Ready, Rising, Valley, Locked };
+
+  static constexpr float minPeakHeightG = 10.0f;
   static constexpr float peakSlopeG = 2.0f;
-  static constexpr float releaseRangeG = 2.0f;
+  static constexpr float minDropAfterPeakG = 6.0f;
+  static constexpr float minRepeatHeightG = 6.0f;
+  static constexpr float minDropFraction = 0.45f;
+  static constexpr float finalReleaseFraction = 0.70f;
+  static constexpr float minRepeatHeightFraction = 0.35f;
+  static constexpr unsigned long minTapSeparationMs = 50;
+  static constexpr unsigned long interTapWindowMs = 400;
+  static constexpr unsigned long maxTapDurationMs = 600;
   static constexpr unsigned long sampleIntervalMs = 100;
   static constexpr uint8_t steadySampleCount = 5;
   static constexpr float steadyRangeG = 0.5f;
-  static constexpr unsigned long interTapWindowMs = 400;
-  static constexpr unsigned long maxTapDurationMs = 600;
 
   float history[steadySampleCount];
   uint8_t historyIndex;
   uint8_t historyCount;
   unsigned long sampleMs;
-  bool steady;
+  State state;
   float baseline;
   float previousWeight;
-  bool rising;
-  bool risingFromSteady;
-  unsigned long tapStartedMs;
-  unsigned long lastReleaseMs;
+  float valley;
+  float peak;
+  float riseOrigin;
+  float strongestHeight;
+  unsigned long riseStartedMs;
+  unsigned long lastTapStartedMs;
+  unsigned long lastPeakMs;
+  float releaseLevel;
+  bool finalReleased;
+  unsigned long lockedMs;
   uint8_t sequenceCount;
-  bool needsRelease;
-  bool sequenceLocked;
 
   void updateSteadyState(unsigned long now, float weight) {
     if (now - sampleMs < sampleIntervalMs) return;
@@ -120,44 +134,61 @@ class TapDetector {
       sum += sample;
     }
     if (high - low < steadyRangeG) {
-      steady = true;
+      state = State::Ready;
       baseline = sum / steadySampleCount;
     } else if (fabsf(weight - baseline) > peakSlopeG) {
-      steady = false;
+      state = State::Settling;
     }
   }
 
-  TapEvent expireSequence(unsigned long now) {
-    if (sequenceCount == 0 || rising || needsRelease ||
-        now - lastReleaseMs < interTapWindowMs) {
+  TapEvent updatePeak(unsigned long now, float weight) {
+    peak = fmaxf(peak, weight);
+    const float amplitude = peak - riseOrigin;
+    const float height = peak - baseline;
+    const float requiredAmplitude = sequenceCount == 0 ? minPeakHeightG : minRepeatHeightG;
+    const bool prominent = amplitude > requiredAmplitude &&
+        height > strongestHeight * minRepeatHeightFraction;
+    if (!prominent && peak - weight > peakSlopeG) {
+      if (sequenceCount == 0) {
+        reset(now, weight);
+      } else {
+        valley = weight;
+        state = State::Valley;
+      }
       return TapEvent::None;
     }
-    const TapEvent event = sequenceCount == 2 && !needsRelease ?
-                               TapEvent::Double : TapEvent::None;
-    sequenceCount = 0;
-    return event;
+    const float requiredDrop = fmaxf(minDropAfterPeakG, amplitude * minDropFraction);
+    if (!prominent || peak - weight < requiredDrop) {
+      return TapEvent::None;
+    }
+    if (sequenceCount > 0 && riseStartedMs - lastTapStartedMs < minTapSeparationMs) {
+      valley = weight;
+      state = State::Valley;
+      return TapEvent::None;
+    }
+    strongestHeight = fmaxf(strongestHeight, height);
+    lastTapStartedMs = riseStartedMs;
+    lastPeakMs = now;
+    releaseLevel = baseline + fmaxf(2.0f, (peak - baseline) * (1.0f - finalReleaseFraction));
+    finalReleased = false;
+    ++sequenceCount;
+    state = State::Valley;
+    valley = weight;
+    return updateValley(now, weight);
   }
 
-  TapEvent acceptPeak(unsigned long now, float weight, bool startedFromSteady) {
-    needsRelease = fabsf(weight - baseline) > releaseRangeG;
-    if (sequenceCount == 0) {
-      if (!startedFromSteady) return TapEvent::None;
-      sequenceCount = 1;
-    } else {
-      ++sequenceCount;
+  TapEvent updateValley(unsigned long now, float weight) {
+    valley = fminf(valley, weight);
+    if (!finalReleased && weight <= releaseLevel) {
+      finalReleased = true;
+      lastPeakMs = now;
     }
-    if (!needsRelease) lastReleaseMs = now;
-
-    if (sequenceCount == 3) {
-      return needsRelease ? TapEvent::None : completeTriple();
+    if (sequenceCount == 3 && finalReleased) {
+      state = State::Locked;
+      lockedMs = now;
+      return TapEvent::Triple;
     }
     return TapEvent::None;
-  }
-
-  TapEvent completeTriple() {
-    sequenceCount = 0;
-    sequenceLocked = true;
-    return TapEvent::Triple;
   }
 };
 

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -503,6 +503,12 @@ public:
         Serial.print("Off ");
     }
 
+    if (inputString == "tapd on" || inputString == "tapd off") {
+      b_tapTraceEnabled = inputString == "tapd on";
+      Serial.printf("[TAPTRACE] enabled=%d tare=%d timer=%d\n",
+                    b_tapTraceEnabled, b_tapTareEnabled, b_tapTimerEnabled);
+    }
+
     if (inputString.startsWith("adsd ")) {
       String cmd = inputString.substring(5);
       cmd.trim();

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1412,6 +1412,9 @@ void pureScale() {
     float raw_weight = scale.getData();
     updatePressSampling();
     f_current_raw_value = raw_weight;
+    if (b_tapTraceEnabled) {
+      Serial.printf("[TAPRAW] %lu %.3f\n", t_lastScaleData, raw_weight);
+    }
 
     float current_diff = raw_weight - f_displayedValue - f_driftCompensation;
 

--- a/test/test_tap_detector/test_main.cpp
+++ b/test/test_tap_detector/test_main.cpp
@@ -1,185 +1,414 @@
+#include <limits.h>
+#include <initializer_list>
 #include <unity.h>
 #include "tap_detector.h"
 
 void setUp() {}
 void tearDown() {}
 
-static void establishBaseline(TapDetector &detector) {
-  for (unsigned long now = 100; now <= 500; now += 100) {
-    TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(now, 0.0f));
+struct Sample {
+  unsigned long at;
+  float weight;
+  TapEvent event = TapEvent::None;
+};
+
+static void trace(TapDetector &detector, std::initializer_list<Sample> samples,
+                  unsigned long offset = 0, float load = 0.0f) {
+  for (const Sample &sample : samples) {
+    TEST_ASSERT_EQUAL_MESSAGE(sample.event, detector.tick(offset + sample.at, load + sample.weight),
+                              "Unexpected gesture in signal trace");
   }
 }
 
-static TapEvent tap(TapDetector &detector, unsigned long riseMs) {
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(riseMs, 100.0f));
-  return detector.tick(riseMs + 50, 0.0f);
+static void establishBaseline(TapDetector &detector, unsigned long offset = 0,
+                              float load = 0.0f) {
+  detector.reset(offset, load);
+  trace(detector, {{100, 0}, {200, 0}, {300, 0}, {400, 0}, {500, 0}}, offset, load);
 }
 
-void testRequiresStableBaselineAndRecovery() {
-  TapDetector detector;
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 100));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 250));
-
-  detector.reset(0, 0.0f);
-  establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(550, 100.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(600, 95.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 101.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(700, 98.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1100, 98.0f));
+static void firstPeak(TapDetector &detector) {
+  trace(detector, {{550, 45}, {575, 75}, {600, 20}, {625, 8}});
 }
 
-void testResetCancelsMenuExitGesture() {
-  TapDetector detector;
-  establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 700));
-  detector.reset(800, 0.0f);
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1200, 0.0f));
+void testFastDoubleWithoutBaselineRecovery() {
+  for (unsigned long spacing : {120UL, 150UL, 200UL}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    firstPeak(detector);
+    trace(detector, {{550 + spacing, 18}, {575 + spacing, 60},
+                    {600 + spacing, 20}, {625 + spacing, 5},
+                    {1025 + spacing, 5}, {1026 + spacing, 5, TapEvent::Double},
+                    {1300, 5}});
+  }
 }
 
-void testDoubleTapRequiresRelease() {
+void testFastTripleWithoutBaselineRecovery() {
   TapDetector detector;
   establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 700));
-  TEST_ASSERT_EQUAL(TapEvent::Double, detector.tick(1150, 0.0f));
+  trace(detector, {{550, 45}, {580, 75}, {610, 28}, {640, 8},
+                  {670, 18}, {700, 60}, {730, 25}, {760, 5},
+                  {790, 18}, {820, 65}, {850, 25}, {880, 8, TapEvent::Triple},
+                  {1000, 8}, {1300, 8}});
 }
 
-void testUnreleasedFinalPeakDoesNotCompleteDoubleOrTriple() {
+void testExampleSecondTapStartsAtFiveGrams() {
   TapDetector detector;
   establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(700, 100.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(750, 50.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1150, 50.0f));
-
-  detector.reset(0, 0.0f);
-  establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 700));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(800, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(850, 100.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(900, 50.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1300, 50.0f));
+  trace(detector, {{550, 20}, {575, 65}, {600, 30}, {625, 10}, {650, 5},
+                  {675, 18}, {700, 55}, {725, 25}, {750, 5},
+                  {1151, 5, TapEvent::Double}});
 }
 
-void testFourthPeakCannotReplaceTriple() {
+void testHeldFingerFluctuationsAndLongContact() {
   TapDetector detector;
   establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 700));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(800, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::Triple, tap(detector, 850));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(950, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 1000));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1400, 0.0f));
+  trace(detector, {{550, 70}, {575, 66}, {600, 72}, {625, 68},
+                  {650, 74}, {675, 67}, {700, 71}, {751, 71},
+                  {850, 68}, {950, 72}, {1050, 67}, {1150, 71},
+                  {1250, 66}, {1350, 70}, {1500, 0}, {1900, 0}});
 }
 
-void testTapRecognitionDoesNotDependOnBaselineSamplePhase() {
+void testRingingDoesNotCountEvenOutsideRefractoryPeriod() {
+  for (unsigned long interval : {12UL, 25UL, 50UL, 100UL}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 65}, {550 + interval, 25}, {550 + 2 * interval, -6},
+                    {550 + 3 * interval, 12}, {550 + 4 * interval, 3},
+                    {550 + 5 * interval, 0}, {1500, 0}});
+  }
+}
+
+void testRingingBeforeGenuineSecondTap() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 65}, {575, 25}, {600, -6}, {625, 12},
+                  {650, 3}, {675, 0}, {700, 30}, {725, 60}, {750, 15},
+                  {775, 4}, {1151, 4, TapEvent::Double}});
+}
+
+void testRejectedReboundDoesNotReuseAnOlderDeeperValley() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 65}, {575, 25}, {600, -6}, {625, 12},
+                  {650, 3}, {675, 18}, {700, 5}, {725, 0}, {1100, 0}});
+}
+
+void testSlowPressureModulation() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 20}, {650, 30}, {750, 40}, {850, 35},
+                  {950, 45}, {1050, 38}, {1200, 20}, {1400, 40},
+                  {1600, 20}, {1800, 40}, {2000, 0}, {2400, 0}});
+}
+
+void testObjectPlacementAndSettledLoad() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 45}, {575, 100}, {600, 80}, {625, 90},
+                  {650, 84}, {675, 86}, {800, 85}, {1000, 85}, {1400, 85}});
+}
+
+void testFinalHeldPeakCancelsDoubleAndTriple() {
+  for (bool third : {false, true}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    firstPeak(detector);
+    if (third) {
+      trace(detector, {{670, 40}, {695, 75}, {720, 20}, {745, 0}});
+    }
+    const unsigned long start = third ? 790 : 670;
+    trace(detector, {{start, 100}, {start + 25, 50}, {start + 100, 50},
+                    {start + 601, 50}, {start + 800, 0}, {start + 1200, 0}});
+  }
+}
+
+void testSeparationBoundaries() {
+  for (unsigned long separation : {49UL, 50UL, 51UL, 411UL, 412UL, 413UL}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 70}, {562, 20}, {575, 8},
+                    {550 + separation, 65}, {562 + separation, 20},
+                    {575 + separation, 5}});
+    const TapEvent expected = separation >= 50 && separation <= 412 ?
+        TapEvent::Double : TapEvent::None;
+    trace(detector, {{976 + separation, 5, expected}});
+  }
+}
+
+void testVeryFastTripleAtMinimumSeparation() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 70}, {562, 20}, {575, 8},
+                  {600, 65}, {612, 20}, {625, 5},
+                  {650, 60}, {662, 20}, {675, 8, TapEvent::Triple},
+                  {700, 65}, {725, 5}, {1200, 5}});
+}
+
+void testThirdStartingAtDeadlineSuppressesDouble() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 70}, {575, 10}, {700, 65}, {725, 8},
+                  {1124, 8}, {1125, 30}, {1150, 60}, {1175, 15, TapEvent::Triple},
+                  {1400, 0}});
+}
+
+void testPeakHeightBoundary() {
+  for (float height : {9.9f, 10.0f, 10.1f}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, height}, {575, 0}, {700, height}, {725, 0}});
+    trace(detector, {{1126, 0, height > 10.0f ? TapEvent::Double : TapEvent::None}});
+  }
+}
+
+void testLightTripleAndMixedDurations() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 13}, {575, 1}, {850, 16}, {925, 10}, {1025, 1},
+                  {1150, 12}, {1200, 3, TapEvent::Triple}, {1600, 0}});
+}
+
+void testAbsoluteDropBoundary() {
+  for (float drop : {5.9f, 6.0f, 6.1f}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 11}, {575, 0}, {700, 6.1f}, {725, 6.1f - drop}});
+    trace(detector, {{1126, 6.1f - drop, drop >= 6.0f ? TapEvent::Double : TapEvent::None}});
+  }
+}
+
+void testRelativeDropBoundary() {
+  for (float drop : {69.9f, 70.0f, 70.1f}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 100}, {575, 0}, {700, 100}, {725, 100 - drop}});
+    trace(detector, {{1126, 100 - drop, drop >= 70.0f ? TapEvent::Double : TapEvent::None}});
+  }
+}
+
+void testRelativeRepeatProminenceBoundary() {
+  for (float height : {34.9f, 35.0f, 35.1f}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 100}, {575, 0}, {700, height}, {725, 0}});
+    trace(detector, {{1126, 0, height > 35.0f ? TapEvent::Double : TapEvent::None}});
+  }
+}
+
+void testProminenceRemainsAnchoredToStrongestTap() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 100}, {575, 0}, {700, 40}, {725, 0},
+                  {850, 20}, {875, 0}, {1126, 0, TapEvent::Double}});
+}
+
+void testDurationBoundary() {
+  for (unsigned long duration : {599UL, 600UL, 601UL}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 70}, {575, 0}, {700, 70}, {700 + duration, 0}});
+    trace(detector, {{1101 + duration, 0, duration <= 600 ? TapEvent::Double : TapEvent::None}});
+  }
+}
+
+void testSlopeBoundary() {
+  for (float slope : {1.9f, 2.0f, 2.1f}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, slope}, {555, slope * 2}, {560, slope * 3},
+                    {565, slope * 4}, {570, slope * 5}, {575, slope * 6},
+                    {600, 0}, {700, 20}, {725, 0}});
+    trace(detector, {{1126, 0, slope > 2 ? TapEvent::Double : TapEvent::None}});
+  }
+}
+
+void testRequiresStableBaseline() {
+  TapDetector detector;
+  trace(detector, {{50, 70}, {75, 8}, {170, 65}, {195, 5},
+                  {290, 60}, {315, 8}, {600, 8}});
+}
+
+void testResetCancelsGesture() {
+  TapDetector detector;
+  establishBaseline(detector);
+  firstPeak(detector);
+  trace(detector, {{670, 60}, {695, 5}});
+  detector.reset(700, 5);
+  trace(detector, {{1001, 5}});
+}
+
+void testBaselinePhaseAndNonzeroLoadDoNotChangeRecognition() {
   for (unsigned long offset = 0; offset < 100; offset += 10) {
     TapDetector detector;
-    establishBaseline(detector);
-    TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550 + offset));
-    TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 750 + offset));
-    TEST_ASSERT_EQUAL(TapEvent::Double, detector.tick(1250 + offset, 0.0f));
+    establishBaseline(detector, 0, 350);
+    trace(detector, {{550, 45}, {575, 75}, {600, 20}, {625, 8},
+                    {700, 18}, {725, 60}, {750, 15},
+                    {1151, 5, TapEvent::Double}}, offset, 350);
   }
 }
 
-void testMultiSampleRiseKeepsStableOrigin() {
+void testCachedSamplesDoNotCreateEdgesOrDelayRecognition() {
   TapDetector detector;
   establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(550, 10.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(600, 40.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 80.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(700, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 850));
-  TEST_ASSERT_EQUAL(TapEvent::Triple, tap(detector, 1050));
+  for (unsigned long now = 550; now <= 1126; ++now) {
+    const float weight = now < 575 ? 70 : now < 700 ? 8 : now < 725 ? 65 : 5;
+    TEST_ASSERT_EQUAL(now == 1126 ? TapEvent::Double : TapEvent::None,
+                      detector.tick(now, weight));
+  }
 }
 
-void testSecondTapMayFinishAfterInterTapDeadline() {
+void testUnsignedClockWrap() {
   TapDetector detector;
-  establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(950, 100.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1050, 100.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1150, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1549, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::Double, detector.tick(1550, 0.0f));
+  const unsigned long offset = ULONG_MAX - 650;
+  establishBaseline(detector, offset);
+  trace(detector, {{550, 70}, {575, 8}, {700, 65}, {725, 5},
+                  {850, 60}, {875, 8, TapEvent::Triple}, {1300, 0}}, offset);
 }
 
-void testTripleAcceptsMixedPressDurations() {
-  TapDetector detector;
-  establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(550, 100.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(750, 50.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(800, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 1100));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1450, 100.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1700, 50.0f));
-  TEST_ASSERT_EQUAL(TapEvent::Triple, detector.tick(1900, 0.0f));
-}
-
-void testOverlongPressCancelsGesture() {
-  for (int heldAfterPeak = 0; heldAfterPeak < 2; ++heldAfterPeak) {
+void testInvalidSamplesCancelGesture() {
+  for (float invalid : {NAN, INFINITY, -INFINITY}) {
     TapDetector detector;
     establishBaseline(detector);
-    TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-    TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(750, 100.0f));
-    TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(850, heldAfterPeak ? 50.0f : 110.0f));
-    TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1351, 0.0f));
-    TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1800, 0.0f));
+    firstPeak(detector);
+    trace(detector, {{650, invalid}, {700, 60}, {725, 5}, {1100, 5}});
   }
 }
 
-void testSeparatedTapsDoNotCombine() {
+void testCapturedTenSpsDouble() {
   TapDetector detector;
-  establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 550));
-  TEST_ASSERT_EQUAL(TapEvent::None, tap(detector, 1001));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1451, 0.0f));
+  establishBaseline(detector, 0, -0.95f);
+  trace(detector, {{715, -0.978f}, {828, -0.955f}, {939, 0.090f},
+                  {1033, 21.978f}, {1129, 30.091f}, {1226, 2.472f},
+                  {1337, -0.278f}, {1434, 15.724f}, {1529, 24.785f},
+                  {1624, 2.376f}, {1735, -0.993f}, {1846, -0.998f},
+                  {1942, -0.987f}, {2036, -0.986f, TapEvent::Double}});
 }
 
-void testLightTripleTapAboveTenGrams() {
+void testCapturedTenSpsTriple() {
   TapDetector detector;
-  establishBaseline(detector);
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(550, 13.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(650, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(850, 16.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(950, 0.0f));
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1150, 10.1f));
-  TEST_ASSERT_EQUAL(TapEvent::Triple, detector.tick(1250, 0.0f));
+  establishBaseline(detector, 0, -1.261f);
+  trace(detector, {{729, -1.217f}, {824, -1.253f}, {919, -1.261f},
+                  {1031, 4.058f}, {1143, 16.239f}, {1239, 6.215f},
+                  {1333, 13.857f}, {1429, 5.446f}, {1539, 16.662f},
+                  {1595, 10.325f}, {1707, -0.770f, TapEvent::Triple},
+                  {1802, -1.070f}, {1897, -1.069f}, {2008, -1.068f}});
 }
 
-void testTenGramOrSmallerPulsesAreRejected() {
+void testCapturedHeldPressure() {
+  TapDetector detector;
+  establishBaseline(detector, 0, -1.0f);
+  trace(detector, {{1121, 20.940f}, {1218, 46.181f}, {1330, 45.662f},
+                  {1426, 38.189f}, {1522, 35.090f}, {1633, 34.699f},
+                  {1728, 32.814f}, {1824, 31.811f}, {1919, 20.030f},
+                  {2031, 2.021f}, {2600, 0}});
+}
+
+void testOriginalSlowMixedDurations() {
   TapDetector detector;
   establishBaseline(detector);
-  for (unsigned long now = 550; now <= 950; now += 200) {
-    TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(now, 10.0f));
-    TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(now + 50, 0.0f));
+  trace(detector, {{550, 100}, {750, 50}, {800, 0},
+                  {1100, 100}, {1150, 0}, {1450, 100}, {1700, 50},
+                  {1900, 0, TapEvent::Triple}});
+}
+
+void testOriginalSlowSecondFinishesAfterDeadline() {
+  TapDetector detector;
+  establishBaseline(detector);
+  trace(detector, {{550, 100}, {600, 0}, {950, 100}, {1050, 100},
+                  {1150, 0}, {1550, 0}, {1551, 0, TapEvent::Double}});
+}
+
+void testIntermediateDropBoundary() {
+  for (float drop : {44.9f, 45.0f, 45.1f}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 100}, {575, 100 - drop}, {700, 100}, {725, 0}});
+    trace(detector, {{1126, 0, drop >= 45.0f ? TapEvent::Double : TapEvent::None}});
   }
-  TEST_ASSERT_EQUAL(TapEvent::None, detector.tick(1500, 0.0f));
+}
+
+void testSlowPartialReleaseWithCachedSamples() {
+  TapDetector detector;
+  establishBaseline(detector);
+  for (unsigned long now = 550; now <= 1701; ++now) {
+    const float weight = now < 575 ? 70 : now < 700 ? 0 :
+        now < 725 ? 100 : now < 1300 ? 50 : 0;
+    TEST_ASSERT_EQUAL(now == 1701 ? TapEvent::Double : TapEvent::None,
+                      detector.tick(now, weight));
+  }
+}
+
+void testCapturedFastDoubleWithHighValley() {
+  TapDetector detector;
+  establishBaseline(detector, 0, -0.163f);
+  trace(detector, {{610, 10.108f}, {751, 36.089f}, {829, 18.525f},
+                  {907, 25.967f}, {1068, 5.605f}, {1143, -0.002f},
+                  {1470, 0.044f, TapEvent::Double}});
+}
+
+void testCapturedFastLightDouble() {
+  TapDetector detector;
+  establishBaseline(detector, 0, -0.017f);
+  trace(detector, {{522, 11.648f}, {594, 10.298f}, {673, 4.468f},
+                  {831, 17.321f}, {911, 5.157f}, {990, -0.002f},
+                  {1312, 0.046f, TapEvent::Double}});
+}
+
+void testCapturedUnresolvedDoubleRemainsRejected() {
+  TapDetector detector;
+  establishBaseline(detector, 0, 0.008f);
+  trace(detector, {{858, 9.583f}, {935, 30.545f}, {1012, 14.709f},
+                  {1091, 15.346f}, {1263, 2.040f}, {1341, 0.063f}, {1900, 0}});
+}
+
+void testLocalRepeatRiseBoundary() {
+  for (float height : {5.9f, 6.0f, 6.1f}) {
+    TapDetector detector;
+    establishBaseline(detector);
+    trace(detector, {{550, 11}, {575, 0}, {700, height}, {725, 0}});
+    trace(detector, {{1126, 0, height > 6.0f ? TapEvent::Double : TapEvent::None}});
+  }
 }
 
 int main(int argc, char **argv) {
   UNITY_BEGIN();
-  RUN_TEST(testRequiresStableBaselineAndRecovery);
-  RUN_TEST(testResetCancelsMenuExitGesture);
-  RUN_TEST(testDoubleTapRequiresRelease);
-  RUN_TEST(testUnreleasedFinalPeakDoesNotCompleteDoubleOrTriple);
-  RUN_TEST(testFourthPeakCannotReplaceTriple);
-  RUN_TEST(testTapRecognitionDoesNotDependOnBaselineSamplePhase);
-  RUN_TEST(testMultiSampleRiseKeepsStableOrigin);
-  RUN_TEST(testSecondTapMayFinishAfterInterTapDeadline);
-  RUN_TEST(testTripleAcceptsMixedPressDurations);
-  RUN_TEST(testOverlongPressCancelsGesture);
-  RUN_TEST(testSeparatedTapsDoNotCombine);
-  RUN_TEST(testLightTripleTapAboveTenGrams);
-  RUN_TEST(testTenGramOrSmallerPulsesAreRejected);
+  RUN_TEST(testFastDoubleWithoutBaselineRecovery);
+  RUN_TEST(testFastTripleWithoutBaselineRecovery);
+  RUN_TEST(testExampleSecondTapStartsAtFiveGrams);
+  RUN_TEST(testHeldFingerFluctuationsAndLongContact);
+  RUN_TEST(testRingingDoesNotCountEvenOutsideRefractoryPeriod);
+  RUN_TEST(testRingingBeforeGenuineSecondTap);
+  RUN_TEST(testRejectedReboundDoesNotReuseAnOlderDeeperValley);
+  RUN_TEST(testSlowPressureModulation);
+  RUN_TEST(testObjectPlacementAndSettledLoad);
+  RUN_TEST(testFinalHeldPeakCancelsDoubleAndTriple);
+  RUN_TEST(testSeparationBoundaries);
+  RUN_TEST(testVeryFastTripleAtMinimumSeparation);
+  RUN_TEST(testThirdStartingAtDeadlineSuppressesDouble);
+  RUN_TEST(testPeakHeightBoundary);
+  RUN_TEST(testLightTripleAndMixedDurations);
+  RUN_TEST(testAbsoluteDropBoundary);
+  RUN_TEST(testRelativeDropBoundary);
+  RUN_TEST(testRelativeRepeatProminenceBoundary);
+  RUN_TEST(testProminenceRemainsAnchoredToStrongestTap);
+  RUN_TEST(testDurationBoundary);
+  RUN_TEST(testSlopeBoundary);
+  RUN_TEST(testRequiresStableBaseline);
+  RUN_TEST(testResetCancelsGesture);
+  RUN_TEST(testBaselinePhaseAndNonzeroLoadDoNotChangeRecognition);
+  RUN_TEST(testCachedSamplesDoNotCreateEdgesOrDelayRecognition);
+  RUN_TEST(testUnsignedClockWrap);
+  RUN_TEST(testInvalidSamplesCancelGesture);
+  RUN_TEST(testCapturedTenSpsDouble);
+  RUN_TEST(testCapturedTenSpsTriple);
+  RUN_TEST(testCapturedHeldPressure);
+  RUN_TEST(testOriginalSlowMixedDurations);
+  RUN_TEST(testOriginalSlowSecondFinishesAfterDeadline);
+  RUN_TEST(testIntermediateDropBoundary);
+  RUN_TEST(testSlowPartialReleaseWithCachedSamples);
+  RUN_TEST(testCapturedFastDoubleWithHighValley);
+  RUN_TEST(testCapturedFastLightDouble);
+  RUN_TEST(testCapturedUnresolvedDoubleRemainsRejected);
+  RUN_TEST(testLocalRepeatRiseBoundary);
   return UNITY_END();
 }

--- a/tools/test_tap_action_contract.py
+++ b/tools/test_tap_action_contract.py
@@ -31,8 +31,19 @@ def main() -> None:
     recognized = function_body(finger, "isFingerPress")
     local_tap = function_body(tap, "runTapLocalAction")
     detector = function_body(tap, "tapDetectTick")
+    parameters = (ROOT / "include" / "parameter.h").read_text(encoding="utf-8")
+    usb = (ROOT / "include" / "usbcomm.h").read_text(encoding="utf-8")
+    sketch = (ROOT / "src" / "hds.ino").read_text(encoding="utf-8")
+    weighing = function_body(sketch, "pureScale")
 
-    assert "TAP_ACTION_DELAY_MS = 100" in tap
+    assert "bool b_tapTraceEnabled = false;" in parameters
+    assert 'inputString == "tapd on" || inputString == "tapd off"' in usb
+    assert 'b_tapTraceEnabled = inputString == "tapd on";' in usb
+    assert weighing.index("if (b_newDataReady)") < weighing.index("if (b_tapTraceEnabled)")
+    assert 'Serial.printf("[TAPRAW] %lu %.3f\\n", t_lastScaleData, raw_weight);' in weighing
+
+    assert "TAP_ACTION_DELAY_MS" not in tap
+    assert "tapActionArmed" not in tap
     assert "bleClientLive && !b_btnFuncWhileConnected" in shared
     assert "sendUsbButton(buttonNumber, 1);" in shared
     assert "sendWebsocketButton(buttonNumber, 1);" in shared
@@ -50,7 +61,8 @@ def main() -> None:
     assert "grinderRuntime.state == GRINDER_STATE_STOPPING" in detector
     assert "tapDetector.reset(now, weight);" in detector
     assert "power_off(-1);" in detector
-    assert "runTapLocalAction(tapTripleArmed);" in detector
+    assert "runTapLocalAction(tripleTapAction);" in detector
+    assert "if (doubleTapAction || tripleTapAction) {" in detector
     assert "runRecognizedButtonAction" not in tap
 
 


### PR DESCRIPTION
## Summary

- Detect successive taps from local peaks and valleys without requiring baseline recovery between taps.
- Keep conservative prominence, drop, final-release and lockout checks to reject held pressure and ringing.
- Preserve the 400 ms inter-tap wait and 600 ms maximum contact for slower gestures. A pending third tap suppresses the double action.
- Remove the redundant 100 ms action delay while retaining existing tare and timer settings and gates.
- Add nonpersistent USB diagnostics (`tapd on` / `tapd off`), disabled by default. ADC sampling and task behavior are unchanged.

## Verification

- Native suite: 77 tests passed, including 38 tap-detector tests covering recorded traces, timing boundaries, slower gestures, held pressure, object placement, ringing, cached samples, clock rollover and invalid samples.
- Tap action, USB text action and AI documentation contract checks passed.
- ESP32-S3 firmware built and flashed successfully to the test scale on COM5, with upload hash verification.
- Final physical double-tap batch: 5/5 recognized, 5 tares, no triple actions.
- Continuous finger contact with varied pressure up to 66.14 g: no double, triple or tare actions, including approximately 24 seconds after pressure release.
- Final physical triple-tap batch: 5/5 recognized, no double or tare actions; timer sequence Start, Stop, Reset, Start, Stop.
- Diagnostics disabled after captures.

## Draft Limitations

The tested scale samples at approximately 10 SPS. Recognition requires distinct measured peaks and valleys; synthetic minimum-separation cases do not demonstrate reliable physical 50-150 ms tapping. An unresolved recorded repeat rise of approximately 0.64 g remains intentionally rejected.

Hardware results are bounded trials on one scale, not a general reliability guarantee. Physical cup-placement testing and broader hardware validation remain outstanding; object placement currently has synthetic test coverage.
