### PR TITLE
Report WiFi install progress and completion to fleet

### DIFF
--- a/.github/workflows/ota-contracts.yml
+++ b/.github/workflows/ota-contracts.yml
@@ -41,6 +41,7 @@ jobs:
           python tools/test_custom_ota_public_key_header.py
           python tools/test_decent_ota_target_contract.py
           python tools/test_custom_build_ota_contract.py
+          python tools/test_filesystem_recovery_runtime.py
 
   public-key-header-platforms:
     strategy:

--- a/cloudflare/custom-build-worker/src/fleet.mjs
+++ b/cloudflare/custom-build-worker/src/fleet.mjs
@@ -312,6 +312,9 @@ function scaleRecord(deviceId, device) {
       ? device.installed_combination : null,
     firmware_version: typeof device.firmware_version === "string" ? device.firmware_version : null,
     last_seen_at: typeof device.last_seen_at === "string" ? device.last_seen_at : null,
+    install_combination: hashPattern.test(device.install_combination || "") ? device.install_combination : null,
+    install_state: ["installing", "failed"].includes(device.install_state) ? device.install_state : null,
+    install_updated_at: typeof device.install_updated_at === "string" ? device.install_updated_at : null,
   };
 }
 
@@ -547,10 +550,18 @@ async function deviceAssignment(request, storage) {
 }
 
 async function deviceCheckIn(request, storage, env) {
+  const rawBody = await readJson(request);
+  const hasInstallState = rawBody && Object.hasOwn(rawBody, "install_state");
   const body = requireObject(
-    await readJson(request),
-    ["firmware_version", "installed_combination"],
+    rawBody,
+    hasInstallState
+      ? ["firmware_version", "installed_combination", "install_combination", "install_state"]
+      : ["firmware_version", "installed_combination"],
   );
+  if (hasInstallState && (!hashPattern.test(body.install_combination || "") ||
+      !["installing", "failed"].includes(body.install_state))) {
+    throw new FleetError(400, "invalid_install_state");
+  }
   if (body.installed_combination !== null &&
       !hashPattern.test(body.installed_combination || "")) {
     throw new FleetError(400, "invalid_combination_hash");
@@ -568,6 +579,9 @@ async function deviceCheckIn(request, storage, env) {
     const updated = {
       ...device,
       installed_combination: body.installed_combination,
+      install_combination: hasInstallState ? body.install_combination : null,
+      install_state: hasInstallState ? body.install_state : null,
+      install_updated_at: hasInstallState ? new Date().toISOString() : null,
       firmware_version: firmwareVersion,
       last_seen_at: new Date().toISOString(),
     };

--- a/cloudflare/custom-build-worker/test/fleet-polling.test.mjs
+++ b/cloudflare/custom-build-worker/test/fleet-polling.test.mjs
@@ -3,6 +3,7 @@ import {test} from "node:test";
 import {readFile} from "node:fs/promises";
 import {runInNewContext} from "node:vm";
 import {startFleetPolling} from "../../../docs/custom-build/fleet-polling.mjs";
+import {deploymentState} from "../../../docs/custom-build/fleet-state.mjs";
 
 test("polling pauses, waits for completion and stops requesting once inactive", async () => {
   let active = false;
@@ -30,6 +31,51 @@ test("polling pauses, waits for completion and stops requesting once inactive", 
   assert.equal(scheduled.length, 1);
 });
 
+test("background refresh updates installation status without replacing focused controls", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  const loader = source.slice(source.indexOf("  const loadFleet ="), source.indexOf("  const renderBuilds ="));
+  const row = {dataset: {deviceId: "scale"}, state: "Install pending"};
+  let installed = "old";
+  let editing = true;
+  let renders = 0;
+  const context = {
+    generation: 0,
+    document: {hidden: false},
+    scales: [], builds: [], buildStates: {}, selectedDeviceIds: new Set(["scale"]),
+    fleetStatus: {}, buildStatus: {}, scaleRows: {children: [row]},
+    editingFleet: () => editing,
+    api: async () => ({scales: [{device_id: "scale", desired_combination: "new",
+      installed_combination: installed, last_seen_at: new Date().toISOString(),
+      desired_updated_at: new Date(0).toISOString()}], builds: [], build_states: {new: "ready"}}),
+    renderScaleStatus: (target, scale) => { target.state = deploymentState(scale, {new: "ready"}); },
+    renderBuilds: () => { renders++; }, renderScales: () => { renders++; },
+  };
+  runInNewContext(`${loader}\nglobalThis.refresh = loadFleet;`, context);
+  await context.refresh(true);
+  assert.equal(row.state, "Install pending");
+  installed = "new";
+  await context.refresh(true);
+  assert.equal(row.state, "Up to date");
+  assert.equal(renders, 0);
+  assert.equal(context.selectedDeviceIds.has("scale"), true);
+  editing = false;
+  await context.refresh(true);
+  assert.equal(renders, 2);
+});
+
+test("deployment reports distinguish installation from assignment and stale confirmation", () => {
+  const now = Date.now();
+  const scale = {desired_combination: "new", installed_combination: "old",
+    install_combination: "new", install_state: "installing",
+    install_updated_at: new Date(now).toISOString(), desired_updated_at: new Date(now - 1000).toISOString()};
+  assert.equal(deploymentState(scale, {}, now), "Installing");
+  assert.equal(deploymentState(scale, {}, now + 16 * 60000), "Status unconfirmed");
+  assert.equal(deploymentState({...scale, install_state: "failed"}, {}, now), "Install failed");
+  assert.equal(deploymentState({...scale, installed_combination: "new"}, {}, now), "Up to date");
+  assert.equal(deploymentState({...scale, desired_combination: "different"}, {}, now), "Update assigned");
+  assert.equal(deploymentState({...scale, desired_updated_at: new Date(now + 1).toISOString()}, {}, now), "Update assigned");
+});
+
 test("fleet polling requires a visible idle page and an outstanding assignment", async () => {
   const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
   const registration = source.slice(source.indexOf("  startFleetPolling("), source.indexOf("\n\n  setMode(Boolean(fleetKey))"));
@@ -50,7 +96,7 @@ test("fleet polling requires a visible idle page and an outstanding assignment",
   assert.equal(eligible(), false);
   context.document.hidden = false;
   editing = true;
-  assert.equal(eligible(), false);
+  assert.equal(eligible(), true);
   editing = false;
   context.activeRequests = 1;
   assert.equal(eligible(), false);

--- a/cloudflare/custom-build-worker/test/fleet.test.mjs
+++ b/cloudflare/custom-build-worker/test/fleet.test.mjs
@@ -251,6 +251,9 @@ test("pairs, assigns, authenticates, and physically relinks a scale", async () =
     installed_combination: null,
     firmware_version: null,
     last_seen_at: null,
+    install_combination: null,
+    install_state: null,
+    install_updated_at: null,
   }]);
 });
 
@@ -272,6 +275,39 @@ test("device check-in reports authoritative installed state without changing des
     browser: true,
   })).status, 200);
 
+  const starting = await request(env, "/api/v1/device/check-in", {
+    method: "POST",
+    body: {installed_combination: null, firmware_version: "3.1.14",
+      install_combination: combinationHash, install_state: "installing"},
+    authorization: deviceSecret,
+    device: true,
+  });
+  assert.equal(starting.status, 200);
+  const inProgress = await storage.get(`device:${deviceId}`);
+  assert.equal(inProgress.install_state, "installing");
+  assert.equal(inProgress.install_combination, combinationHash);
+  assert.equal(inProgress.installed_combination, null);
+  assert.ok(Number.isFinite(Date.parse(inProgress.install_updated_at)));
+  for (const installState of ["complete", null, 123]) {
+    const invalid = await request(env, "/api/v1/device/check-in", {
+      method: "POST",
+      body: {installed_combination: null, firmware_version: "3.1.14",
+        install_combination: combinationHash, install_state: installState},
+      authorization: deviceSecret,
+      device: true,
+    });
+    assert.equal(invalid.status, 400);
+  }
+  assert.deepEqual(await storage.get(`device:${deviceId}`), inProgress);
+  const failed = await request(env, "/api/v1/device/check-in", {
+    method: "POST",
+    body: {installed_combination: null, firmware_version: "3.1.14",
+      install_combination: combinationHash, install_state: "failed"},
+    authorization: deviceSecret,
+    device: true,
+  });
+  assert.equal(failed.status, 200);
+  assert.equal((await storage.get(`device:${deviceId}`)).install_state, "failed");
   const converged = await request(env, "/api/v1/device/check-in", {
     method: "POST",
     body: {installed_combination: combinationHash, firmware_version: "3.1.14-custom"},
@@ -285,6 +321,8 @@ test("device check-in reports authoritative installed state without changing des
   });
   const installed = await storage.get(`device:${deviceId}`);
   assert.equal(installed.installed_combination, combinationHash);
+  assert.equal(installed.install_state, null);
+  assert.equal(installed.install_combination, null);
   assert.equal(installed.firmware_version, "3.1.14-custom");
   assert.ok(Number.isFinite(Date.parse(installed.last_seen_at)));
 
@@ -588,6 +626,9 @@ test("legacy fleet records remain readable with unknown installed state", async 
     installed_combination: null,
     firmware_version: null,
     last_seen_at: null,
+    install_combination: null,
+    install_state: null,
+    install_updated_at: null,
   });
 });
 

--- a/docs/AI_FIRMWARE_NOTES.md
+++ b/docs/AI_FIRMWARE_NOTES.md
@@ -111,6 +111,11 @@ while still above baseline; another light first peak fell only 7.2 g. The
 captured traces. A captured 0.64 g second rise remains rejected deliberately:
 counting that as a tap would undermine noise and held-finger rejection.
 
+Weight-tap recognition is gated during physical Circle/Square presses, their
+weight-sampling recovery, the double-click window, BLE shutdown confirmation,
+and a queued power-off. Button gestures keep priority over scale-top taps.
+`tools/test_tap_button_priority.py` exercises this gate with both tap actions enabled.
+
 Cached readings create no extra edges. Recognition still requires distinct ADC
 peaks and valleys: 10 SPS cannot reliably resolve 50 ms taps, and smoothing can
 hide fast taps. Do not change sampling to compensate without a separate hardware
