### PR TITLE
Fix false Wake-on-Weight boots from uninitialized RTC inputs

### DIFF
--- a/docs/AI_GPIO_NOTES.md
+++ b/docs/AI_GPIO_NOTES.md
@@ -83,11 +83,15 @@ Current active config is `V8_1` with `TWO_BUTTON`.
 Wake-on-Weight (`include/wake_on_weight.h`) adds a second release/re-latch
 path: an RTC-timer micro-wakeup releases `gpio_hold` on `SCALE_SCLK`,
 `SCALE_PDWN`, `SCALE_DOUT`, `PWR_CTRL` only, raises `PWR_CTRL` briefly to
-read one ADS1232 conversion, then re-latches exactly those four pins before
+discard one ADS1232 startup conversion and confirm the next two, then re-latches exactly those four pins before
 re-entering deep sleep. OLED, I2C, secondary-scale, and `ACC_PWR_CTRL` holds
 are never touched by the micro path; the normal `setup()` release block
 (`gpio_hold_dis` sequence in `src/hds.ino`) is idempotent on pins the micro
 path already released.
+
+Before its first button/charging check, the timer path releases the three wake pins'
+RTC holds and explicitly restores RTC input mode and pull-ups. A disabled input can
+read low and otherwise be mistaken for a pressed button before ADC sampling begins.
 
 ## Change Checklist
 

--- a/docs/wake-on-weight.md
+++ b/docs/wake-on-weight.md
@@ -2,7 +2,8 @@
 
 Wake-on-Weight (WoW) defaults to off. When enabled, normal shutdown captures
 the current weight, then RTC timer wakes briefly power the primary ADS1232
-and compare one conversion against that baseline. A change greater than the
+and discard the first conversion after ADC startup. The next two valid conversions
+must both differ from the shutdown baseline in the same direction. A change greater than the
 50 g threshold (with a 500-raw-count minimum) continues into normal boot,
 including boot tare. Removing weight can
 also trigger a boot. No separate firmware or energy-menu build is required.
@@ -15,29 +16,34 @@ detection periods. The NVS key `wow_interval` stores indices 0 through 3;
 all default and migration paths use 0. The selected interval is snapshotted
 at shutdown. Changing it does not change a sleep session already underway.
 
+Enabling without a valid calibration displays `Please calibrate` and leaves the
+setting off. If calibration becomes invalid while enabled, the next press turns it off.
+
 The timer starts when entering deep sleep, after the micro-wake work.
 The detection period is sleep interval plus micro-wake duration. The PR's
 V8.1 measurement was approximately 850 ms per micro-wake, including about
 300 ms ROM/Arduino startup, 100 ms rail settling, and the first 10 SPS ADC
-conversion. Firmware polling has a separate 900 ms timeout after settling.
+conversion. Confirmation now adds two conversions, approximately 200 ms at 10 SPS.
+Firmware polling has a shared 900 ms timeout for all three conversions after settling.
 The revised path runs before Serial initialization and does not log per tick;
 its exact duration must be remeasured on hardware.
 
 | Sleep interval | Estimated detection period | Active duty |
 | --- | --- | --- |
-| 2 s | 2.85 s | 29.8% |
-| 3 s | 3.85 s | 22.1% |
-| 4 s | 4.85 s | 17.5% |
+| 2 s | 3.05 s | 34.4% |
+| 3 s | 4.05 s | 25.9% |
+| 4 s | 5.05 s | 20.8% |
 
-Duty is `0.85 / (sleep seconds + 0.85)`, not `0.85 / sleep seconds`.
+Duty is `1.05 / (sleep seconds + 1.05)`, not `1.05 / sleep seconds`.
 ADC failures lengthen the active portion. Sampling is intermittent: a load
 placed and removed between samples can be missed.
 
 ## Button and Charging Wake
 
 Normal deep sleep keeps the existing EXT1 any-low button and charging wake
-sources. During a WoW micro-wake, the same RTC input pins are checked on
-entry, every 2 ms during rail settling and ADC polling, after ADC cleanup,
+sources. A WoW micro-wake first releases their RTC holds and restores RTC input
+mode and pull-ups before reading any wake pin. The pins are checked on entry,
+every 2 ms during rail settling and ADC polling, after ADC cleanup,
 and immediately before the final pin-latch/sleep sequence. A detected press
 aborts the micro-wake and continues into normal boot without waiting for ADC
 readiness. Square has priority over circle, and both have priority over
