### PR TITLE
Show live custom-build activity and enlarge status animation

### DIFF
--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -11,6 +11,7 @@ import {
   shortHash,
 } from "../../../docs/custom-build/fleet-state.mjs";
 import {buildEstimate, buildTimeRange} from "../../../docs/custom-build/build-estimate.mjs";
+import {elapsedTime, initBuildProgress} from "../../../docs/custom-build/build-progress.mjs";
 import {
   catalogRevisionChanged,
   defaultSelection,
@@ -357,4 +358,38 @@ test("USB-ready builds use a persistent updater cue instead of flashing", async 
   assert.ok(source.includes('result.state === "ready" && installMethod === "usb"'));
   assert.ok(source.includes('classList.toggle("is-ready", updaterReady)'));
   assert.equal(source.includes("is-next-step"), false);
+});
+
+test("build activity reflects confirmed stages and stops on disconnect or completion", () => {
+  assert.equal(elapsedTime(-1000), "0:00");
+  assert.equal(elapsedTime(578000), "9:38");
+  assert.equal(elapsedTime(3600000), "60:00");
+  const element = () => ({dataset: {}, hidden: false, textContent: "", attributes: {},
+    setAttribute(name, value) { this.attributes[name] = value; },
+    removeAttribute(name) { delete this.attributes[name]; }});
+  const steps = [element(), element(), element()];
+  const children = new Map(["[data-build-elapsed]", "[data-build-checked]", ".build-activity", ".build-live-details"]
+    .map(key => [key, element()]));
+  const root = {...element(), querySelectorAll: () => steps, querySelector: key => children.get(key)};
+  const update = initBuildProgress(root);
+  try {
+    update({state: "building", updated_at: new Date(Date.now() - 578000).toISOString()});
+    assert.equal(root.dataset.active, "true");
+    assert.deepEqual(steps.map(step => step.dataset.state), ["complete", "current", "pending"]);
+    assert.equal(steps[1].attributes["aria-current"], "step");
+    assert.match(children.get("[data-build-elapsed]").textContent, /^Elapsed 9:38/);
+    update({state: "building", connectionLost: true});
+    assert.equal(root.dataset.active, "false");
+    assert.match(children.get("[data-build-checked]").textContent, /interrupted/);
+    update({state: "building", pollingPaused: true});
+    assert.equal(root.dataset.active, "false");
+    update({state: "ready"});
+    assert.equal(root.hidden, false);
+    assert.equal(children.get(".build-live-details").hidden, true);
+    assert.equal(steps[2].attributes["aria-current"], "step");
+    assert.equal(steps[1].attributes["aria-current"], undefined);
+  } finally {
+    update({state: "missing"});
+  }
+  assert.equal(root.hidden, true);
 });

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -10,6 +10,7 @@ import {
 } from "./selection.mjs?v=5";
 import {initFleet} from "./fleet.js?v=12";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
+import {initBuildProgress} from "./build-progress.mjs?v=1";
 
 (async () => {
   const themeStorageKey = "hds-custom-build-theme-v1";
@@ -78,6 +79,7 @@ import {buildEstimate} from "./build-estimate.mjs?v=1";
   const featureById = new Map(catalog.features.map(item => [item.id, item]));
   const pluginById = new Map(catalog.plugins.map(item => [item.id, item]));
   const buildButton = document.querySelector("#request-build");
+  const updateBuildProgress = initBuildProgress(document.querySelector("#build-progress"));
   const fleetPanel = document.querySelector("#fleet-panel");
   let toastTimer;
   let statusTimer;
@@ -89,6 +91,7 @@ import {buildEstimate} from "./build-estimate.mjs?v=1";
   let currentCombinationHash = "";
   let currentBuildState = "checking";
   let catalogRetryDelay = 2000;
+  let lastBuildResult;
 
   const escapeHtml = value => String(value).replace(/[&<>'"]/g, character => ({
     "&": "&amp;", "<": "&lt;", ">": "&gt;", "'": "&#39;", '"': "&quot;"
@@ -175,10 +178,13 @@ import {buildEstimate} from "./build-estimate.mjs?v=1";
       checking: "Checking the build cache."
     };
     const labels = {"rate-limited": "Rate limited", updating: "Updating"};
-    buildState.className = `ready state-${result.state}`;
-    buildState.textContent = labels[result.state] || result.state[0].toUpperCase() + result.state.slice(1);
+    buildState.className = `ready state-${result.connectionLost ? "unavailable" : result.state}`;
+    buildState.textContent = result.connectionLost ? "Reconnecting"
+      : labels[result.state] || result.state[0].toUpperCase() + result.state.slice(1);
     currentCombinationHash = combinationHash;
     currentBuildState = result.state;
+    lastBuildResult = result;
+    updateBuildProgress({...result, pollingPaused: pollRemaining <= 0});
     const updaterLink = document.querySelector("#hds-updater-link");
     const updaterReady = result.state === "ready" && installMethod === "usb";
     updaterLink.classList.toggle("is-ready", updaterReady);
@@ -188,7 +194,8 @@ import {buildEstimate} from "./build-estimate.mjs?v=1";
     const retryMessage = result.state === "failed" ?
       (result.retryable ? " One retry is available." : " No retries remain.") : "";
     document.querySelector("#status-message").textContent =
-      [messages[result.state] ?? messages.unavailable, retryMessage, buildEstimate(result, currentSelection)].filter(Boolean).join(" ");
+      result.connectionLost ? "Waiting for the build service to respond. The last confirmed build state is shown."
+        : [messages[result.state] ?? messages.unavailable, retryMessage, buildEstimate(result, currentSelection)].filter(Boolean).join(" ");
     buildButton.disabled = result.state !== "missing" && !(result.state === "failed" && result.retryable);
     const downloads = document.querySelector("#downloads");
     downloads.replaceChildren();
@@ -274,7 +281,7 @@ import {buildEstimate} from "./build-estimate.mjs?v=1";
         if (result.combination_hash === combinationHash) setStatus(result, generation);
       } catch (error) {
         if (error.name !== "AbortError") {
-          setStatus({state: "unavailable", combination_hash: combinationHash}, generation);
+          setStatus({...lastBuildResult, connectionLost: true, combination_hash: combinationHash}, generation);
         }
       }
     }, 10000);