@@ -170,7 +175,7 @@ if (info->final && info->index == 0 && info->len == len && info->opcode == WS_TE
 | Device is pingable but HTTP times out mid-body | AsyncTCP starvation from main-loop work or hardware work moved into the callback. |
 | `ping` shows duplicates or BLE has packet loss | Look for `WiFi.setSleep(false)`. |
 | Device is unreachable after flash but USB enumerates | WiFi association failed on this boot; reset and retry. |
-| Boot logs show `LittleFS mount failed` | Upload the filesystem image; firmware-only flashing does not update LittleFS. |
+| LittleFS is unavailable | The embedded HTTP setup page remains available; use the scale's WiFi OTA or Custom Build menu to install signed firmware and filesystem together. Firmware-only flashing does not update LittleFS. |
 | Flashing becomes much slower than usual | Firmware may be interfering with bootloader handshake. Treat as a serious firmware bug. |
 | Panic or abort under multi-client WiFi load | Check the WebSocket heap constants and serial patterns above for connection churn, skipped broadcasts, and critical heap. |
 

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -24,6 +24,16 @@ AI-documentation audit, read `docs/AI_RELEASE_NOTES.md`.
 Opening the Custom Build menu performs one authenticated device check-in. Custom firmware reports
 the normalized compile-time `HDS_CUSTOM_BUILD_COMBINATION_HASH`; official firmware reports null.
 The response contains only linking state, one desired combination, and its canonical build state.
+Once pending filesystem state is saved, paired scales report the target combination as installing
+before streaming custom firmware, or failed if streaming fails. These reports never claim the
+target is already installed. The browser shows Installing only for the currently assigned target
+and shows Status unconfirmed after 15 minutes without completion. Old firmware remains compatible
+but cannot report installation start. Deploy the Worker changes before firmware using these fields.
+After verifying the installed filesystem and accepting the running firmware, the OTA completion
+path reports the current identity again before clearing its pending transaction and rebooting.
+Only previously paired devices report; up to three attempts are made without initiating another
+installation. A service outage does not roll back a verified installation. If all attempts fail,
+opening Custom Build later refreshes the report.
 
 Fresh devices start pairing from Custom Build. Once a pair code has been registered
 (`ota_custom/pair_init`), Connections exposes a separate Relink entry. Relink requires

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -160,6 +160,8 @@ Acceptance is not installability. A transport acknowledges only that a well-form
 
 Staged LittleFS OTA stores target and rollback metadata in NVS namespace `ota_fs`, including custom combination hashes and `target_try`, `fs_dirty`, `restore`, and `restore_try` recovery state. Custom-to-custom rollback fetches the installed combination's signed custom manifest and identifies both app slots by combination hash rather than their shared version string.
 
+`install_combo` retains the original attempted custom target across conversion to a rollback restore. Terminal failure telemetry uses that identity, not the running rollback firmware. Legacy restore transactions without an original target omit failure telemetry rather than attributing it to the wrong build.
+
 Flow:
 
 1. Current firmware stores both manifests, writes `firmware.bin` to the inactive app slot, and reboots.

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -30,7 +30,7 @@ target is already installed. The browser shows Installing only for the currently
 and shows Status unconfirmed after 15 minutes without completion. Old firmware remains compatible
 but cannot report installation start. Deploy the Worker changes before firmware using these fields.
 After verifying the installed filesystem and accepting the running firmware, the OTA completion
-path reports the current identity again before clearing its pending transaction and rebooting.
+path clears its pending transaction, reports the current identity again, and reboots.
 Only previously paired devices report; up to three attempts are made without initiating another
 installation. A service outage does not roll back a verified installation. If all attempts fail,
 opening Custom Build later refreshes the report.
@@ -118,7 +118,7 @@ Catalog manifests merge the previous latest stable signed manifest, dedupe by mo
 
 When the installed release has aged out of the latest catalog, firmware fetches that release's own signed manifest using both supported tag forms. It accepts only the compatible top-level release entry with the exact installed version and required LittleFS metadata. Firmware rollback remains local in the other app slot; this fallback supplies the signed asset metadata needed to restore the single shared LittleFS partition.
 
-Recovery lookup preserves preview/RC suffixes and must not substitute stable assets with the same numeric version. A hosted custom build, including one based on `main`, instead uses its embedded combination hash and published `ota-manifest.json`/`ota-manifest.sig`. A local build without published recovery metadata is not a supported OTA starting point. Preview 3 predates exact-version recovery and lacks published signed recovery assets; use USB to move to a corrected release or a hosted custom build.
+Recovery lookup preserves preview/RC suffixes and must not substitute stable assets with the same numeric version. A hosted custom build, including one based on `main`, instead uses its embedded combination hash and published `ota-manifest.json`/`ota-manifest.sig`. Firmware containing the forward-recovery path can update without published source recovery assets when the signed target manifest declares `forward_recovery: 1`. Older source firmware, including preview 3, still needs its supported recovery assets or USB; these changes cannot alter already-flashed firmware.
 
 ## Picker Rules
 
@@ -132,7 +132,7 @@ Do not offer:
 - malformed versions
 - versions before `v3.1.13`
 - incompatible hardware
-- the same installed version
+- the same installed version, except when repairing LittleFS
 
 Compatible older stable releases at `v3.1.13+` may be offered as signed downgrades.
 
@@ -144,7 +144,7 @@ A start request may name a target release. Over BLE and USB that is the five-byt
 
 The unattended path skips only `pullOtaPickRelease()` and `pullOtaConfirmInstall()`. Everything else is shared and unchanged: WiFi, clock, signed catalog fetch and signature verification, rollback-manifest resolution before any write, `pullOtaInstall()`, HTTPS with CA validation, asset URL allowlisting, exact size checks, SHA-256 verification, and the staged LittleFS transaction with its bounded retries and rollback metadata.
 
-A request is refused when the target is absent from the verified catalog, incompatible with this hardware, not a stable numeric release, below `HDS_OTA_MIN_INSTALL_VERSION`, equal to the installed version, or when no signed rollback manifest can be resolved. A refusal calls `pullOtaFail()` and returns. It must never fall back to the picker, and it must never install a release other than the one requested.
+A request is refused when the target is absent from the verified catalog, incompatible with this hardware, not a stable numeric release, below `HDS_OTA_MIN_INSTALL_VERSION`, or equal to the installed version outside LittleFS recovery. Missing signed rollback metadata requires the target's signed forward-recovery capability; an older target without it is refused before writes. A refusal calls `pullOtaFail()` and returns. It must never fall back to the picker, and it must never install a release other than the one requested.
 
 An eligible downgrade is accepted, matching picker behavior.
 
@@ -168,11 +168,13 @@ Flow:
 4. A successful target write passes the same checks. The new application is then marked valid before pending state is cleared, and the device reboots.
 5. If both attempts fail before filesystem writing begins, `setup()` calls `hdsOtaRollback("LittleFS update")`; the previous application remains paired with its unchanged filesystem.
 6. If writing may have begun, recovery first replaces pending state with the previous application's matching signed filesystem asset, then rolls the application back. The previous application gets one recorded restore attempt.
-7. A failed restore stops at `UPDATE ERROR`. A successful restore clears pending state and reboots.
+7. A failed restore persists `ota_recovery/active` and pauses the failed `ota_fs` transaction. It disables filesystem serving, accepts the running firmware for filesystem-free operation, reports the failure, and returns to the application. The embedded HTTP setup page and on-device WiFi OTA and Custom Build menus remain available. A successful restore clears pending state and reboots.
 
 Invalid or version-mismatched pending metadata is cleared only by the validation and terminal paths implemented in `pullOtaLoadPendingLittleFs()`. A boot with no pending filesystem transaction can call `hdsOtaRollbackMarkValid()` after normal setup validation.
 
-The single LittleFS partition has no independent rollback slot. Do not weaken signed rollback-asset validation, bounded attempts, persisted write-state tracking, or the stop-on-failed-restore behavior.
+The single LittleFS partition has no independent rollback slot. Keep signed asset validation, bounded attempts, and persisted write-state tracking. Terminal failures must not serve unverified filesystem content or report a complete installation. Recovery state survives reboot and is cleared only after successful filesystem verification. Same-version and same-combination reinstalls are allowed in recovery; device check-ins report no installed combination until repair succeeds.
+
+`HDS_OTA_FORWARD_RECOVERY_VERSION 1` declares the bounded, filesystem-free fallback contract. Release manifests derive this capability from the built source header. Custom manifests derive it from the source checkout and require Pull OTA to be selected; historical builds never inherit the current builder's capability. Without a rollback manifest, installation saves the signed target firmware hash/size alongside filesystem metadata before flashing. On boot, exact running-firmware hash and identity verification precede accepting that app and any filesystem writes. This prevents bootloader rollback to an incompatible old app after a partial filesystem write. Two recorded target attempts then either complete the installation or return to the minimal fallback and menu. Available rollback manifests retain the normal rollback flow.
 
 `HDS_FEATURE_LITTLEFS` controls runtime filesystem use by the webserver and plugins. It does not disable or alter Pull OTA's mandatory staged `littlefs.bin` transaction.
 

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=12";
+import {initFleet} from "./fleet.js?v=13";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
 import {initBuildProgress} from "./build-progress.mjs?v=1";
 

--- a/docs/custom-build/catalog.json
+++ b/docs/custom-build/catalog.json
@@ -130,7 +130,7 @@
       "id": "energy-menu",
       "name": "Energy Saving Beta",
       "description": "Enable optional energy-saving controls.",
-      "tooltip": "Adds the Energy Saving menu and its persistent feature toggles.",
+      "tooltip": "Adds Energy Saving settings under Power and saves your selections.",
       "requires": [],
       "firmware_refs": [
         "v3.1.14",

--- a/docs/custom-build/fleet-state.mjs
+++ b/docs/custom-build/fleet-state.mjs
@@ -22,6 +22,14 @@ export function deploymentState(scale, buildStates, now = Date.now()) {
   if (Number.isFinite(lastSeen) && now - lastSeen > offlineAfterMs) return "Offline";
   const desired = scale.desired_combination;
   if (desired && desired === scale.installed_combination) return "Up to date";
+  const installUpdated = Date.parse(scale.install_updated_at || "");
+  const assignedAt = Date.parse(scale.desired_updated_at || "");
+  if (desired && scale.install_combination === desired && installUpdated >= assignedAt) {
+    if (scale.install_state === "failed") return "Install failed";
+    if (scale.install_state === "installing") {
+      return now - installUpdated > 15 * 60 * 1000 ? "Status unconfirmed" : "Installing";
+    }
+  }
   const buildState = buildStates[desired];
   if (["queued", "building"].includes(buildState)) return "Build preparing";
   if (desired && ["failed", "missing"].includes(buildState)) return "Build unavailable";

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -1,4 +1,4 @@
-import {buildLabel, buildSummary, deploymentState, lastSeenLabel, shortHash} from "./fleet-state.mjs?v=2";
+import {buildLabel, buildSummary, deploymentState, lastSeenLabel, shortHash} from "./fleet-state.mjs?v=3";
 import {startFleetPolling} from "./fleet-polling.mjs";
 
 const storageKey = "hds-custom-build-fleet-v2";
@@ -198,14 +198,21 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     try {
       const result = await api("/api/v1/fleet/overview");
       if (currentGeneration !== generation) return;
-      if (background && (document.hidden || editingFleet())) return;
+      if (background && document.hidden) return;
       scales = Array.isArray(result.scales) ? result.scales : [];
       builds = Array.isArray(result.builds) ? result.builds : [];
       buildStates = result.build_states || {};
       selectedDeviceIds = new Set([...selectedDeviceIds].filter(deviceId =>
         scales.some(scale => scale.device_id === deviceId)));
-      renderBuilds();
-      renderScales();
+      if (background && editingFleet()) {
+        for (const row of scaleRows.children) {
+          const scale = scales.find(item => item.device_id === row.dataset.deviceId);
+          if (scale) renderScaleStatus(row, scale);
+        }
+      } else {
+        renderBuilds();
+        renderScales();
+      }
       fleetStatus.textContent = scales.length
         ? `${scales.length} scale${scales.length === 1 ? "" : "s"}` : "No scales linked yet";
       buildStatus.textContent = builds.length
@@ -288,9 +295,23 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     renderControls();
   };
 
+  const renderScaleStatus = (row, scale) => {
+    const installed = row.querySelector(".scale-build");
+    installed.querySelector("strong").textContent = scale.firmware_version || "Unknown";
+    installed.querySelector("span").textContent = scale.installed_combination
+      ? identityForBuild(scale.installed_combination) : (scale.last_seen_at ? "Official" : "Unknown");
+    row.querySelector(".desired-build strong").textContent = scale.desired_combination
+      ? identityForBuild(scale.desired_combination) : "None";
+    const state = row.querySelector(".deployment-state");
+    state.textContent = deploymentState(scale, buildStates);
+    state.dataset.state = state.textContent.toLowerCase().replaceAll(" ", "-");
+    row.querySelector(".last-seen").textContent = lastSeenLabel(scale.last_seen_at);
+  };
+
   const renderScales = () => {
     scaleRows.replaceChildren(...scales.map(scale => {
       const row = document.createElement("tr");
+      row.dataset.deviceId = scale.device_id;
       row.innerHTML = `
         <td class="scale-select"><input type="checkbox"></td>
         <td class="scale-identity"><input class="scale-name" maxlength="40"><span class="scale-hint"></span></td>
@@ -312,17 +333,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
       name.value = scale.name;
       name.addEventListener("keydown", event => { if (event.key === "Enter") name.blur(); });
       row.querySelector(".scale-hint").textContent = scale.serial_hint;
-      const installed = row.querySelector(".scale-build");
-      installed.querySelector("strong").textContent = scale.firmware_version || "Unknown";
-      installed.querySelector("span").textContent = scale.installed_combination
-        ? identityForBuild(scale.installed_combination) : (scale.last_seen_at ? "Official" : "Unknown");
-      const desired = row.querySelector(".desired-build");
-      desired.querySelector("strong").textContent = scale.desired_combination
-        ? identityForBuild(scale.desired_combination) : "None";
-      const state = row.querySelector(".deployment-state");
-      state.textContent = deploymentState(scale, buildStates);
-      state.dataset.state = state.textContent.toLowerCase().replaceAll(" ", "-");
-      row.querySelector(".last-seen").textContent = lastSeenLabel(scale.last_seen_at);
+      renderScaleStatus(row, scale);
       name.addEventListener("change", async () => {
         const previous = scales.find(item => item.device_id === scale.device_id)?.name || scale.name;
         const next = name.value.trim();
@@ -482,7 +493,7 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   ));
   document.addEventListener("openscale-build-status", renderControls);
   startFleetPolling(
-    () => Boolean(fleetKey) && !document.hidden && !activeRequests && !editingFleet() &&
+    () => Boolean(fleetKey) && !document.hidden && !activeRequests &&
       scales.some(scale => scale.desired_combination &&
         scale.desired_combination !== scale.installed_combination),
     () => loadFleet(true),

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -309,7 +309,7 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=29"></script>
+  <script type="module" src="app.js?v=30"></script>
   <script type="module" src="wizard.js?v=2"></script>
 </body>
 </html>

--- a/include/custom_build_ota.h
+++ b/include/custom_build_ota.h
@@ -156,11 +156,17 @@ bool customBuildRequest(
 
 bool customBuildCheckIn(
     const String &installedCombination,
-    CustomBuildAssignment &assignment) {
+    CustomBuildAssignment &assignment,
+    const String &installCombination = "",
+    const char *installState = "installing") {
   JsonDocument request;
   request["installed_combination"] = installedCombination.length() > 0
       ? installedCombination.c_str() : nullptr;
   request["firmware_version"] = pullOtaCurrentVersion();
+  if (installCombination.length() > 0) {
+    request["install_combination"] = installCombination;
+    request["install_state"] = installState;
+  }
   String requestBody;
   serializeJson(request, requestBody);
   String body;
@@ -180,6 +186,24 @@ bool customBuildCheckIn(
   if (assignment.combinationHash.length() > 0 &&
       !customBuildHexValueValid(assignment.combinationHash, 64)) return false;
   return true;
+}
+
+void customBuildReportInstallState(const String &combinationHash, const char *state) {
+  if (!customBuildRelinkAvailable() || combinationHash.length() == 0) return;
+  CustomBuildAssignment assignment;
+  customBuildCheckIn(pullOtaCurrentCombinationHash(), assignment, combinationHash, state);
+}
+
+void customBuildReportInstalled() {
+  if (!customBuildRelinkAvailable()) return;
+  pullOtaDraw("Update done", "Syncing status");
+  if (!pullOtaEnsureWifi() || !pullOtaClockReady()) return;
+  for (uint8_t attempt = 0; attempt < 3; attempt++) {
+    CustomBuildAssignment assignment;
+    if (customBuildCheckIn(pullOtaCurrentCombinationHash(), assignment)) return;
+    if (attempt < 2) delay(1000);
+  }
+  Serial.println("[custom-ota] Install status report failed");
 }
 
 bool customBuildRegisterPairCode(const char *pairCode) {

--- a/include/custom_build_ota.h
+++ b/include/custom_build_ota.h
@@ -160,7 +160,7 @@ bool customBuildCheckIn(
     const String &installCombination = "",
     const char *installState = "installing") {
   JsonDocument request;
-  request["installed_combination"] = installedCombination.length() > 0
+  request["installed_combination"] = !filesystemRecoveryActive.load() && installedCombination.length() > 0
       ? installedCombination.c_str() : nullptr;
   request["firmware_version"] = pullOtaCurrentVersion();
   if (installCombination.length() > 0) {
@@ -421,7 +421,7 @@ void customBuildRun(bool interactive = true) {
     customBuildShowStatus("Custom Build", "No build assigned");
     return;
   }
-  if (assignment.combinationHash == installedCombination) {
+  if (assignment.combinationHash == installedCombination && !filesystemRecoveryActive.load()) {
     char hashPrefix[9];
     customBuildHashPrefix(installedCombination, hashPrefix);
     customBuildShowStatus("Already installed", hashPrefix);
@@ -446,10 +446,7 @@ void customBuildRun(bool interactive = true) {
   const bool rollbackFound = rollbackCombinationHash.length() > 0
       ? customBuildFetchManifest(rollbackCombinationHash, rollbackManifest)
       : pullOtaFetchCurrentReleaseManifest(rollbackManifest);
-  if (!rollbackFound) {
-    pullOtaFail("Rollback missing");
-    return;
-  }
+  if (!rollbackFound) rollbackManifest = PullOtaManifest();
   pullOtaInstall(
       manifest,
       rollbackManifest,
@@ -476,6 +473,7 @@ void customBuildTask(void *args) {
   const bool restartPending = (wsPendingMask & WSP_OTA_RESET) != 0;
   portEXIT_CRITICAL(&wsPendingMux);
   if (!restartPending) {
+    if (filesystemRecoveryActive.load()) pullOtaResumeFilesystemServices();
     b_ota = false;
     b_pullOtaRunning = false;
   }

--- a/include/filesystem_recovery.h
+++ b/include/filesystem_recovery.h
@@ -1,0 +1,23 @@
+#ifndef FILESYSTEM_RECOVERY_H
+#define FILESYSTEM_RECOVERY_H
+
+#include "parameter.h"
+#include <Preferences.h>
+
+bool filesystemRecoveryStore(bool active) {
+  Preferences preferences;
+  if (!preferences.begin("ota_recovery", false)) return false;
+  const bool stored = preferences.putBool("active", active) > 0;
+  preferences.end();
+  if (stored) filesystemRecoveryActive.store(active);
+  return stored;
+}
+
+void filesystemRecoveryLoad() {
+  Preferences preferences;
+  if (!preferences.begin("ota_recovery", true)) return;
+  filesystemRecoveryActive.store(preferences.getBool("active", false));
+  preferences.end();
+}
+
+#endif

--- a/include/ota_rollback.h
+++ b/include/ota_rollback.h
@@ -6,6 +6,7 @@
 #include <Preferences.h>
 #include <esp_ota_ops.h>
 #include <esp_system.h>
+#include "filesystem_recovery.h"
 
 static bool hdsOtaPendingVerify = false;
 static const uint32_t HDS_OTA_MAX_VERIFY_ATTEMPTS = 1;
@@ -72,6 +73,7 @@ static void hdsOtaRollback(const char *reason) {
 }
 
 void hdsOtaRollbackBegin(esp_reset_reason_t resetReason) {
+  filesystemRecoveryLoad();
   hdsOtaPendingVerify = hdsOtaIsPendingVerify();
   if (!hdsOtaPendingVerify) {
     hdsOtaClearAttempts();
@@ -86,6 +88,19 @@ void hdsOtaRollbackBegin(esp_reset_reason_t resetReason) {
   if (hdsOtaResetLooksCrashy(resetReason)) {
     hdsOtaRollback("reset reason");
   }
+}
+
+bool hdsOtaAcceptFilesystemRecovery() {
+  if (!filesystemRecoveryActive.load()) return false;
+#ifdef CONFIG_APP_ROLLBACK_ENABLE
+  if (hdsOtaPendingVerify && esp_ota_mark_app_valid_cancel_rollback() != ESP_OK) {
+    return false;
+  }
+#endif
+  hdsOtaClearAttempts();
+  hdsOtaPendingVerify = false;
+  Serial.println("[ota-verify] firmware usable; LittleFS recovery still required");
+  return true;
 }
 
 static bool hdsOtaLocalChecksPass() {

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -559,6 +559,8 @@ inline void leaveMenu() {
 bool b_calibration = false;  //Calibration flag
 volatile bool b_ota = false; //wifi ota flag
 volatile bool b_pullOtaRunning = false;
+volatile std::atomic<bool> filesystemRecoveryActive{false};
+volatile std::atomic<bool> webFilesystemReady{false};
 int i_calibration = 0;       //0 for manual cal, 1 for smart cal
 //bool b_set_sample = false;              //开机菜单 设置采样数
 bool b_show_info = false;               //开机菜单 显示信息

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -1028,6 +1028,8 @@ bool pullOtaStorePendingLittleFs(
     return false;
   }
   bool ok = preferences.clear() &&
+            (combinationHash.length() == 0 ||
+             preferences.putString("install_combo", combinationHash) == 64) &&
             (!forwardRecovery ||
              (preferences.putUChar("recovery", HDS_OTA_FORWARD_RECOVERY_VERSION) > 0 &&
               preferences.putString("fw_sha", manifest.firmware.sha256) > 0 &&
@@ -1172,8 +1174,11 @@ bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &pending) {
   if (!preferences.begin("ota_fs", false)) {
     return false;
   }
-  preferences.clear();
-  bool ok = (pending.rollbackCombinationHash.length() == 0 ||
+  const String attemptedCombination = preferences.getString("install_combo", pending.combinationHash);
+  bool ok = preferences.clear() &&
+            (attemptedCombination.length() == 0 ||
+             preferences.putString("install_combo", attemptedCombination) == 64) &&
+            (pending.rollbackCombinationHash.length() == 0 ||
              preferences.putString(
                  "combo", pending.rollbackCombinationHash) == 64) &&
             preferences.putString("url", pending.rollbackAsset.url) > 0 &&
@@ -1484,10 +1489,15 @@ bool pullOtaRecoveryError() {
   if (!filesystemRecoveryStore(true)) return false;
   Preferences preferences;
   if (!preferences.begin("ota_fs", false)) return false;
+  const String attemptedCombination = preferences.getString(
+      "install_combo", preferences.getBool("restore", false)
+          ? String("") : preferences.getString("combo", ""));
   const bool paused = preferences.putBool("paused", true) > 0;
   preferences.end();
   if (!paused || !hdsOtaAcceptFilesystemRecovery()) return false;
-  customBuildReportInstallState(pullOtaCurrentCombinationHash(), "failed");
+  if (pullOtaShaLooksValid(attemptedCombination)) {
+    customBuildReportInstallState(attemptedCombination, "failed");
+  }
   Serial.println("[pull-ota] LittleFS could not be installed; WiFi setup and OTA remain available");
   pullOtaFail("LittleFS could not", "be installed");
   return true;

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -169,6 +169,8 @@ struct PullOtaManifest {
 };
 
 bool customBuildFetchManifest(const String &combinationHash, PullOtaManifest &manifest);
+void customBuildReportInstalled();
+void customBuildReportInstallState(const String &combinationHash, const char *state);
 
 struct PullOtaReleaseList {
   PullOtaManifest releases[HDS_OTA_MAX_RELEASE_CHOICES];
@@ -1408,7 +1410,9 @@ bool pullOtaInstall(
           rollbackCombinationHash)) {
     return pullOtaFail("FS state failed");
   }
+  customBuildReportInstallState(combinationHash, "installing");
   if (!pullOtaStreamAsset(manifest.firmware, U_FLASH, "Firmware")) {
+    customBuildReportInstallState(combinationHash, "failed");
     pullOtaClearPendingLittleFs();
     return false;
   }
@@ -1499,6 +1503,7 @@ bool pullOtaResumePendingLittleFs() {
     return false;
   }
   hdsOtaRollbackMarkValid();
+  customBuildReportInstalled();
   if (!pullOtaClearPendingLittleFs()) {
     pullOtaFail("FS state failed");
     pullOtaRecoveryError();

--- a/include/pull_ota.h
+++ b/include/pull_ota.h
@@ -6,6 +6,7 @@
 
 #include "display.h"
 #include "parameter.h"
+#include "filesystem_recovery.h"
 #include "pull_ota_catalog.h"
 #include "pull_ota_version.h"
 #if HDS_FEATURE_WEBSERVER
@@ -27,6 +28,7 @@
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
 #include <esp_partition.h>
+#include <esp_ota_ops.h>
 #include <mbedtls/md.h>
 #include <mbedtls/pk.h>
 #include <string.h>
@@ -35,6 +37,7 @@
 
 void wifi_init();
 void hdsOtaRollbackMarkValid();
+bool hdsOtaAcceptFilesystemRecovery();
 
 #ifndef HDS_OTA_MANIFEST_URL
 #define HDS_OTA_MANIFEST_URL "https://github.com/decentespresso/openscale/releases/latest/download/manifest.json"
@@ -164,6 +167,7 @@ struct PullOtaManifest {
   uint32_t appPartitionMinSize = 0;
   uint32_t fsPartitionSize = 0;
   uint32_t fsSchema = 0;
+  uint8_t forwardRecoveryVersion = 0;
   PullOtaAsset firmware;
   PullOtaAsset littlefs;
 };
@@ -187,6 +191,7 @@ struct PullOtaPendingLittleFs {
   bool restore = false;
   bool restoreAttempted = false;
   bool filesystemDirty = false;
+  bool forwardRecovery = false;
   uint8_t targetAttempts = 0;
   String version = "";
   String rollbackVersion = "";
@@ -448,6 +453,8 @@ bool pullOtaParseManifestObject(
   manifest.appPartitionMinSize = (uint32_t)appPartitionMinSize;
   manifest.fsPartitionSize = (uint32_t)fsPartitionSize;
   manifest.fsSchema = (uint32_t)fsSchema;
+  manifest.forwardRecoveryVersion = root["forward_recovery"] == HDS_OTA_FORWARD_RECOVERY_VERSION
+      ? HDS_OTA_FORWARD_RECOVERY_VERSION : 0;
   if (!pullOtaParseAsset(root["firmware"], manifest.firmware, true, assetUrlPrefix)) {
     return false;
   }
@@ -498,7 +505,7 @@ void pullOtaBuildSelectableReleases(
                                    !pullOtaVersionIsStable(currentVersion.c_str());
   for (uint8_t i = 0; i < catalog.count; i++) {
     int currentCompare = pullOtaCompareVersions(catalog.releases[i].version, currentVersion);
-    if ((currentCompare != 0 || currentIsPrerelease) && selection.count < HDS_OTA_MAX_RELEASE_CHOICES) {
+    if ((currentCompare != 0 || currentIsPrerelease || filesystemRecoveryActive.load()) && selection.count < HDS_OTA_MAX_RELEASE_CHOICES) {
       selection.indices[selection.count++] = i;
     }
   }
@@ -724,10 +731,7 @@ bool pullOtaVerifyManifestSignature(
       body, signature, signatureLen, publicKeys, sizeof(publicKeys) / sizeof(publicKeys[0]));
 }
 
-bool pullOtaPartitionShaMatches(const PullOtaAsset &asset) {
-  const esp_partition_t *partition = esp_partition_find_first(
-      ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS,
-      HDS_OTA_FS_PARTITION_LABEL);
+bool pullOtaPartitionShaMatches(const PullOtaAsset &asset, const esp_partition_t *partition) {
   if (partition == nullptr || asset.size > partition->size) {
     return false;
   }
@@ -754,6 +758,12 @@ bool pullOtaPartitionShaMatches(const PullOtaAsset &asset) {
   bool hashFinished = pullOtaHashFinish(hash, digest);
   return ok && hashFinished && checked == asset.size &&
          sha256Matches(digest, asset.sha256);
+}
+
+bool pullOtaPartitionShaMatches(const PullOtaAsset &asset) {
+  return pullOtaPartitionShaMatches(asset, esp_partition_find_first(
+      ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS,
+      HDS_OTA_FS_PARTITION_LABEL));
 }
 
 bool pullOtaLittleFsPartitionSizeMatches(uint32_t expectedSize) {
@@ -1004,8 +1014,10 @@ bool pullOtaStorePendingLittleFs(
     const PullOtaManifest &rollbackManifest,
     const String &combinationHash = "",
     const String &rollbackCombinationHash = "") {
+  const bool forwardRecovery = !rollbackManifest.littlefs.present;
   if (!manifest.littlefs.present || !manifest.littlefs.required ||
-      !rollbackManifest.littlefs.present || !rollbackManifest.littlefs.required ||
+      (forwardRecovery ? manifest.forwardRecoveryVersion != HDS_OTA_FORWARD_RECOVERY_VERSION
+                       : !rollbackManifest.littlefs.required) ||
       (combinationHash.length() > 0 && !pullOtaShaLooksValid(combinationHash)) ||
       (rollbackCombinationHash.length() > 0 &&
        !pullOtaShaLooksValid(rollbackCombinationHash))) {
@@ -1015,8 +1027,12 @@ bool pullOtaStorePendingLittleFs(
   if (!preferences.begin("ota_fs", false)) {
     return false;
   }
-  preferences.clear();
-  bool ok = (combinationHash.length() == 0 ||
+  bool ok = preferences.clear() &&
+            (!forwardRecovery ||
+             (preferences.putUChar("recovery", HDS_OTA_FORWARD_RECOVERY_VERSION) > 0 &&
+              preferences.putString("fw_sha", manifest.firmware.sha256) > 0 &&
+              preferences.putUInt("fw_size", (uint32_t)manifest.firmware.size) > 0)) &&
+            (combinationHash.length() == 0 ||
              preferences.putString("combo", combinationHash) == 64) &&
             (rollbackCombinationHash.length() == 0 ||
              preferences.putString("rb_combo", rollbackCombinationHash) == 64) &&
@@ -1024,10 +1040,11 @@ bool pullOtaStorePendingLittleFs(
             preferences.putUInt("size", (uint32_t)manifest.littlefs.size) > 0 &&
             preferences.putString("sha", manifest.littlefs.sha256) > 0 &&
             preferences.putString("version", manifest.version) > 0 &&
-            preferences.putString("rb_url", rollbackManifest.littlefs.url) > 0 &&
+            (forwardRecovery ||
+            (preferences.putString("rb_url", rollbackManifest.littlefs.url) > 0 &&
             preferences.putUInt("rb_size", (uint32_t)rollbackManifest.littlefs.size) > 0 &&
             preferences.putString("rb_sha", rollbackManifest.littlefs.sha256) > 0 &&
-            preferences.putString("rb_ver", rollbackManifest.version) > 0 &&
+            preferences.putString("rb_ver", rollbackManifest.version) > 0)) &&
             preferences.putString("label", manifest.fsPartitionLabel) > 0 &&
             preferences.putUInt("fs_size", manifest.fsPartitionSize) > 0 &&
             preferences.putUInt("fs_schema", manifest.fsSchema) > 0 &&
@@ -1041,14 +1058,15 @@ bool pullOtaStorePendingLittleFs(
 }
 
 bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &pending);
-[[noreturn]] void pullOtaRecoveryError();
+bool pullOtaRecoveryError();
 
 bool pullOtaLoadPendingLittleFs(PullOtaPendingLittleFs &pending) {
   Preferences preferences;
   if (!preferences.begin("ota_fs", true)) {
     return false;
   }
-  bool hasPending = preferences.getBool("pending", false);
+  bool hasPending = preferences.getBool("pending", false) &&
+                    !(preferences.getBool("paused", false) && filesystemRecoveryActive.load());
   if (!hasPending) {
     preferences.end();
     return false;
@@ -1070,6 +1088,11 @@ bool pullOtaLoadPendingLittleFs(PullOtaPendingLittleFs &pending) {
   loaded.restore = preferences.getBool("restore", false);
   loaded.restoreAttempted = preferences.getBool("restore_try", false);
   loaded.filesystemDirty = preferences.getBool("fs_dirty", false);
+  const uint8_t recoveryVersion = preferences.getUChar("recovery", 0);
+  loaded.forwardRecovery = recoveryVersion == HDS_OTA_FORWARD_RECOVERY_VERSION;
+  PullOtaAsset recoveryFirmware;
+  recoveryFirmware.sha256 = preferences.getString("fw_sha", "");
+  recoveryFirmware.size = preferences.getUInt("fw_size", 0);
   loaded.targetAttempts = preferences.getUChar("target_try", 0);
   loaded.rollbackAsset.present = true;
   loaded.rollbackAsset.required = true;
@@ -1087,6 +1110,12 @@ bool pullOtaLoadPendingLittleFs(PullOtaPendingLittleFs &pending) {
   loaded.fsPartitionSize = preferences.getUInt("fs_size", 0);
   loaded.fsSchema = preferences.getUInt("fs_schema", 0);
   preferences.end();
+  if (recoveryVersion != 0 &&
+      (!loaded.forwardRecovery || loaded.restore || recoveryFirmware.size == 0 ||
+       !pullOtaShaLooksValid(recoveryFirmware.sha256))) {
+    pullOtaRecoveryError();
+    return false;
+  }
   const bool targetUrlAllowed = loaded.combinationHash.length() == 0
       ? pullOtaUrlAllowed(loaded.asset.url)
       : pullOtaCustomLittleFsUrlAllowed(
@@ -1097,28 +1126,37 @@ bool pullOtaLoadPendingLittleFs(PullOtaPendingLittleFs &pending) {
       loaded.fsPartitionLabel != HDS_OTA_FS_PARTITION_LABEL ||
       loaded.fsPartitionSize != HDS_OTA_FS_PARTITION_SIZE ||
       loaded.fsSchema != HDS_OTA_FS_SCHEMA) {
-    pullOtaClearPendingLittleFs();
+    if (loaded.filesystemDirty) pullOtaRecoveryError();
+    else pullOtaClearPendingLittleFs();
     return false;
   }
   const bool rollbackUrlAllowed = loaded.rollbackCombinationHash.length() == 0
       ? pullOtaUrlAllowed(loaded.rollbackAsset.url)
       : pullOtaCustomLittleFsUrlAllowed(
           loaded.rollbackAsset.url, loaded.rollbackCombinationHash);
-  if (!loaded.restore &&
+  if (!loaded.restore && !loaded.forwardRecovery &&
       (!rollbackUrlAllowed ||
        !pullOtaShaLooksValid(loaded.rollbackAsset.sha256) ||
        loaded.rollbackAsset.size != HDS_OTA_FS_PARTITION_SIZE ||
        (loaded.rollbackCombinationHash.length() == 0 &&
-        !pullOtaVersionLooksStable(loaded.rollbackVersion)))) {
-    pullOtaClearPendingLittleFs();
+        !pullOtaVersionIsRelease(loaded.rollbackVersion.c_str())))) {
+    if (loaded.filesystemDirty) pullOtaRecoveryError();
+    else pullOtaClearPendingLittleFs();
     return false;
   }
-  if (!pullOtaIdentityMatches(loaded.version, loaded.combinationHash)) {
+  const bool recoveryFirmwareMatches = !loaded.forwardRecovery ||
+      pullOtaPartitionShaMatches(recoveryFirmware, esp_ota_get_running_partition());
+  if (!pullOtaIdentityMatches(loaded.version, loaded.combinationHash) || !recoveryFirmwareMatches) {
+    if (loaded.forwardRecovery && loaded.filesystemDirty) {
+      pullOtaRecoveryError();
+      return false;
+    }
     if (!loaded.restore && loaded.filesystemDirty &&
         pullOtaIdentityMatches(
             loaded.rollbackVersion, loaded.rollbackCombinationHash)) {
       if (!pullOtaActivateRollbackLittleFs(loaded)) {
         pullOtaRecoveryError();
+        return false;
       }
       return pullOtaLoadPendingLittleFs(pending);
     }
@@ -1277,6 +1315,7 @@ bool pullOtaConfirmInstall(const PullOtaManifest &manifest) {
 }
 
 void pullOtaPauseFilesystemServices() {
+  webFilesystemReady.store(false);
 #if HDS_FEATURE_WEBSERVER
   stopWebServer();
 #endif
@@ -1285,7 +1324,7 @@ void pullOtaPauseFilesystemServices() {
 }
 
 void pullOtaResumeFilesystemServices() {
-  LittleFS.begin();
+  if (!filesystemRecoveryActive.load()) LittleFS.begin();
 #if HDS_FEATURE_WEBSERVER
   if (b_wifiEnabled) {
     startWebServer();
@@ -1402,6 +1441,10 @@ bool pullOtaInstall(
     const PullOtaManifest &rollbackManifest,
     const String &combinationHash = "",
     const String &rollbackCombinationHash = "") {
+  if (!rollbackManifest.littlefs.present &&
+      manifest.forwardRecoveryVersion != HDS_OTA_FORWARD_RECOVERY_VERSION) {
+    return pullOtaFail("Recovery unsupported", "Choose newer build");
+  }
   b_ota = true;
   if (!pullOtaStorePendingLittleFs(
           manifest,
@@ -1436,13 +1479,18 @@ bool pullOtaVerifyPendingLittleFs(const PullOtaPendingLittleFs &pending) {
   return LittleFS.totalBytes() > 0;
 }
 
-[[noreturn]] void pullOtaRecoveryError() {
-  b_ota = true;
-  Serial.println("[pull-ota] UPDATE ERROR - Use HDS updater");
-  while (true) {
-    pullOtaDraw("UPDATE ERROR", "Use HDS updater!");
-    delay(1000);
-  }
+bool pullOtaRecoveryError() {
+  pullOtaPauseFilesystemServices();
+  if (!filesystemRecoveryStore(true)) return false;
+  Preferences preferences;
+  if (!preferences.begin("ota_fs", false)) return false;
+  const bool paused = preferences.putBool("paused", true) > 0;
+  preferences.end();
+  if (!paused || !hdsOtaAcceptFilesystemRecovery()) return false;
+  customBuildReportInstallState(pullOtaCurrentCombinationHash(), "failed");
+  Serial.println("[pull-ota] LittleFS could not be installed; WiFi setup and OTA remain available");
+  pullOtaFail("LittleFS could not", "be installed");
+  return true;
 }
 
 bool pullOtaAttemptPendingLittleFs(
@@ -1477,13 +1525,17 @@ bool pullOtaResumePendingLittleFs() {
   uint8_t attempts = pending.restore ? 0 : pending.targetAttempts;
   bool filesystemWriteStarted = pending.filesystemDirty;
   bool updated = pullOtaVerifyPendingLittleFs(pending);
+  if (pending.forwardRecovery && !updated &&
+      (!filesystemRecoveryStore(true) || !hdsOtaAcceptFilesystemRecovery())) {
+    return false;
+  }
   while (!updated && attempts < maxAttempts) {
     attempts++;
     bool attemptRecorded = pending.restore
         ? !pending.restoreAttempted && pullOtaBeginRollbackLittleFsAttempt()
         : pullOtaBeginTargetLittleFsAttempt(attempts);
     if (!attemptRecorded) {
-      pullOtaRecoveryError();
+      return pullOtaRecoveryError();
     }
     bool attemptWriteStarted = false;
     if (pullOtaAttemptPendingLittleFs(pending, attemptWriteStarted)) {
@@ -1493,21 +1545,23 @@ bool pullOtaResumePendingLittleFs() {
     }
     filesystemWriteStarted = filesystemWriteStarted || attemptWriteStarted;
     if (pending.restore) {
-      pullOtaRecoveryError();
+      return pullOtaRecoveryError();
     }
   }
   if (!updated) {
+    if (pending.forwardRecovery) return pullOtaRecoveryError();
     if (filesystemWriteStarted && !pullOtaActivateRollbackLittleFs(pending)) {
-      pullOtaRecoveryError();
+      return pullOtaRecoveryError();
     }
     return false;
   }
   hdsOtaRollbackMarkValid();
-  customBuildReportInstalled();
+  if (!filesystemRecoveryStore(false)) return pullOtaRecoveryError();
   if (!pullOtaClearPendingLittleFs()) {
     pullOtaFail("FS state failed");
-    pullOtaRecoveryError();
+    return pullOtaRecoveryError();
   }
+  customBuildReportInstalled();
   pullOtaDraw("Update done", "Restarting");
   delay(1500);
   remoteQueueOtaResetAt(millis());
@@ -1584,10 +1638,7 @@ void pullOtaRunUpdate(const PullOtaTargetVersion &target) {
     rollbackFound = pullOtaFindCurrentRelease(catalog, rollbackManifest);
     if (!rollbackFound) rollbackFound = pullOtaFetchCurrentReleaseManifest(rollbackManifest);
   }
-  if (!rollbackFound) {
-    pullOtaFail("Rollback missing");
-    return;
-  }
+  if (!rollbackFound) rollbackManifest = PullOtaManifest();
   uint8_t selectedCatalogIndex = 0;
   if (target.present) {
     if (!pullOtaFindTargetRelease(catalog, selection, target, &selectedCatalogIndex)) {
@@ -1651,6 +1702,7 @@ void pullOtaUpdateTask(void *args) {
   const bool restartPending = (wsPendingMask & WSP_OTA_RESET) != 0;
   portEXIT_CRITICAL(&wsPendingMux);
   if (!restartPending) {
+    if (filesystemRecoveryActive.load()) pullOtaResumeFilesystemServices();
     b_ota = false;
     b_pullOtaRunning = false;
   }

--- a/include/pull_ota_version.h
+++ b/include/pull_ota_version.h
@@ -2,6 +2,7 @@
 #define PULL_OTA_VERSION_H
 
 #define HDS_OTA_RELEASE_RECOVERY_VERSION 1
+#define HDS_OTA_FORWARD_RECOVERY_VERSION 1
 
 #include <stddef.h>
 #include <stdint.h>

--- a/include/tap_detection.h
+++ b/include/tap_detection.h
@@ -25,11 +25,17 @@ void tapDetectTick() {
   const unsigned long now = millis();
   const float weight = f_current_raw_value;
   const bool timerRunning = stopWatch.isRunning();
+  const bool buttonGestureActive =
+      digitalRead(BUTTON_CIRCLE) == LOW || digitalRead(BUTTON_SQUARE) == LOW ||
+      circle_press_data.active || square_press_data.active ||
+      now - circle_press_data.releaseTime <= DOUBLECLICK_DELAY ||
+      now - square_press_data.releaseTime <= DOUBLECLICK_DELAY ||
+      (b_shutdownFailBle && now - t_shutdownFailBle < 3000) || b_powerOff;
   const bool noTapActionAvailable =
       (!b_tapTareEnabled && !b_tapTimerEnabled) ||
       (timerRunning && !b_tapTimerEnabled);
 
-  if (noTapActionAvailable || b_bootTare || b_bootFreshTarePending
+  if (buttonGestureActive || noTapActionAvailable || b_bootTare || b_bootFreshTarePending
 #if HDS_ENABLE_GRINDER
       || grinderRuntime.state == GRINDER_STATE_GRINDING
       || grinderRuntime.state == GRINDER_STATE_STOPPING

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -6,6 +6,7 @@
 #include "esp_system.h"
 #include "mdns_name.h"
 #include "parameter.h"
+#include "filesystem_recovery.h"
 #include "wifi_setup.h"
 #include <ArduinoJson.h>
 #include <AsyncJson.h>
@@ -22,7 +23,6 @@ static AsyncWebServer server(80);
 static AsyncWebSocket websocket("/snapshot");
 #endif
 
-#if !HDS_FEATURE_LITTLEFS
 static const char HDS_WIFI_SETUP_PAGE[] PROGMEM = R"html(<!doctype html>
 <html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>OpenScale setup</title><style>body{font:16px sans-serif;max-width:30rem;margin:2rem auto;padding:0 1rem}label,input,button{display:block;width:100%;box-sizing:border-box;margin:.5rem 0}input,button{padding:.7rem}</style>
@@ -31,11 +31,10 @@ static const char HDS_WIFI_SETUP_PAGE[] PROGMEM = R"html(<!doctype html>
 <form id="name"><label>Device name<input name="name" required></label><button>Save name</button></form>
 <p id="status"></p><script>
 const send=(path,data)=>fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)}).then(r=>{if(!r.ok)throw Error(r.status);return 'Saved. Restarting.'});
-wifi.onsubmit=e=>{e.preventDefault();send('/setup/wifi',Object.fromEntries(new FormData(wifi))).then(show).catch(show)};
-name.onsubmit=e=>{e.preventDefault();send('/setup/name',Object.fromEntries(new FormData(name))).then(show).catch(show)};
-const show=value=>status.textContent=value;
+document.getElementById('wifi').onsubmit=e=>{e.preventDefault();send('/setup/wifi',Object.fromEntries(new FormData(e.currentTarget))).then(show).catch(show)};
+document.getElementById('name').onsubmit=e=>{e.preventDefault();send('/setup/name',Object.fromEntries(new FormData(e.currentTarget))).then(show).catch(show)};
+const show=value=>document.getElementById('status').textContent=value;
 </script></html>)html";
-#endif
 
 static const unsigned long HTTP_MIN_INTERVAL_WHILE_STREAMING_MS = 200;
 static const int HTTP_STREAMING_BURST = 24;
@@ -79,6 +78,13 @@ static const char *parseDeviceNameRequest(JsonVariant &json) {
 }
 
 void startWebServer() {
+#if HDS_FEATURE_LITTLEFS
+  webFilesystemReady.store(!filesystemRecoveryActive.load() && LittleFS.begin());
+  if (!webFilesystemReady.load()) {
+    filesystemRecoveryActive.store(true);
+    Serial.println("LittleFS unavailable -- serving WiFi setup");
+  }
+#endif
   static bool handlersRegistered = false;
   if (!handlersRegistered) {
     AsyncCallbackJsonWebHandler *wifiHandler = new AsyncCallbackJsonWebHandler(
@@ -146,24 +152,19 @@ void startWebServer() {
 #endif
 
 #if HDS_FEATURE_LITTLEFS
-    if (!LittleFS.begin()) {
-      Serial.println("LittleFS mount failed -- web UI unavailable");
-      server.onNotFound([](AsyncWebServerRequest *request) {
-        request->send(503, "text/plain",
-                      "filesystem mount failed; device needs reflashing");
-      });
-    } else {
-      server.serveStatic("/", LittleFS, "/")
-          .setTryGzipFirst(true)
-          .setDefaultFile("index.html")
-          .setCacheControl(LITTLEFS_CACHE_CONTROL);
-      Serial.println("Serving web-apps");
-    }
-#else
-    server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
-      request->send(200, "text/html", HDS_WIFI_SETUP_PAGE);
-    });
+    server.serveStatic("/", LittleFS, "/")
+        .setTryGzipFirst(true)
+        .setDefaultFile("index.html")
+        .setCacheControl(LITTLEFS_CACHE_CONTROL)
+        .setFilter([](AsyncWebServerRequest *) {
+          return webFilesystemReady.load() && !filesystemRecoveryActive.load();
+        });
 #endif
+    server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+      AsyncWebServerResponse *response = request->beginResponse(200, "text/html", HDS_WIFI_SETUP_PAGE);
+      response->addHeader("Cache-Control", "no-store");
+      request->send(response);
+    });
 
     server.addMiddleware([](AsyncWebServerRequest *request, ArMiddlewareNext next) {
       const String &url = request->url();

--- a/src/hds.ino
+++ b/src/hds.ino
@@ -1115,7 +1115,8 @@ void setup() {
     ble_init();
   }
 #if HDS_FEATURE_WIFI
-  if (b_wifiOnBoot && GPIO_power_on_with != BATTERY_CHARGING && !b_pendingOtaLittleFs) {
+  if (b_wifiOnBoot && GPIO_power_on_with != BATTERY_CHARGING && !b_pendingOtaLittleFs &&
+      !filesystemRecoveryActive.load()) {
     wifi_init();
   }
 #endif
@@ -1231,7 +1232,23 @@ void setup() {
       hdsOtaRollback("LittleFS update");
     }
   } else {
-    hdsOtaRollbackMarkValid();
+    if (filesystemRecoveryActive.load()) {
+      if (!filesystemRecoveryStore(true) || !hdsOtaAcceptFilesystemRecovery()) {
+        hdsOtaRollback("LittleFS recovery");
+      }
+    } else {
+      hdsOtaRollbackMarkValid();
+    }
+  }
+  if (filesystemRecoveryActive.load()) {
+    b_ota = false;
+    if (b_pendingOtaLittleFs && b_ble_enabled) ble_init();
+    if (!b_wifiEnabled) {
+      b_wifiOnBoot = true;
+      wifi_init();
+    } else {
+      pullOtaResumeFilesystemServices();
+    }
   }
 #endif
 #if HDS_ENABLE_ENERGY_MENU

--- a/tools/configure_custom_build.py
+++ b/tools/configure_custom_build.py
@@ -74,7 +74,7 @@ FEATURE_PRESENTATION = {
     "energy-menu": (
         "Energy Saving Beta",
         "Enable optional energy-saving controls.",
-        "Adds the Energy Saving menu and its persistent feature toggles.",
+        "Adds Energy Saving settings under Power and saves your selections.",
     ),
 }
 HIDDEN_FEATURES = {"grinder"}
@@ -765,6 +765,13 @@ def combinationHash(value):
     return hashlib.sha256(canonical).hexdigest()
 
 
+def forwardRecoveryVersion(configuration, sourceRoot):
+    header = sourceRoot / "include" / "pull_ota_version.h"
+    if "pull-ota" not in configuration["features"] or not header.is_file():
+        return 0
+    return int("#define HDS_OTA_FORWARD_RECOVERY_VERSION 1" in header.read_text(encoding="utf-8").splitlines())
+
+
 def writeBuildManifest(
     configuration, buildDir, outputPath, commitSha=None, sourceRoot=ROOT, identity=None
 ):
@@ -784,6 +791,7 @@ def writeBuildManifest(
         "base_source": commitSha,
         "builder_source": identity["builder_source"],
         "firmware_version": identity["firmware_version"],
+        "forward_recovery": forwardRecoveryVersion(configuration, sourceRoot),
         "platformio_environment": platformioEnvironment(configuration),
         "partition_schema": partitionMetadata(sourceRoot),
         "packages": packageMetadata(configuration),

--- a/tools/generate_custom_ota_manifest.py
+++ b/tools/generate_custom_ota_manifest.py
@@ -56,6 +56,7 @@ def customManifest(buildDir, build, baseUrl):
         "firmware": asset("firmware.bin"),
         "littlefs": littlefs,
         "custom_build": True,
+        "forward_recovery": 1 if build.get("forward_recovery") == 1 else 0,
         "combination_hash": combinationHash,
     }
 

--- a/tools/generate_release_manifest.py
+++ b/tools/generate_release_manifest.py
@@ -57,6 +57,13 @@ def detect_active_board(config_path):
     return None
 
 
+def forward_recovery_version(config_path):
+    header = config_path.parent / "pull_ota_version.h"
+    if not header.is_file():
+        return 0
+    return int("#define HDS_OTA_FORWARD_RECOVERY_VERSION 1" in header.read_text(encoding="utf-8").splitlines())
+
+
 def detect_pcb_version(config_path):
     text = config_path.read_text(encoding="utf-8")
     active_board = detect_active_board(config_path)
@@ -115,6 +122,7 @@ def build_manifest(
     fs_partition_size=DEFAULT_FS_PARTITION_SIZE,
     fs_schema=DEFAULT_FS_SCHEMA,
     release_notes_url=None,
+    forward_recovery=0,
 ):
     build_dir = Path(build_dir)
     match = RELEASE_VERSION_RE.fullmatch(tag.strip())
@@ -139,6 +147,8 @@ def build_manifest(
     }
     if pcb:
         manifest["pcb"] = pcb
+    if forward_recovery == 1:
+        manifest["forward_recovery"] = 1
     littlefs_path = build_dir / "littlefs.bin"
     if not littlefs_path.is_file():
         raise FileNotFoundError(littlefs_path)
@@ -277,6 +287,7 @@ def main():
         fs_partition_size=args.fs_partition_size,
         fs_schema=args.fs_schema,
         release_notes_url=args.release_notes_url,
+        forward_recovery=forward_recovery_version(args.config),
     )
     if args.catalog:
         previous_manifests = [

--- a/tools/test_custom_build_ota_contract.py
+++ b/tools/test_custom_build_ota_contract.py
@@ -115,7 +115,7 @@ def main():
     assert 'pullOtaFail("Service failed");' in failure
     installed = run.index("const String installedCombination = pullOtaCurrentCombinationHash()")
     check_in = run.index("customBuildCheckIn(installedCombination, assignment)")
-    no_op = run.index("if (assignment.combinationHash == installedCombination)")
+    no_op = run.index("if (assignment.combinationHash == installedCombination && !filesystemRecoveryActive.load())")
     ready_state = run.index('if (assignment.state == "queued"')
     manifest = run.index("customBuildFetchManifest(assignment.combinationHash, manifest)")
     install = run.index("pullOtaInstall(")

--- a/tools/test_custom_build_reporting_runtime.py
+++ b/tools/test_custom_build_reporting_runtime.py
@@ -23,7 +23,8 @@ def main():
 #include <vector>
 using String = std::string;
 struct CustomBuildAssignment {};
-struct PullOtaManifest { int firmware = 0; };
+struct PullOtaManifest { int firmware = 0; struct { bool present = true; } littlefs; int forwardRecoveryVersion = 0; };
+const int HDS_OTA_FORWARD_RECOVERY_VERSION = 1;
 bool b_ota, storeOk, streamOk;
 const int U_FLASH = 0;
 struct PullOtaPendingLittleFs {
@@ -31,6 +32,7 @@ struct PullOtaPendingLittleFs {
   bool restoreAttempted = false;
   uint8_t targetAttempts = 0;
   bool filesystemDirty = false;
+  bool forwardRecovery = false;
 };
 bool paired, network, clockReady, pending, verified, succeeds;
 int reports, failedReports, retries;
@@ -54,12 +56,14 @@ bool pullOtaLoadPendingLittleFs(PullOtaPendingLittleFs &) { return pending; }
 bool pullOtaVerifyPendingLittleFs(const PullOtaPendingLittleFs &) { return verified; }
 bool pullOtaBeginRollbackLittleFsAttempt() { return true; }
 bool pullOtaBeginTargetLittleFsAttempt(uint8_t) { return true; }
-void pullOtaRecoveryError() { assert(false); }
+bool pullOtaRecoveryError() { assert(false); return false; }
+bool filesystemRecoveryStore(bool) { return true; }
+bool hdsOtaAcceptFilesystemRecovery() { return true; }
 bool pullOtaAttemptPendingLittleFs(const PullOtaPendingLittleFs &, bool &) { return succeeds; }
 bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &) { return true; }
 void hdsOtaRollbackMarkValid() { events.push_back("valid"); }
 bool pullOtaClearPendingLittleFs() { events.push_back("clear"); return true; }
-bool pullOtaFail(const char *) { return false; }
+bool pullOtaFail(const char *, const char * = "") { return false; }
 bool pullOtaStorePendingLittleFs(const PullOtaManifest &, const PullOtaManifest &,
     const String &, const String &) { events.push_back("store"); return storeOk; }
 bool pullOtaStreamAsset(int, int, const char *) { events.push_back("stream"); return streamOk; }
@@ -81,6 +85,14 @@ void reset() {
     source += "bool pullOtaResumePendingLittleFs() {" + resume + "}\n"
     source += r'''
 int main() {
+  for (int capability : {0, 1, 2}) {
+    reset();
+    PullOtaManifest target, missingRollback;
+    target.forwardRecoveryVersion = capability;
+    missingRollback.littlefs.present = false;
+    assert(pullOtaInstall(target, missingRollback, String(64, 'b'), identity) == (capability == 1));
+    if (capability != 1) assert(events.empty() && reports == 0);
+  }
   reset();
   assert(pullOtaInstall({}, {}, String(64, 'b'), identity));
   assert(reported == identity);
@@ -102,7 +114,7 @@ int main() {
   reset();
   assert(pullOtaResumePendingLittleFs());
   assert(reported == identity);
-  assert((events == std::vector<String>{"valid", "report", "clear", "restart"}));
+  assert((events == std::vector<String>{"valid", "clear", "report", "restart"}));
   reset();
   verified = false;
   assert(!pullOtaResumePendingLittleFs());

--- a/tools/test_custom_build_reporting_runtime.py
+++ b/tools/test_custom_build_reporting_runtime.py
@@ -1,0 +1,158 @@
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+from test_custom_build_ota_contract import function_body
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    custom = (ROOT / "include/custom_build_ota.h").read_text(encoding="utf-8")
+    ota = (ROOT / "include/pull_ota.h").read_text(encoding="utf-8")
+    report = function_body(custom, "void customBuildReportInstalled()")
+    reportState = function_body(custom, "void customBuildReportInstallState(")
+    install = function_body(ota, "bool pullOtaInstall(")
+    resume = function_body(ota, "bool pullOtaResumePendingLittleFs()")
+    source = r'''
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+using String = std::string;
+struct CustomBuildAssignment {};
+struct PullOtaManifest { int firmware = 0; };
+bool b_ota, storeOk, streamOk;
+const int U_FLASH = 0;
+struct PullOtaPendingLittleFs {
+  bool restore = false;
+  bool restoreAttempted = false;
+  uint8_t targetAttempts = 0;
+  bool filesystemDirty = false;
+};
+bool paired, network, clockReady, pending, verified, succeeds;
+int reports, failedReports, retries;
+String identity, reported;
+std::vector<String> events;
+struct Logger { void println(const char *) {};} Serial;
+bool customBuildRelinkAvailable() { return paired; }
+void pullOtaDraw(const char *, const char *, const char * = "") {}
+bool pullOtaEnsureWifi() { return network; }
+bool pullOtaClockReady() { return clockReady; }
+String pullOtaCurrentCombinationHash() { return identity; }
+bool customBuildCheckIn(const String &value, CustomBuildAssignment &,
+    const String &combination = "", const char *state = "installing") {
+  reports++;
+  reported = value;
+  events.push_back(combination.empty() ? "report" : state);
+  return reports > failedReports;
+}
+void delay(int) { retries++; }
+bool pullOtaLoadPendingLittleFs(PullOtaPendingLittleFs &) { return pending; }
+bool pullOtaVerifyPendingLittleFs(const PullOtaPendingLittleFs &) { return verified; }
+bool pullOtaBeginRollbackLittleFsAttempt() { return true; }
+bool pullOtaBeginTargetLittleFsAttempt(uint8_t) { return true; }
+void pullOtaRecoveryError() { assert(false); }
+bool pullOtaAttemptPendingLittleFs(const PullOtaPendingLittleFs &, bool &) { return succeeds; }
+bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &) { return true; }
+void hdsOtaRollbackMarkValid() { events.push_back("valid"); }
+bool pullOtaClearPendingLittleFs() { events.push_back("clear"); return true; }
+bool pullOtaFail(const char *) { return false; }
+bool pullOtaStorePendingLittleFs(const PullOtaManifest &, const PullOtaManifest &,
+    const String &, const String &) { events.push_back("store"); return storeOk; }
+bool pullOtaStreamAsset(int, int, const char *) { events.push_back("stream"); return streamOk; }
+unsigned long millis() { return 0; }
+void remoteQueueOtaResetAt(unsigned long) { events.push_back("restart"); }
+void reset() {
+  paired = network = clockReady = pending = verified = true;
+  succeeds = false;
+  storeOk = streamOk = true;
+  reports = failedReports = retries = 0;
+  identity = String(64, 'a');
+  reported.clear();
+  events.clear();
+}
+'''
+    source += "void customBuildReportInstalled() {" + report + "}\n"
+    source += "void customBuildReportInstallState(const String &combinationHash, const char *state) {" + reportState + "}\n"
+    source += "bool pullOtaInstall(const PullOtaManifest &manifest, const PullOtaManifest &rollbackManifest, const String &combinationHash, const String &rollbackCombinationHash) {" + install + "}\n"
+    source += "bool pullOtaResumePendingLittleFs() {" + resume + "}\n"
+    source += r'''
+int main() {
+  reset();
+  assert(pullOtaInstall({}, {}, String(64, 'b'), identity));
+  assert(reported == identity);
+  assert((events == std::vector<String>{"store", "installing", "stream", "restart"}));
+  reset();
+  storeOk = false;
+  assert(!pullOtaInstall({}, {}, String(64, 'b'), identity));
+  assert(reports == 0);
+  reset();
+  streamOk = false;
+  assert(!pullOtaInstall({}, {}, String(64, 'b'), identity));
+  assert((events == std::vector<String>{"store", "installing", "stream", "failed", "clear"}));
+  reset();
+  failedReports = 100;
+  assert(pullOtaInstall({}, {}, String(64, 'b'), identity));
+  reset();
+  assert(pullOtaInstall({}, {}, "", identity));
+  assert(reports == 0);
+  reset();
+  assert(pullOtaResumePendingLittleFs());
+  assert(reported == identity);
+  assert((events == std::vector<String>{"valid", "report", "clear", "restart"}));
+  reset();
+  verified = false;
+  assert(!pullOtaResumePendingLittleFs());
+  assert(reports == 0);
+  reset();
+  verified = false;
+  succeeds = true;
+  assert(pullOtaResumePendingLittleFs());
+  assert(reports == 1);
+  reset();
+  pending = false;
+  assert(pullOtaResumePendingLittleFs());
+  assert(reports == 0);
+  reset();
+  paired = false;
+  assert(pullOtaResumePendingLittleFs());
+  assert(reports == 0);
+  reset();
+  identity.clear();
+  assert(pullOtaResumePendingLittleFs());
+  assert(reports == 1 && reported.empty());
+  reset();
+  failedReports = 2;
+  customBuildReportInstalled();
+  assert(reports == 3 && retries == 2);
+  reset();
+  failedReports = 100;
+  assert(pullOtaResumePendingLittleFs());
+  assert(reports == 3 && events.back() == "restart");
+  reset();
+  network = false;
+  assert(pullOtaResumePendingLittleFs());
+  assert(reports == 0 && events.back() == "restart");
+  reset();
+  clockReady = false;
+  customBuildReportInstalled();
+  assert(reports == 0);
+}
+'''
+    compiler = shutil.which("g++")
+    assert compiler, "g++ is required"
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory)
+        cpp = path / "report.cpp"
+        binary = path / "report.exe"
+        cpp.write_text(source, encoding="utf-8")
+        subprocess.run([compiler, "-std=c++17", str(cpp), "-o", str(binary)], check=True)
+        subprocess.run([str(binary)], check=True)
+    print("custom build reporting runtime tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_filesystem_recovery_runtime.py
+++ b/tools/test_filesystem_recovery_runtime.py
@@ -70,11 +70,18 @@ def main():
 using String = std::string;
 volatile std::atomic<bool> filesystemRecoveryActive{false}, webFilesystemReady{true};
 std::map<String, bool> nvs;
+std::map<String, String> strings;
+std::map<String, uint32_t> numbers;
 std::vector<String> events;
+String runningCombination, reportedCombination;
 bool storageOk = true, acceptOk = true, clearOk = true;
 bool hdsOtaPendingVerify = true;
 bool b_ota = true;
 const int ESP_OK = 0;
+const int HDS_OTA_FORWARD_RECOVERY_VERSION = 1;
+bool pullOtaShaLooksValid(const String &value) {
+  return value.size() == 64 && value.find_first_not_of("0123456789abcdef") == String::npos;
+}
 struct Preferences {
   String name;
   bool begin(const char *value, bool) { name = value; return storageOk; }
@@ -83,6 +90,25 @@ struct Preferences {
     return found == nvs.end() ? fallback : found->second;
   }
   int putBool(const char *key, bool value) { nvs[name + key] = value; return 1; }
+  String getString(const char *key, const String &fallback) {
+    const auto found = strings.find(name + key);
+    return found == strings.end() ? fallback : found->second;
+  }
+  size_t putString(const char *key, const String &value) { strings[name + key] = value; return value.size(); }
+  int putUInt(const char *key, uint32_t value) { numbers[name + key] = value; return 4; }
+  int putUChar(const char *key, uint8_t value) { numbers[name + key] = value; return 1; }
+  bool clear() {
+    for (auto it = nvs.begin(); it != nvs.end();) {
+      if (it->first.rfind(name, 0) == 0) it = nvs.erase(it); else ++it;
+    }
+    for (auto it = strings.begin(); it != strings.end();) {
+      if (it->first.rfind(name, 0) == 0) it = strings.erase(it); else ++it;
+    }
+    for (auto it = numbers.begin(); it != numbers.end();) {
+      if (it->first.rfind(name, 0) == 0) it = numbers.erase(it); else ++it;
+    }
+    return true;
+  }
   void end() {}
 };
 struct Logger { void println(const char *) {};} Serial;
@@ -93,13 +119,30 @@ int esp_ota_mark_app_valid_cancel_rollback() {
 }
 void hdsOtaClearAttempts() {}
 void pullOtaPauseFilesystemServices() { webFilesystemReady.store(false); events.push_back("stop-fs"); }
-String pullOtaCurrentCombinationHash() { return "build"; }
-void customBuildReportInstallState(const String &, const char *state) { events.push_back(state); }
+String pullOtaCurrentCombinationHash() { return runningCombination; }
+void customBuildReportInstallState(const String &combination, const char *state) {
+  reportedCombination = combination; events.push_back(state);
+}
 bool pullOtaFail(const char *, const char * = "") { events.push_back("error"); return false; }
+struct PullOtaAsset {
+  bool present = true, required = true;
+  String url = "asset", sha256 = String(64, 'c');
+  size_t size = 1;
+};
+struct PullOtaManifest {
+  PullOtaAsset firmware, littlefs;
+  int forwardRecoveryVersion = 1;
+  String version = "3.1.14", fsPartitionLabel = "spiffs";
+  uint32_t fsPartitionSize = 1, fsSchema = 1;
+};
 struct PullOtaPendingLittleFs {
   bool restore = false, restoreAttempted = false, filesystemDirty = false;
   bool forwardRecovery = false;
   uint8_t targetAttempts = 0;
+  String combinationHash, rollbackCombinationHash;
+  PullOtaAsset rollbackAsset;
+  String rollbackVersion = "3.1.14", fsPartitionLabel = "spiffs";
+  uint32_t fsPartitionSize = 1, fsSchema = 1;
 };
 PullOtaPendingLittleFs saved;
 bool verified = false, succeeds = false, activateOk = true, pending = true;
@@ -112,7 +155,10 @@ bool pullOtaAttemptPendingLittleFs(const PullOtaPendingLittleFs &, bool &dirty) 
   if (saved.forwardRecovery) assert(!hdsOtaPendingVerify && nvs["ota_recoveryactive"]);
   attempts++; dirty = saved.filesystemDirty; return succeeds;
 }
-bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &) { events.push_back("rollback"); return activateOk; }
+bool activateRollback(const PullOtaPendingLittleFs &);
+bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &value) {
+  events.push_back("rollback"); return activateOk && activateRollback(value);
+}
 void hdsOtaRollbackMarkValid() { events.push_back("valid"); }
 void customBuildReportInstalled() { assert(!filesystemRecoveryActive.load()); events.push_back("installed"); }
 bool pullOtaClearPendingLittleFs() { events.push_back("clear"); return clearOk; }
@@ -122,12 +168,18 @@ unsigned long millis() { return 0; }
 void remoteQueueOtaResetAt(unsigned long) { events.push_back("restart"); }
 void reset() {
   filesystemRecoveryActive.store(false); webFilesystemReady.store(true);
-  nvs.clear(); events.clear(); saved = {};
+  nvs.clear(); strings.clear(); numbers.clear(); events.clear(); saved = {};
+  runningCombination = String(64, 'a'); reportedCombination.clear();
+  strings["ota_fsinstall_combo"] = String(64, 'b');
   storageOk = acceptOk = clearOk = hdsOtaPendingVerify = b_ota = activateOk = pending = true;
   verified = succeeds = false; attempts = 0;
 }
 '''
     source += re.sub(r"^#include[^\n]*", "", recovery, flags=re.MULTILINE)
+    source += "bool activateRollback(const PullOtaPendingLittleFs &pending) {" + function_body(
+        ota, "bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &pending) {") + "}\n"
+    source += "bool pullOtaStorePendingLittleFs(const PullOtaManifest &manifest, const PullOtaManifest &rollbackManifest, const String &combinationHash, const String &rollbackCombinationHash) {" + function_body(
+        ota, "bool pullOtaStorePendingLittleFs(") + "}\n"
     for text, declaration in (
         (rollback, "bool hdsOtaAcceptFilesystemRecovery()"),
         (ota, "bool pullOtaRecoveryError()"),
@@ -136,6 +188,37 @@ void reset() {
         source += declaration + " {" + function_body(text, declaration + " {") + "}\n"
     source += r'''
 int main() {
+  const String buildA(64, 'a'), buildB(64, 'b');
+  reset();
+  assert(pullOtaStorePendingLittleFs({}, {}, buildB, buildA));
+  assert(strings["ota_fsinstall_combo"] == buildB);
+  customBuildReportInstallState(buildB, "installing");
+  assert(reportedCombination == buildB);
+  runningCombination = buildB;
+  saved.combinationHash = strings["ota_fscombo"];
+  saved.rollbackCombinationHash = strings["ota_fsrb_combo"];
+  saved.filesystemDirty = true;
+  assert(!pullOtaResumePendingLittleFs() && attempts == 2);
+  assert(strings["ota_fscombo"] == buildA && strings["ota_fsinstall_combo"] == buildB);
+  runningCombination = buildA; hdsOtaPendingVerify = false; saved = {};
+  saved.restore = nvs["ota_fsrestore"];
+  assert(saved.restore && pullOtaResumePendingLittleFs());
+  assert(reportedCombination == buildB && events[events.size() - 2] == "failed");
+  assert(nvs["ota_fspaused"] && strings["ota_fsinstall_combo"] == buildB);
+  for (const String &legacyTarget : {buildB, String("invalid"), String("")}) {
+    reset(); strings.erase("ota_fsinstall_combo"); strings["ota_fscombo"] = legacyTarget;
+    assert(pullOtaRecoveryError());
+    assert(reportedCombination == (legacyTarget == buildB ? buildB : String("")));
+  }
+  reset(); strings.erase("ota_fsinstall_combo"); strings["ota_fscombo"] = buildA;
+  nvs["ota_fsrestore"] = true;
+  assert(pullOtaRecoveryError() && reportedCombination.empty());
+  reset(); strings.erase("ota_fsinstall_combo");
+  saved.combinationHash = buildB; saved.rollbackCombinationHash = buildA;
+  assert(activateRollback(saved) && strings["ota_fsinstall_combo"] == buildB);
+  reset();
+  assert(pullOtaStorePendingLittleFs({}, {}, "", buildA));
+  assert(pullOtaRecoveryError() && reportedCombination.empty());
   reset(); saved.restore = true;
   assert(pullOtaResumePendingLittleFs());
   assert(attempts == 1 && filesystemRecoveryActive.load() && !webFilesystemReady.load());

--- a/tools/test_filesystem_recovery_runtime.py
+++ b/tools/test_filesystem_recovery_runtime.py
@@ -1,0 +1,218 @@
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+
+from test_custom_build_ota_contract import function_body
+import configure_custom_build as custom_build
+import generate_custom_ota_manifest as custom_manifest
+import generate_release_manifest as release_manifest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    ota = (ROOT / "include/pull_ota.h").read_text(encoding="utf-8")
+    recovery = (ROOT / "include/filesystem_recovery.h").read_text(encoding="utf-8")
+    rollback = (ROOT / "include/ota_rollback.h").read_text(encoding="utf-8")
+    web = (ROOT / "include/webserver.h").read_text(encoding="utf-8")
+    custom = (ROOT / "include/custom_build_ota.h").read_text(encoding="utf-8")
+    setup = (ROOT / "src/hds.ino").read_text(encoding="utf-8")
+    loader = function_body(ota, "bool pullOtaLoadPendingLittleFs(")
+    assert 'preferences.getBool("paused", false) && filesystemRecoveryActive.load()' in loader
+    assert "filesystemRecoveryLoad();" in function_body(rollback, "void hdsOtaRollbackBegin(")
+    assert "filesystemRecoveryActive.load()" in function_body(custom, "bool customBuildCheckIn(")
+    assert "assignment.combinationHash == installedCombination && !filesystemRecoveryActive.load()" in custom
+    assert "currentCompare != 0 || currentIsPrerelease || filesystemRecoveryActive.load()" in ota
+    assert "if (filesystemRecoveryActive.load())" in setup
+    assert web.index('server.serveStatic("/", LittleFS, "/")') < web.index('server.on("/", HTTP_GET')
+    assert "return webFilesystemReady.load() && !filesystemRecoveryActive.load();" in web
+    assert "#if !HDS_FEATURE_LITTLEFS" not in web
+    assert 'response->addHeader("Cache-Control", "no-store")' in web
+    assert "while (true)" not in function_body(ota, "bool pullOtaRecoveryError() {")
+    assert "pullOtaPartitionShaMatches(recoveryFirmware, esp_ota_get_running_partition())" in loader
+    assert "!loaded.restore && !loaded.forwardRecovery" in loader
+    assert 'preferences.putString("fw_sha", manifest.firmware.sha256)' in ota
+    assert 'preferences.putUInt("fw_size", (uint32_t)manifest.firmware.size)' in ota
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        (root / "include").mkdir()
+        header = root / "include/pull_ota_version.h"
+        config = root / "include/config.h"
+        features = {"features": ["pull-ota"]}
+        assert release_manifest.forward_recovery_version(config) == 0
+        assert custom_build.forwardRecoveryVersion(features, root) == 0
+        for version in (0, 1, 2):
+            header.write_text(f"#define HDS_OTA_FORWARD_RECOVERY_VERSION {version}\n", encoding="utf-8")
+            assert release_manifest.forward_recovery_version(config) == int(version == 1)
+            assert custom_build.forwardRecoveryVersion(features, root) == int(version == 1)
+            assert custom_build.forwardRecoveryVersion({"features": ["wifi"]}, root) == 0
+        for name in ("firmware.bin", "littlefs.bin"):
+            (root / name).write_bytes(b"test")
+        for capability in (0, 1):
+            manifest = release_manifest.build_manifest(root, "v3.1.14", "decentespresso/openscale", "hds", "3.1.13", forward_recovery=capability)
+            assert manifest.get("forward_recovery", 0) == capability
+            build = {"combination_hash": "a" * 64, "firmware_version": "3.1.14-custom", "forward_recovery": capability}
+            manifest = custom_manifest.customManifest(root, build, "https://example.com")
+            assert manifest["forward_recovery"] == capability
+
+    source = r'''
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+#define CONFIG_APP_ROLLBACK_ENABLE 1
+using String = std::string;
+volatile std::atomic<bool> filesystemRecoveryActive{false}, webFilesystemReady{true};
+std::map<String, bool> nvs;
+std::vector<String> events;
+bool storageOk = true, acceptOk = true, clearOk = true;
+bool hdsOtaPendingVerify = true;
+bool b_ota = true;
+const int ESP_OK = 0;
+struct Preferences {
+  String name;
+  bool begin(const char *value, bool) { name = value; return storageOk; }
+  bool getBool(const char *key, bool fallback) {
+    const auto found = nvs.find(name + key);
+    return found == nvs.end() ? fallback : found->second;
+  }
+  int putBool(const char *key, bool value) { nvs[name + key] = value; return 1; }
+  void end() {}
+};
+struct Logger { void println(const char *) {};} Serial;
+int esp_ota_mark_app_valid_cancel_rollback() {
+  assert(nvs["ota_recoveryactive"]);
+  events.push_back("accept-recovery");
+  return acceptOk ? ESP_OK : -1;
+}
+void hdsOtaClearAttempts() {}
+void pullOtaPauseFilesystemServices() { webFilesystemReady.store(false); events.push_back("stop-fs"); }
+String pullOtaCurrentCombinationHash() { return "build"; }
+void customBuildReportInstallState(const String &, const char *state) { events.push_back(state); }
+bool pullOtaFail(const char *, const char * = "") { events.push_back("error"); return false; }
+struct PullOtaPendingLittleFs {
+  bool restore = false, restoreAttempted = false, filesystemDirty = false;
+  bool forwardRecovery = false;
+  uint8_t targetAttempts = 0;
+};
+PullOtaPendingLittleFs saved;
+bool verified = false, succeeds = false, activateOk = true, pending = true;
+int attempts = 0;
+bool pullOtaLoadPendingLittleFs(PullOtaPendingLittleFs &out) { out = saved; return pending; }
+bool pullOtaVerifyPendingLittleFs(const PullOtaPendingLittleFs &) { return verified; }
+bool pullOtaBeginRollbackLittleFsAttempt() { return true; }
+bool pullOtaBeginTargetLittleFsAttempt(uint8_t) { return true; }
+bool pullOtaAttemptPendingLittleFs(const PullOtaPendingLittleFs &, bool &dirty) {
+  if (saved.forwardRecovery) assert(!hdsOtaPendingVerify && nvs["ota_recoveryactive"]);
+  attempts++; dirty = saved.filesystemDirty; return succeeds;
+}
+bool pullOtaActivateRollbackLittleFs(const PullOtaPendingLittleFs &) { events.push_back("rollback"); return activateOk; }
+void hdsOtaRollbackMarkValid() { events.push_back("valid"); }
+void customBuildReportInstalled() { assert(!filesystemRecoveryActive.load()); events.push_back("installed"); }
+bool pullOtaClearPendingLittleFs() { events.push_back("clear"); return clearOk; }
+void pullOtaDraw(const char *, const char *) {}
+void delay(int) {}
+unsigned long millis() { return 0; }
+void remoteQueueOtaResetAt(unsigned long) { events.push_back("restart"); }
+void reset() {
+  filesystemRecoveryActive.store(false); webFilesystemReady.store(true);
+  nvs.clear(); events.clear(); saved = {};
+  storageOk = acceptOk = clearOk = hdsOtaPendingVerify = b_ota = activateOk = pending = true;
+  verified = succeeds = false; attempts = 0;
+}
+'''
+    source += re.sub(r"^#include[^\n]*", "", recovery, flags=re.MULTILINE)
+    for text, declaration in (
+        (rollback, "bool hdsOtaAcceptFilesystemRecovery()"),
+        (ota, "bool pullOtaRecoveryError()"),
+        (ota, "bool pullOtaResumePendingLittleFs()"),
+    ):
+        source += declaration + " {" + function_body(text, declaration + " {") + "}\n"
+    source += r'''
+int main() {
+  reset(); saved.restore = true;
+  assert(pullOtaResumePendingLittleFs());
+  assert(attempts == 1 && filesystemRecoveryActive.load() && !webFilesystemReady.load());
+  assert((events == std::vector<String>{"stop-fs", "accept-recovery", "failed", "error"}));
+  assert(!hdsOtaPendingVerify && nvs["ota_fspaused"]);
+  filesystemRecoveryActive.store(false); filesystemRecoveryLoad();
+  assert(filesystemRecoveryActive.load());
+  reset(); saved.restore = saved.restoreAttempted = true;
+  assert(pullOtaResumePendingLittleFs() && attempts == 0);
+  reset(); saved.filesystemDirty = true;
+  assert(!pullOtaResumePendingLittleFs() && attempts == 2);
+  assert((events == std::vector<String>{"rollback"}));
+  reset();
+  assert(!pullOtaResumePendingLittleFs() && attempts == 2 && events.empty());
+  reset(); saved.filesystemDirty = true; activateOk = false;
+  assert(pullOtaResumePendingLittleFs() && filesystemRecoveryActive.load());
+  reset(); saved.restore = true; storageOk = false;
+  assert(!pullOtaResumePendingLittleFs() && hdsOtaPendingVerify);
+  reset(); saved.restore = true; acceptOk = false;
+  assert(!pullOtaResumePendingLittleFs() && hdsOtaPendingVerify);
+  reset(); filesystemRecoveryStore(true); verified = true;
+  assert(pullOtaResumePendingLittleFs() && attempts == 0);
+  assert(!filesystemRecoveryActive.load() && !nvs["ota_recoveryactive"]);
+  assert((events == std::vector<String>{"valid", "clear", "installed", "restart"}));
+  reset(); verified = true; clearOk = false;
+  assert(pullOtaResumePendingLittleFs() && filesystemRecoveryActive.load());
+  for (const auto &event : events) assert(event != "installed" && event != "restart");
+  reset(); saved.forwardRecovery = true;
+  assert(pullOtaResumePendingLittleFs() && attempts == 2);
+  assert(filesystemRecoveryActive.load() && nvs["ota_fspaused"]);
+  for (const auto &event : events) assert(event != "rollback" && event != "installed");
+  reset(); saved.forwardRecovery = true; succeeds = true;
+  assert(pullOtaResumePendingLittleFs() && attempts == 1);
+  assert(!filesystemRecoveryActive.load() && events.back() == "restart");
+  reset(); saved.forwardRecovery = true; acceptOk = false;
+  assert(!pullOtaResumePendingLittleFs() && attempts == 0);
+  reset(); saved.forwardRecovery = true; saved.targetAttempts = 2;
+  assert(pullOtaResumePendingLittleFs() && attempts == 0 && nvs["ota_fspaused"]);
+}
+'''
+    compiler = shutil.which("g++")
+    assert compiler, "g++ is required"
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory)
+        cpp, binary = path / "recovery.cpp", path / "recovery.exe"
+        cpp.write_text(source, encoding="utf-8")
+        subprocess.run([compiler, "-std=c++17", "-Wall", "-Wextra", "-Werror", str(cpp), "-o", str(binary)], check=True)
+        subprocess.run([str(binary)], check=True)
+    print("filesystem recovery runtime tests passed")
+    script = web.split("<script>", 1)[1].split("</script>", 1)[0]
+    subprocess.run(["node", "-e", r'''
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const forms = {wifi: {data: {ssid: 'network', pass: 'secret'}}, name: {data: {name: 'scale'}}, status: {}};
+const calls = [];
+let ok = true;
+vm.runInNewContext(process.argv[1], {
+  document: {getElementById: id => forms[id]},
+  name: '', status: '',
+  FormData: class { constructor(form) { return Object.entries(form.data); } },
+  fetch: async (path, options) => { calls.push([path, JSON.parse(options.body)]); return {ok, status: 500}; }
+});
+(async () => {
+  for (const id of ['wifi', 'name']) {
+    forms[id].onsubmit({preventDefault() {}, currentTarget: forms[id]});
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(calls.at(-1), ['/setup/' + id, forms[id].data]);
+    assert.equal(forms.status.textContent, 'Saved. Restarting.');
+  }
+  ok = false;
+  forms.wifi.onsubmit({preventDefault() {}, currentTarget: forms.wifi});
+  await new Promise(resolve => setImmediate(resolve));
+  assert.match(String(forms.status.textContent), /500/);
+  console.log('fallback HTTP page form tests passed');
+})().catch(error => { console.error(error); process.exitCode = 1; });
+''', script], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,7 +254,7 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=29"' in indexPage
+    assert 'type="module" src="app.js?v=30"' in indexPage
     assert 'href="styles.css?v=18"' in indexPage
     assert 'href="fleet.css?v=7"' in indexPage
     assert 'id="request-build"' in indexPage
@@ -271,7 +271,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=12' in appScript
+    assert 'fleet.js?v=13' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" not in fleetScript
     assert "localStorage.setItem(storageKey" in fleetScript

--- a/tools/test_pull_ota_contract.py
+++ b/tools/test_pull_ota_contract.py
@@ -128,7 +128,7 @@ def main():
     assert_contains(PULL_OTA_HEADER, "maxAttempts = pending.restore ? 1 : 2")
     assert_contains(PULL_OTA_HEADER, "pullOtaBeginTargetLittleFsAttempt(attempts)")
     assert_contains(PULL_OTA_HEADER, "pullOtaActivateRollbackLittleFs(pending)")
-    assert_contains(PULL_OTA_HEADER, 'pullOtaDraw("UPDATE ERROR", "Use HDS updater!")')
+    assert_contains(PULL_OTA_HEADER, 'pullOtaFail("LittleFS could not", "be installed")')
     assert_contains(PULL_OTA_HEADER, "pullOtaPartitionShaMatches")
     assert_contains(PULL_OTA_HEADER, "ESP.getFlashChipSize()")
     assert_contains(PULL_OTA_HEADER, "ESP.getFlashChipSize() < manifest.flashSize")
@@ -202,7 +202,10 @@ def main():
     assert "pullOtaFindCurrentRelease" not in custom_branch
     assert "pullOtaFetchCurrentReleaseManifest" not in custom_branch
     assert 'pullOtaInstall(manifest, rollbackManifest, "", rollbackCombinationHash);' in interactive
-    assert run.index('pullOtaFail("Rollback missing")') < targeted_start
+    assert run.index('if (!rollbackFound) rollbackManifest = PullOtaManifest();') < targeted_start
+    install = contents[contents.index("bool pullOtaInstall("):contents.index("bool pullOtaVerifyPendingLittleFs(")]
+    assert install.index('pullOtaFail("Recovery unsupported"') < install.index("pullOtaStorePendingLittleFs(")
+    assert "manifest.forwardRecoveryVersion != HDS_OTA_FORWARD_RECOVERY_VERSION" in install
     if "pullOtaPickRelease(catalog, selection, &selectedCatalogIndex)" not in interactive:
         raise AssertionError("the interactive picker must remain on the no-target path")
     if "pullOtaConfirmInstall(manifest)" not in interactive:

--- a/tools/test_tap_button_priority.py
+++ b/tools/test_tap_button_priority.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+from test_tap_action_contract import function_body
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    tap = (ROOT / "include/tap_detection.h").read_text(encoding="utf-8")
+    source = r'''
+#include <cassert>
+#include <cstdint>
+const int LOW = 0, HIGH = 1, BUTTON_CIRCLE = 1, BUTTON_SQUARE = 2;
+const unsigned long DOUBLECLICK_DELAY = 600;
+unsigned long now = 10000, t_menuExitTime = 0, t_shutdownFailBle = 0;
+unsigned long t_quickZeroStart = 0, t_tareByButton = 0;
+float f_current_raw_value = 0;
+bool b_tapTareEnabled = true, b_tapTimerEnabled = true;
+bool b_shutdownFailBle = false, b_powerOff = false;
+bool b_bootTare = false, b_bootFreshTarePending = false;
+bool b_weight_quick_zero = false, b_tareByButton = false;
+bool tapDetectionGated = false;
+int circle = HIGH, square = HIGH, timerActions = 0;
+struct Press { bool active = false; unsigned long releaseTime = 0; } circle_press_data, square_press_data;
+struct Timer { bool isRunning() { return false; } } stopWatch;
+enum class TapEvent { Double, Triple };
+TapEvent nextEvent = TapEvent::Double;
+struct Detector {
+  int ticks = 0, resets = 0;
+  void reset(unsigned long, float) { resets++; }
+  TapEvent tick(unsigned long, float) { ticks++; return nextEvent; }
+} tapDetector;
+struct Logger { void println(const char *) {};} Serial;
+int digitalRead(int pin) { return pin == BUTTON_CIRCLE ? circle : square; }
+unsigned long millis() { return now; }
+void power_off(int) {}
+void scaleTimer() { timerActions++; }
+'''
+    for declaration, name in (
+        ("void runTapLocalAction(bool tripleTap)", "runTapLocalAction"),
+        ("void tapDetectTick()", "tapDetectTick"),
+    ):
+        source += declaration + function_body(tap, name) + "\n"
+    source += r'''
+void blocked() {
+  const int ticks = tapDetector.ticks;
+  b_tareByButton = false;
+  tapDetectTick();
+  assert(tapDetector.ticks == ticks && !b_tareByButton && tapDetectionGated);
+}
+int main() {
+  tapDetectTick(); assert(b_tareByButton);
+  circle = LOW; blocked(); circle = HIGH;
+  square = LOW; blocked(); square = HIGH;
+  circle_press_data.active = true; blocked(); circle_press_data.active = false;
+  square_press_data.active = true; blocked(); square_press_data.active = false;
+  for (auto *press : {&circle_press_data, &square_press_data}) {
+    press->releaseTime = now - DOUBLECLICK_DELAY; blocked(); press->releaseTime = 0;
+  }
+  b_shutdownFailBle = true; t_shutdownFailBle = now - 2999; blocked();
+  b_shutdownFailBle = false;
+  b_powerOff = true; blocked(); assert(b_powerOff); b_powerOff = false;
+  const int resets = tapDetector.resets;
+  tapDetectTick(); assert(b_tareByButton && !tapDetectionGated && tapDetector.resets > resets);
+  nextEvent = TapEvent::Triple;
+  square = LOW; blocked(); assert(timerActions == 0); square = HIGH;
+  tapDetectTick(); assert(timerActions == 1);
+}
+'''
+    compiler = shutil.which("g++")
+    assert compiler, "g++ is required"
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory)
+        cpp, binary = path / "tap.cpp", path / "tap.exe"
+        cpp.write_text(source, encoding="utf-8")
+        subprocess.run([compiler, "-std=c++17", "-include", "initializer_list", str(cpp), "-o", str(binary)], check=True)
+        subprocess.run([str(binary)], check=True)
+    print("tap button priority runtime tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Report custom installation start after pending filesystem state is saved, and firmware streaming failure without claiming the target is installed.
- Report the running identity after filesystem verification and firmware acceptance, before reboot. Retry completion reports up to three times; telemetry outages do not block successful installs.
- Accept authenticated optional install telemetry in the Worker while retaining compatibility with old firmware.
- Show Installing, Install failed, and Status unconfirmed after 15 minutes without confirmation. Only verified installed identity yields Up to date.
- Keep fleet status polling active during editing without replacing focused controls or open details.

## Verification
- All Python contract scripts passed; extended compiled C++ reporting harness and OTA contracts passed.
- All 44 Worker/configurator Node tests passed.
- ESP32-S3 PlatformIO firmware build passed.
- Playwright desktop/mobile verified Install pending to Installing to Up to date without reload, preserving focused draft text.
- No physical-scale OTA test performed.

## Rollout
Deploy the Worker change before firmware using the optional telemetry fields; merge publishes the site through the existing Pages flow. Start reporting requires the source firmware to contain this fix. Completion reporting requires the installed target firmware to contain this fix. Older installed builds still need a manual Custom Build check-in. Worker deployment is not included in this PR operation.
## Additional Fixes
- Keep the embedded WiFi setup page available when LittleFS cannot mount or staged recovery fails. Preserve the error across reboot, disable unverified filesystem serving, and return to the normal menu for WiFi OTA or Custom Build.
- Allow reinstalling the same release/build during filesystem recovery. Do not report a complete installed identity while repair is pending.
- When source rollback metadata is unavailable, permit the selected signed target only if its manifest declares forward_recovery version 1. Save the signed firmware hash/size before flashing, verify the running firmware exactly, then accept that app before filesystem writes. Exhausted attempts return to the fallback page and menu rather than an infinite error loop.
- Derive the signed capability from the actual release/custom source checkout, not the current builder. Custom targets must include Pull OTA. Historical targets without this capability remain blocked when rollback metadata is unavailable.
- Correct the Energy Saving tooltip to locate its settings under Power.
- Gate scale-top weight taps during Circle/Square gestures, post-release recognition, BLE shutdown confirmation, and queued shutdown. The button power-off sequence itself is unchanged.

## Additional Verification
- Compiled C++ recovery tests cover bounded retries, persisted fallback, acceptance failure, unchanged normal rollback, forward recovery before filesystem writes, repair completion, and no false success reporting.
- Capability-generation and install-admission tests cover supported, absent, and future capability versions.
- Embedded-page JavaScript tests cover WiFi/name submissions and request failure; button-priority runtime checks cover both tap actions.
- All local Python contract scripts passed after supplying OpenSSL on PATH and using the current checkout for the prospective v3.1.14 catalog entry, matching CI's prospective-tag setup.
- Standard esp32s3 and esp32s3-custom with WiFi/WebServer/Pull OTA but no LittleFS built successfully.
- No hardware recovery test or local flash performed. Already-installed firmware does not acquire these behaviors until updated.