@@ -64,8 +70,8 @@ An observed low-battery count or a known voltage below 3.2 V prevents arming.
 Non-finite or overflowing calibration thresholds also prevent arming.
 
 Battery protection during sleep uses a **900-tick maximum per session**,
-not recurring voltage measurements. At the measured 850 ms active duration,
-this is about 43, 58, or 73 minutes for 2, 3, or 4 s sleep intervals. It is a
+not recurring voltage measurements. With the estimated 1050 ms active duration,
+this is about 46, 61, or 76 minutes for 2, 3, or 4 s sleep intervals. It is a
 tick bound, not a precise wall-clock deadline; slow startup and ADC timeouts
 extend elapsed time. After the limit, WoW is disabled for that sleep session
 and the device stays in ordinary deep sleep until a physical/charging wake.
@@ -134,9 +140,9 @@ window** and 0.1 mA asleep, `Iavg = duty * 6 + (1 - duty) * 0.1`:
 
 | Sleep interval | Estimated average while WoW cycles |
 | --- | --- |
-| 2 s | 1.86 mA |
-| 3 s | 1.40 mA |
-| 4 s | 1.13 mA |
+| 2 s | 2.13 mA |
+| 3 s | 1.63 mA |
+| 4 s | 1.33 mA |
 
 The startup part runs at the boot clock, not 20 MHz. PM-enabled builds also
 use their configured frequency policy during polling. The 6 mA assumption is