--- a/docs/custom-build/build-progress.mjs
+++ b/docs/custom-build/build-progress.mjs
@@ -1,0 +1,42 @@
+export const elapsedTime = milliseconds => {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000));
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+};
+
+export const initBuildProgress = root => {
+  const steps = [...root.querySelectorAll("[data-build-step]")];
+  const elapsed = root.querySelector("[data-build-elapsed]");
+  const checked = root.querySelector("[data-build-checked]");
+  let latest = null;
+  let checkedAt = 0;
+  let timer;
+  const renderTime = () => {
+    if (!latest) return;
+    const startedAt = Date.parse(latest.updated_at);
+    elapsed.textContent = Number.isFinite(startedAt)
+      ? `${latest.state === "queued" ? "Queued" : "Elapsed"} ${elapsedTime(Date.now() - startedAt)}` : "";
+    checked.textContent = latest.connectionLost ? "Connection interrupted; retrying"
+      : latest.pollingPaused ? "Automatic status checks paused"
+      : `Status checked ${Math.max(0, Math.floor((Date.now() - checkedAt) / 1000))}s ago`;
+  };
+  return result => {
+    clearInterval(timer);
+    latest = result;
+    if (!result.connectionLost) checkedAt = Date.now();
+    const active = ["queued", "building"].includes(result.state);
+    root.hidden = !active && result.state !== "ready";
+    root.dataset.active = String(active && !result.connectionLost && !result.pollingPaused);
+    root.querySelector(".build-activity").hidden = !active;
+    const current = ["queued", "building", "ready"].indexOf(result.state);
+    steps.forEach((step, index) => {
+      step.dataset.state = index < current ? "complete" : index === current ? "current" : "pending";
+      if (index === current) step.setAttribute("aria-current", "step");
+      else step.removeAttribute("aria-current");
+    });
+    root.querySelector(".build-live-details").hidden = !active;
+    if (active) {
+      renderTime();
+      timer = setInterval(renderTime, 1000);
+    }
+  };
+};

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -23,7 +23,7 @@
       document.querySelector("#theme-color").content = dark ? "#111413" : "#0d6b4f";
     })();
   </script>
-  <link rel="stylesheet" href="styles.css?v=17">
+  <link rel="stylesheet" href="styles.css?v=18">
   <link rel="stylesheet" href="fleet.css?v=7">
   <link rel="stylesheet" href="wizard.css?v=1">
 </head>
@@ -157,6 +157,18 @@
           <div class="service-section">
             <div class="service-heading">
               <span>Build status</span>
+            </div>
+            <div id="build-progress" hidden>
+              <ol class="build-steps" aria-label="Build progress">
+                <li data-build-step>Queued</li>
+                <li data-build-step>Building</li>
+                <li data-build-step>Ready</li>
+              </ol>
+              <div class="build-activity" aria-hidden="true"><span></span></div>
+              <div class="build-live-details">
+                <span data-build-elapsed></span>
+                <span data-build-checked></span>
+              </div>
             </div>
             <p id="status-message" class="status-message" role="status" aria-live="polite">Checking the build cache.</p>
             <p id="pull-ota-warning" class="pull-ota-warning" hidden>Wifi Pull OTA installs official releases and replaces this custom build.</p>