--- a/include/menu.h
+++ b/include/menu.h
@@ -548,7 +548,16 @@ void updateWakeOnWeightLabel() {
 }
 
 void cycleWakeOnWeight() {
-  const int next = (i_wow_interval + 1) % WOW_INTERVAL_COUNT;
+  const bool calibrated = f_calibration_value != CALIBRATION_VALUE_DEFAULT &&
+                          isValidCalibrationValue(f_calibration_value);
+  if (!calibrated && i_wow_interval == 0) {
+    actionMessage = "WakeOnWeight";
+    actionMessage2 = "Please calibrate";
+    menuActionMessageChanged();
+    t_actionMessageDelay = 2000;
+    return;
+  }
+  const int next = calibrated ? (i_wow_interval + 1) % WOW_INTERVAL_COUNT : 0;
   const bool stored = storagePutInt(KEY_WOW_INTERVAL, next);
   if (stored) i_wow_interval = next;
   updateWakeOnWeightLabel();

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -394,6 +394,11 @@ struct WowRtcState {
 RTC_DATA_ATTR WowRtcState wowRtc;
 bool wowTimerArmedThisBoot = false;
 bool wowButtonWake = false;
+struct WowWakeDiagnostics {
+  uint8_t samplesRead = 0;
+  int32_t raw[3] = {};
+};
+WowWakeDiagnostics wowWakeDiagnostics;
 #endif
 unsigned int i_buttonBootDelay = 500;
 bool b_showChargingUI = false;

--- a/include/power.h
+++ b/include/power.h
@@ -97,6 +97,7 @@ void ADS_init() {
 
 int i_wakeupPin;
 void configureWakePinForDeepSleep(gpio_num_t pin) {
+  rtc_gpio_hold_dis(pin);
   rtc_gpio_init(pin);
   rtc_gpio_set_direction(pin, RTC_GPIO_MODE_INPUT_ONLY);
   rtc_gpio_pullup_en(pin);
@@ -248,6 +249,11 @@ void esp32_sleep() {
   digitalWrite(PWR_CTRL, LOW);
   gpio_hold_en((gpio_num_t)PWR_CTRL);
   gpio_deep_sleep_hold_en();
+  Serial.printf("[sleep] wow=%d circle=%d square=%d charge=%d\n", i_wow_interval,
+                rtc_gpio_get_level((gpio_num_t)BUTTON_CIRCLE),
+                rtc_gpio_get_level((gpio_num_t)BUTTON_SQUARE),
+                rtc_gpio_get_level((gpio_num_t)BATTERY_CHARGING));
+  Serial.flush();
   esp_deep_sleep_start();
 }
 #endif  //ESP32

--- a/include/usbcomm.h
+++ b/include/usbcomm.h
@@ -509,6 +509,27 @@ public:
                     b_tapTraceEnabled, b_tapTareEnabled, b_tapTimerEnabled);
     }
 
+#ifdef ESP32
+    if (inputString == "wakeinfo") {
+      Serial.printf("[wake] reset=%u cause=%u ext1=%llu wow=%d charge=%d circle=%d square=%d",
+                    (unsigned)esp_reset_reason(), (unsigned)esp_sleep_get_wakeup_cause(),
+                    (unsigned long long)esp_sleep_get_ext1_wakeup_status(), i_wow_interval,
+                    digitalRead(BATTERY_CHARGING), digitalRead(BUTTON_CIRCLE), digitalRead(BUTTON_SQUARE));
+#ifdef USB_DET
+      Serial.printf(" usb=%d", digitalRead(USB_DET));
+#endif
+      Serial.println();
+#ifdef ADS1232ADC
+      Serial.printf("[wow] source=%d armed=%u baseline=%ld threshold=%ld count=%u raw=%ld,%ld,%ld\n",
+                    GPIO_power_on_with, (unsigned)wowRtc.armed,
+                    (long)wowRtc.baselineRaw, (long)wowRtc.thresholdRaw,
+                    (unsigned)wowWakeDiagnostics.samplesRead,
+                    (long)wowWakeDiagnostics.raw[0], (long)wowWakeDiagnostics.raw[1],
+                    (long)wowWakeDiagnostics.raw[2]);
+#endif
+    }
+#endif
+
     if (inputString.startsWith("adsd ")) {
       String cmd = inputString.substring(5);
       cmd.trim();

--- a/include/wake_on_weight.h
+++ b/include/wake_on_weight.h
@@ -72,15 +72,31 @@ static bool wowWaitForRail() {
   return !wowPhysicalWakeRequested();
 }
 
-static bool wowReadOneSample(ADS1232_ADC &adc, int32_t &rawSample, bool &outOfRange) {
+static bool wowReadWakeSamples(ADS1232_ADC &adc, int32_t &rawSample, bool &outOfRange) {
   const unsigned long startedAt = millis();
+  uint8_t samplesRead = 0;
+  int32_t previousSample = 0;
   while (millis() - startedAt < WOW_READ_TIMEOUT_MS) {
     if (wowPhysicalWakeRequested()) return false;
     if (digitalRead(SCALE_DOUT) == LOW) {
       if (adc.update()) {
-        rawSample = adc.getDebugInfo().rawValue;
-        outOfRange = adc.getDebugInfo().dataOutOfRange;
-        return true;
+        const auto info = adc.getDebugInfo();
+        wowWakeDiagnostics.raw[samplesRead] = info.rawValue;
+        samplesRead++;
+        wowWakeDiagnostics.samplesRead = samplesRead;
+        if (samplesRead > 1) {
+          outOfRange = info.validSamples <= 0 || info.dataOutOfRange || info.signalTimeout;
+          if (outOfRange) return false;
+          if (samplesRead == 3) {
+            const int64_t previousDelta = (int64_t)previousSample - wowRtc.baselineRaw;
+            const int64_t currentDelta = (int64_t)info.rawValue - wowRtc.baselineRaw;
+            const bool increased = previousDelta > wowRtc.thresholdRaw && currentDelta > wowRtc.thresholdRaw;
+            const bool decreased = previousDelta < -(int64_t)wowRtc.thresholdRaw && currentDelta < -(int64_t)wowRtc.thresholdRaw;
+            rawSample = increased || decreased ? info.rawValue : wowRtc.baselineRaw;
+            return true;
+          }
+          previousSample = info.rawValue;
+        }
       }
     }
     delay(2);
@@ -111,6 +127,7 @@ static void wowSetCpuFrequencyMhz(unsigned long frequencyMhz) {
 void wowMicroWakeOrContinue() {
   if (esp_sleep_get_wakeup_cause() != ESP_SLEEP_WAKEUP_TIMER) return;
   if (wowRtc.magic != WOW_RTC_MAGIC || !wowRtc.armed) return;
+  configureWakePinsForDeepSleep();
   if (wowPhysicalWakeRequested()) {
     wowRtc.armed = 0;
     return;
@@ -136,7 +153,7 @@ void wowMicroWakeOrContinue() {
   bool outOfRange = false;
   int32_t rawSample = 0;
   const bool gotSample =
-      wowReadOneSample(wowAdc, rawSample, outOfRange);
+      wowReadWakeSamples(wowAdc, rawSample, outOfRange);
   wowAdc.powerDown();
   wowAdc.end();
 

--- a/tools/test_usb_text_actions_contract.py
+++ b/tools/test_usb_text_actions_contract.py
@@ -39,6 +39,14 @@ def main():
     if "usbCallbacks.toggleTimer = scaleTimer;" not in hds:
         raise AssertionError("USB timer callback is not wired")
 
+    wake = block_after(usb, 'if (inputString == "wakeinfo")')
+    for value in ("esp_reset_reason()", "esp_sleep_get_wakeup_cause()",
+                  "esp_sleep_get_ext1_wakeup_status()", "i_wow_interval",
+                  "digitalRead(BATTERY_CHARGING)", "digitalRead(USB_DET)"):
+        assert value in wake
+    for mutation in ("reset();", "digitalWrite(", "pinMode(", "storagePut"):
+        assert mutation not in wake
+
     print("USB text action contract tests passed")
 
 

--- a/tools/test_wake_on_weight_contract.py
+++ b/tools/test_wake_on_weight_contract.py
@@ -174,15 +174,19 @@ class WakeOnWeightContractTests(unittest.TestCase):
     def test_docs_state_machine(self):
         self.assertIn("10 SPS", DOCS)
         self.assertIn("50 g", DOCS)
+        self.assertIn("WOW_TRIGGER_GRAMS = 50.0f", WOW)
         self.assertIn("2 s", DOCS)
         self.assertIn("3 s", DOCS)
         self.assertIn("4 s", DOCS)
         self.assertIn("defaults to off", DOCS)
 
     def test_button_polling_and_latched_boot(self):
-        for signature in ("static bool wowWaitForRail()", "static bool wowReadOneSample("):
+        configure = body(POWER, "void configureWakePinForDeepSleep(")
+        self.assertLess(configure.index("rtc_gpio_hold_dis(pin)"), configure.index("rtc_gpio_init(pin)"))
+        for signature in ("static bool wowWaitForRail()", "static bool wowReadWakeSamples("):
             self.assertIn("wowPhysicalWakeRequested()", body(WOW_ADS, signature))
         micro = body(WOW_ADS, "void wowMicroWakeOrContinue()")
+        self.assertLess(micro.index("configureWakePinsForDeepSleep()"), micro.index("wowPhysicalWakeRequested()"))
         self.assertGreaterEqual(micro.count("wowPhysicalWakeRequested()"), 3)
         self.assertIn("rtc_gpio_get_level", WOW)
         self.assertIn("if (wowButtonWake) break;", body(FIRMWARE, "void setup()"))

--- a/tools/test_wake_on_weight_runtime.py
+++ b/tools/test_wake_on_weight_runtime.py
@@ -15,6 +15,8 @@ HARNESS = r"""
 #include <cstdint>
 #include <climits>
 #include <cstdio>
+#include <string>
+#include <vector>
 #include "calibration_validation.h"
 using std::max;
 using std::isfinite;
@@ -34,10 +36,15 @@ unsigned long pressDuration = 500;
 int pressPin = BUTTON_CIRCLE, wakeCause = ESP_SLEEP_WAKEUP_TIMER;
 int liveAdcs = 0, endedAdcs = 0, begunAdcs = 0;
 bool badSample = false, sampleAvailable = true, ext1 = false, pressOnRearm = false;
+bool rtcInputsReady = false;
 uint64_t timerUs = 0;
 bool holds[64] = {};
 int levels[64] = {};
 int32_t sampleRaw = 1000;
+std::vector<int32_t> sampleSequence;
+unsigned int samplesRead = 0;
+unsigned int invalidSampleAt = 0;
+int32_t lastSampleRaw = 1000;
 struct DebugInfo {
   int validSamples = 1;
   int32_t smoothedValue = 1000;
@@ -58,6 +65,7 @@ bool setCpuFrequencyMhz(unsigned long mhz) {
 }
 int esp_sleep_get_wakeup_cause() { return wakeCause; }
 int rtc_gpio_get_level(int pin) {
+  if (!rtcInputsReady) return LOW;
   return pin == pressPin && nowMs >= pressAt && nowMs - pressAt < pressDuration ? LOW : HIGH;
 }
 int digitalRead(int pin) { assert(pin == SCALE_DOUT); return sampleAvailable && nowMs >= readyAt ? LOW : HIGH; }
@@ -67,7 +75,7 @@ void gpio_hold_en(int pin) { holds[pin] = true; }
 void gpio_hold_dis(int pin) { holds[pin] = false; }
 void gpio_deep_sleep_hold_en() {}
 void gpio_deep_sleep_hold_dis() {}
-void configureWakePinsForDeepSleep() {}
+void configureWakePinsForDeepSleep() { rtcInputsReady = true; }
 void esp_sleep_enable_ext1_wakeup_io(uint64_t mask, int) {
   assert(mask == PIN_BITMASK);
   ext1 = true;
@@ -81,20 +89,42 @@ struct ADS1232_ADC {
   bool poweredDown = false;
   ADS1232_ADC(int, int, int, int) { liveAdcs++; }
   void begin() { begunAdcs++; }
-  bool update() { return true; }
-  DebugInfo getDebugInfo() { return {1, 1000, sampleRaw, badSample}; }
+  bool update() {
+    lastSampleRaw = samplesRead < sampleSequence.size() ? sampleSequence[samplesRead] : sampleRaw;
+    samplesRead++;
+    readyAt = nowMs + 100;
+    return true;
+  }
+  DebugInfo getDebugInfo() { return {1, 1000, lastSampleRaw, badSample || samplesRead == invalidSampleAt}; }
   void powerDown() { poweredDown = true; }
   void end() { assert(poweredDown); liveAdcs--; endedAdcs++; }
 };
 """
 
 CHECKS = r"""
+char menuWakeOnWeightLabel[24];
+std::string actionMessage, actionMessage2;
+int t_actionMessageDelay = 0, menuNotifications = 0, settingsWrites = 0;
+int storedInterval = -1;
+const int KEY_WOW_INTERVAL = 1;
+bool storageWorks = true;
+bool storagePutInt(int, int value) {
+  settingsWrites++;
+  if (storageWorks) storedInterval = value;
+  return storageWorks;
+}
+void menuActionMessageChanged() { menuNotifications++; }
+MENU_FUNCTIONS
+
 void resetBoot() {
   nowMs = 0; cpuMhz = 240; timerUs = 0; ext1 = false;
+  rtcInputsReady = false;
   GPIO_power_on_with = -1; wowButtonWake = false; wowTimerArmedThisBoot = false;
   liveAdcs = 0; endedAdcs = 0; begunAdcs = 0;
   pressAt = ULONG_MAX; pressOnRearm = false; pressPin = BUTTON_CIRCLE;
   readyAt = 500; sampleAvailable = true; badSample = false; sampleRaw = 1000;
+  samplesRead = 0; invalidSampleAt = 0; sampleSequence.clear();
+  wowWakeDiagnostics = {};
   wakeCause = ESP_SLEEP_WAKEUP_TIMER;
   for (int pin = 0; pin < 64; pin++) { holds[pin] = true; levels[pin] = LOW; }
 }
@@ -125,7 +155,7 @@ int main() {
   }
   for (bool missing : {false, true}) {
     for (int pin : {BUTTON_CIRCLE, BUTTON_SQUARE, BATTERY_CHARGING}) {
-      for (unsigned long start = 0; start <= (missing ? 998UL : 500UL); start += 2) {
+      for (unsigned long start = 0; start <= (missing ? 998UL : 700UL); start += 2) {
         resetBoot(); arm(); pressAt = start; pressPin = pin; sampleAvailable = !missing;
         assert(tick());
         assert(GPIO_power_on_with == pin && !wowRtc.armed);
@@ -149,6 +179,43 @@ int main() {
     resetBoot(); arm(); sampleRaw = raw;
     assert(!tick() && wowRtc.armed && timerUs == 2000000);
   }
+  for (const auto &sequence : std::vector<std::vector<int32_t>>{
+      {100000, 1000, 1000}, {1000, 100000, 1000}, {1000, 1000, 100000},
+      {1000, 2000, 0}, {1000, 0, 2000}}) {
+    resetBoot(); arm(); sampleSequence = sequence;
+    assert(!tick() && wowRtc.armed && samplesRead == 3);
+    assert(wowWakeDiagnostics.samplesRead == 3);
+    for (unsigned int index = 0; index < 3; index++) {
+      assert(wowWakeDiagnostics.raw[index] == sequence[index]);
+    }
+    assert(wowRtc.baselineRaw == 1000);
+  }
+  for (const auto &sequence : std::vector<std::vector<int32_t>>{
+      {100000, 1600, 1700}, {-100000, 400, 300}}) {
+    resetBoot(); arm(); sampleSequence = sequence;
+    assert(tick() && !wowRtc.armed && samplesRead == 3);
+  }
+  resetBoot(); arm(); readyAt = 950;
+  assert(!tick() && wowRtc.armed && samplesRead == 1 && nowMs == 1000);
+  for (unsigned int invalidAt : {2U, 3U}) {
+    resetBoot(); arm(); sampleRaw = 2000; invalidSampleAt = invalidAt;
+    assert(!tick() && wowRtc.armed && wowRtc.consecutiveFailures == 1);
+  }
+  resetBoot(); arm(); invalidSampleAt = 1;
+  assert(!tick() && wowRtc.armed && wowRtc.consecutiveFailures == 0);
+  for (float factor : {100.0f, -100.0f}) {
+    f_calibration_value = factor;
+    for (int32_t change : {-5000, -4999, -1000, 0, 1000, 4999, 5000}) {
+      resetBoot(); arm(); sampleRaw = 1000 + change;
+      assert(wowRtc.thresholdRaw == 5000);
+      assert(!tick() && wowRtc.armed);
+    }
+    for (int32_t change : {-5001, 5001}) {
+      resetBoot(); arm(); sampleRaw = 1000 + change;
+      assert(tick() && !wowRtc.armed);
+    }
+  }
+  f_calibration_value = 10;
   for (bool missing : {false, true}) {
     resetBoot(); arm();
     for (int failure = 1; failure <= WOW_MAX_FAILURES; failure++) {
@@ -194,6 +261,29 @@ int main() {
   assert(tick() && begunAdcs == 0 && !wowButtonWake);
   resetBoot(); arm(); wowRtc.magic = 0;
   assert(tick() && begunAdcs == 0);
+  for (float calibration : {CALIBRATION_VALUE_DEFAULT, 0.0f, NAN, INFINITY, 1e30f}) {
+    f_calibration_value = calibration;
+    i_wow_interval = 0;
+    settingsWrites = 0;
+    const int before = menuNotifications;
+    cycleWakeOnWeight();
+    assert(i_wow_interval == 0 && settingsWrites == 0);
+    assert(actionMessage2 == "Please calibrate" && menuNotifications == before + 1);
+    assert(t_actionMessageDelay == 2000);
+    for (int interval : {1, 2, 3}) {
+      i_wow_interval = interval;
+      cycleWakeOnWeight();
+      assert(i_wow_interval == 0 && storedInterval == 0 && actionMessage2 == "Off");
+    }
+  }
+  f_calibration_value = 10;
+  for (int expected : {1, 2, 3, 0}) {
+    cycleWakeOnWeight();
+    assert(i_wow_interval == expected && storedInterval == expected);
+  }
+  storageWorks = false;
+  cycleWakeOnWeight();
+  assert(i_wow_interval == 0 && actionMessage == "Save Failed");
   std::puts("WoW runtime checks passed: button sweep, charging, cleanup, failures, recovery, cap, gates");
 }
 """
@@ -207,7 +297,10 @@ def main():
     state = parameter[parameter.index("struct WowRtcState {"):]
     state = state[:state.index("#endif")]
     wow = (ROOT / "include/wake_on_weight.h").read_text(encoding="utf-8")
-    source = HARNESS + state + re.sub(r"^#include[^\n]*", "", wow, flags=re.MULTILINE) + CHECKS
+    menu = (ROOT / "include/menu.h").read_text(encoding="utf-8")
+    menuFunctions = menu[menu.index("void updateWakeOnWeightLabel() {"):]
+    menuFunctions = menuFunctions[:menuFunctions.index("#endif")]
+    source = HARNESS + state + re.sub(r"^#include[^\n]*", "", wow, flags=re.MULTILINE) + CHECKS.replace("MENU_FUNCTIONS", menuFunctions)
     with tempfile.TemporaryDirectory(prefix="wow-test-") as directory:
         cpp = Path(directory) / "wow.cpp"
         binary = Path(directory) / "wow-test.exe"


### PR DESCRIPTION
## Summary
- Release RTC holds and restore input mode and pull-ups before the first timer-wake button check. Hardware diagnostics showed a timer wake accepting Square before reading any ADC sample.
- Keep the 50 g threshold; discard the startup conversion and require two valid conversions beyond the threshold in the same direction within the existing shared timeout.
- Show Please calibrate rather than enabling WoW without calibration; disabling remains possible.
- Retain read-only wakeinfo diagnostics and shutdown pin logging used during hardware investigation.
- Update timing estimates and regression checks.

## Verification
- WoW compiled runtime harness passed with and without CONFIG_PM_ENABLE, including unconfigured RTC inputs, transient samples, threshold boundaries, input priority, timeout and calibration-menu cases.
- 23 WoW contract tests, USB text action tests and documentation contracts passed.
- ESP32-S3 firmware built, flashed on COM5 and write-verified.
- User confirmed the corrected behavior on the physical scale after the RTC-input fix.
- No hardware validation on other board revisions or new current-consumption measurement.