@@ -297,7 +309,7 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=28"></script>
+  <script type="module" src="app.js?v=29"></script>
   <script type="module" src="wizard.js?v=2"></script>
 </body>
 </html>

--- a/docs/custom-build/styles.css
+++ b/docs/custom-build/styles.css
@@ -609,8 +609,12 @@
 
     .state-checking::before, .state-queued::before, .state-building::before,
     .state-updating::before {
+      width: 10.5px;
+      height: 10.5px;
+      flex-shrink: 0;
+      margin-right: 4px;
       background: #b77a20;
-      box-shadow: 0 0 0 4px var(--amber-soft);
+      box-shadow: 0 0 0 6px var(--amber-soft);
     }
 
     .state-checking::after, .state-queued::after, .state-building::after,
@@ -619,9 +623,9 @@
       position: absolute;
       left: 0;
       top: 50%;
-      width: 7px;
-      height: 7px;
-      border: 1px solid #b77a20;
+      width: 10.5px;
+      height: 10.5px;
+      border: 1.5px solid #b77a20;
       border-radius: 999px;
       animation: status-pulse 1.6s cubic-bezier(.22, 1, .36, 1) infinite;
     }
@@ -708,6 +712,47 @@
       color: var(--muted);
       font-size: .79rem;
       line-height: 1.55;
+    }
+
+    .build-steps {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+      padding: 0;
+      margin: 0 0 12px;
+      list-style: none;
+      font-size: .75rem;
+      color: var(--muted);
+    }
+
+    .build-steps li {
+      border-top: 3px solid var(--line);
+      padding-top: 7px;
+    }
+
+    .build-steps [data-state="complete"] { border-color: #568975; }
+    .build-steps [data-state="current"] { border-color: #ce982d; color: var(--ink); font-weight: 700; }
+    .build-steps [data-state="current"]:last-child { border-color: #568975; }
+
+    .build-activity { height: 4px; overflow: hidden; background: var(--line); }
+    .build-activity span { display: block; width: 30%; height: 100%; background: #ce982d; }
+    [data-active="true"] .build-activity span { animation: build-activity 2s ease-in-out infinite alternate; }
+    @keyframes build-activity { to { transform: translateX(234%); } }
+
+    .build-live-details {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 4px 12px;
+      margin: 10px 0 12px;
+      color: var(--muted);
+      font-size: .7rem;
+      font-variant-numeric: tabular-nums;
+    }
+
+    [data-build-elapsed] { color: var(--ink); font-weight: 650; }
+    @media (prefers-reduced-motion: reduce) {
+      [data-active="true"] .build-activity span { animation: none; }
     }
 
     .pull-ota-warning {
@@ -1260,6 +1305,11 @@
     html[data-theme="dark"] .state-queued::after,
     html[data-theme="dark"] .state-building::after,
     html[data-theme="dark"] .state-updating::after { border-color: #d39b45; }
+
+    html[data-theme="dark"] .state-checking::before,
+    html[data-theme="dark"] .state-queued::before,
+    html[data-theme="dark"] .state-building::before,
+    html[data-theme="dark"] .state-updating::before { box-shadow: 0 0 0 6px var(--amber-soft); }
 
     html[data-theme="dark"] .resolved-chip { color: #b5c0ba; }
 

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,8 +254,8 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=28"' in indexPage
-    assert 'href="styles.css?v=17"' in indexPage
+    assert 'type="module" src="app.js?v=29"' in indexPage
+    assert 'href="styles.css?v=18"' in indexPage
     assert 'href="fleet.css?v=7"' in indexPage
     assert 'id="request-build"' in indexPage
     assert "catalog-data" not in indexPage


### PR DESCRIPTION
## Summary
- Add a queued/building/ready indicator, animated activity bar, seconds-level elapsed timer, and time since the last successful status check.
- Keep the last confirmed state visible during connection failures and retry polling; pause activity while disconnected.
- Enlarge the existing animated status indicator by 50%, including dark mode, while respecting reduced motion.
- Use existing service states, without guessed percentages or simulated compiler stages.

## Verification
- All 18 configurator tests passed.
- Custom-build execution tests passed.
- Playwright checks passed on desktop/mobile and light/dark themes, including live clock updates, enlarged indicator dimensions, disconnect/reconnect, and reduced motion.
- JavaScript syntax and git diff checks passed.

## Deployment
GitHub Pages serves main:/docs. This branch becomes available on the hosted configurator after merge and Pages deployment. Firmware recovery changes are separate.