### PR TITLE
Keep Wake on Weight active without automatic session cutoffs

### DIFF
--- a/docs/wake-on-weight.md
+++ b/docs/wake-on-weight.md
@@ -69,33 +69,29 @@ Arming requires a valid interval, calibration, and an existing live sample.
 An observed low-battery count or a known voltage below 3.2 V prevents arming.
 Non-finite or overflowing calibration thresholds also prevent arming.
 
-Battery protection during sleep uses a **900-tick maximum per session**,
-not recurring voltage measurements. With the estimated 1050 ms active duration,
-this is about 46, 61, or 76 minutes for 2, 3, or 4 s sleep intervals. It is a
-tick bound, not a precise wall-clock deadline; slow startup and ADC timeouts
-extend elapsed time. After the limit, WoW is disabled for that sleep session
-and the device stays in ordinary deep sleep until a physical/charging wake.
-A later qualifying shutdown starts a new session. The saved menu setting
-does not change. This deliberately does not provide all-night WoW standby.
+Wake-on-Weight has **no fixed session time limit**. Selecting a sleep interval
+enables ongoing weight checks until a wake event or loss of battery power.
+There are no recurring battery voltage measurements.
+The low-voltage arming check does not enforce a 3.2 V cutoff during standby.
+This user-selected mode can exhaust the battery; runtime depends on measured
+whole-cycle consumption and battery capacity, not a guaranteed number of weeks.
 
-Five consecutive ADC timeouts or unusable conversions also disable WoW for
-the current session. One reliable conversion resets the failure count.
-Both fallback paths preserve EXT1 and leave the timer unarmed in the fresh
-deep-sleep boot. They do not run the normal shutdown path or recapture a
-baseline. A button/charging request takes priority over fallback.
+ADC timeouts and unusable conversions are ignored, never treated as weight
+changes. The next timer wake retries without a failure-count cutoff and without
+recapturing the baseline. Each attempt retains its bounded read timeout and
+returns to deep sleep between attempts. Button and charging wakes remain active.
 
 No micro-wake initializes I2C, ADS1115, OLED, radio, storage, or battery ADC.
 No NVS reads or writes occur. V8.1's `BATTERY_PIN` is only a placeholder;
-using `analogRead(BATTERY_PIN)` would not measure its battery. The session
-cap bounds extra WoW consumption but is not a voltage cutoff or a substitute
-for cell protection. A cell already near empty can still discharge below
-the normal cutoff during that bounded session.
+using `analogRead(BATTERY_PIN)` would not measure its battery. Standby is not
+a substitute for hardware cell protection, and can discharge below the normal
+software cutoff.
 
 ## Resources and GPIOs
 
 RTC state is an explicit 20-byte structure in `include/parameter.h`: magic,
-armed flag, consecutive failure count, tick count, baseline, threshold, and
-sleep interval. Arming resets both counters; the layout has a new magic.
+armed flag, baseline, threshold, and sleep interval (including alignment padding).
+The layout has a new magic.
 Transient setup flags are not retained. No cross-task state is introduced.
 
 The micro-wake releases only primary `SCLK`, `PDWN`, `DOUT`, and `PWR_CTRL`
@@ -147,8 +143,8 @@ window** and 0.1 mA asleep, `Iavg = duty * 6 + (1 - duty) * 0.1`:
 The startup part runs at the boot clock, not 20 MHz. PM-enabled builds also
 use their configured frequency policy during polling. The 6 mA assumption is
 not a measured whole-cycle current and may underestimate consumption.
-Continuous multi-day standby projections are inappropriate because of the
-900-tick cap. After fallback only ordinary deep-sleep consumption remains.
+Standby duration needs hardware measurement; there is no fixed session cap.
+An unavailable ADC causes ongoing retries and can increase standby consumption.
 Measure complete cycles with an ammeter, including startup and failed reads.
 
 ## Verification
@@ -157,5 +153,5 @@ Run `python tools/test_wake_on_weight_contract.py` and
 `python tools/test_wake_on_weight_runtime.py`, then build `esp32s3` and
 `esp32s3-energy-menu`. Hardware follow-up should sweep normal button presses
 across startup, rail settling, ADC wait, and sleep handoff; check both buttons,
-charging insertion, ADC disconnect/recovery, session expiry, boot tare,
+charging insertion, ADC disconnect/recovery, extended standby, boot tare,
 resource cleanup, and whole-cycle current. WoW-off sleep must remain unchanged.

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -385,8 +385,6 @@ int i_wow_interval = 0;
 struct WowRtcState {
   uint32_t magic;
   uint8_t armed;
-  uint8_t consecutiveFailures;
-  uint16_t tickCount;
   int32_t baselineRaw;
   int32_t thresholdRaw;
   uint32_t intervalUs;

--- a/include/wake_on_weight.h
+++ b/include/wake_on_weight.h
@@ -18,9 +18,7 @@ const float WOW_TRIGGER_GRAMS = 50.0f;
 const unsigned long WOW_READ_TIMEOUT_MS = 900;
 const unsigned long WOW_RAIL_SETTLE_MS = 100;
 const int32_t WOW_MIN_THRESHOLD_RAW = 500;
-const uint32_t WOW_RTC_MAGIC = 0x574F5732;
-const uint16_t WOW_MAX_TICKS = 900;
-const uint8_t WOW_MAX_FAILURES = 5;
+const uint32_t WOW_RTC_MAGIC = 0x574F5733;
 const uint8_t WOW_INTERVAL_COUNT = 4;
 const uint64_t wowIntervalUs[WOW_INTERVAL_COUNT] = { 0, 2000000, 3000000, 4000000 };
 
@@ -35,8 +33,6 @@ void wowCaptureBaselineForSleep() {
   if (info.validSamples <= 0 || info.dataOutOfRange || info.signalTimeout) return;
   wowRtc.magic = WOW_RTC_MAGIC;
   wowRtc.armed = 1;
-  wowRtc.tickCount = 0;
-  wowRtc.consecutiveFailures = 0;
   wowRtc.baselineRaw = info.smoothedValue;
   wowRtc.thresholdRaw = max((int32_t)(threshold + 0.5f), WOW_MIN_THRESHOLD_RAW);
   wowRtc.intervalUs = wowIntervalUs[i_wow_interval];
@@ -164,7 +160,6 @@ void wowMicroWakeOrContinue() {
   }
 
   if (gotSample && !outOfRange) {
-    wowRtc.consecutiveFailures = 0;
     const int64_t delta = rawSample > wowRtc.baselineRaw
                               ? (int64_t)rawSample - wowRtc.baselineRaw
                               : (int64_t)wowRtc.baselineRaw - rawSample;
@@ -173,13 +168,6 @@ void wowMicroWakeOrContinue() {
       wowSetCpuFrequencyMhz(bootFreqMhz);
       return;
     }
-  } else {
-    wowRtc.consecutiveFailures++;
-  }
-
-  wowRtc.tickCount++;
-  if (wowRtc.consecutiveFailures >= WOW_MAX_FAILURES || wowRtc.tickCount >= WOW_MAX_TICKS) {
-    wowRtc.armed = 0;
   }
 
   configureWakePinsForDeepSleep();

--- a/tools/test_wake_on_weight_contract.py
+++ b/tools/test_wake_on_weight_contract.py
@@ -197,14 +197,17 @@ class WakeOnWeightContractTests(unittest.TestCase):
         self.assertLess(micro.index("wowAdc.powerDown()"), micro.index("wowAdc.end()"))
         self.assertLess(micro.index("wowAdc.end()"), micro.index("if (gotSample"))
 
-    def test_session_fallbacks_and_sleep_interval(self):
-        self.assertIn("WOW_MAX_TICKS = 900", WOW)
-        self.assertIn("WOW_MAX_FAILURES = 5", WOW)
-        self.assertIn("wowRtc.consecutiveFailures = 0", WOW)
+    def test_unlimited_retries_and_sleep_interval(self):
+        self.assertNotIn("WOW_MAX_TICKS", WOW)
+        self.assertNotIn("tickCount", WOW)
+        self.assertNotIn("tickCount", PARAMETER)
+        self.assertNotIn("WOW_MAX_FAILURES", WOW)
+        self.assertNotIn("consecutiveFailures", WOW)
+        self.assertNotIn("consecutiveFailures", PARAMETER)
         self.assertIn("if (wowRtc.armed) esp_sleep_enable_timer_wakeup", WOW)
         self.assertIn('"Sleep 2s", "Sleep 3s", "Sleep 4s"', MENU)
         self.assertIn("sleep intervals", DOCS)
-        self.assertIn("900-tick", DOCS)
+        self.assertIn("no fixed session time limit", DOCS)
 
 
 if __name__ == "__main__":

--- a/tools/test_wake_on_weight_runtime.py
+++ b/tools/test_wake_on_weight_runtime.py
@@ -166,10 +166,7 @@ int main() {
   }
   resetBoot(); arm(); pressOnRearm = true;
   assert(tick() && wowButtonWake && !wowRtc.armed);
-  resetBoot(); arm(); pressOnRearm = true; wowRtc.tickCount = WOW_MAX_TICKS - 1;
-  assert(tick() && wowButtonWake && timerUs == 0);
   resetBoot(); arm(); pressOnRearm = true; badSample = true;
-  wowRtc.consecutiveFailures = WOW_MAX_FAILURES - 1;
   assert(tick() && wowButtonWake && timerUs == 0);
   for (int32_t raw : {499, 1501, INT32_MIN, INT32_MAX}) {
     resetBoot(); arm(); sampleRaw = raw;
@@ -199,10 +196,10 @@ int main() {
   assert(!tick() && wowRtc.armed && samplesRead == 1 && nowMs == 1000);
   for (unsigned int invalidAt : {2U, 3U}) {
     resetBoot(); arm(); sampleRaw = 2000; invalidSampleAt = invalidAt;
-    assert(!tick() && wowRtc.armed && wowRtc.consecutiveFailures == 1);
+    assert(!tick() && wowRtc.armed && timerUs == 2000000);
   }
   resetBoot(); arm(); invalidSampleAt = 1;
-  assert(!tick() && wowRtc.armed && wowRtc.consecutiveFailures == 0);
+  assert(!tick() && wowRtc.armed && timerUs == 2000000);
   for (float factor : {100.0f, -100.0f}) {
     f_calibration_value = factor;
     for (int32_t change : {-5000, -4999, -1000, 0, 1000, 4999, 5000}) {
@@ -218,26 +215,24 @@ int main() {
   f_calibration_value = 10;
   for (bool missing : {false, true}) {
     resetBoot(); arm();
-    for (int failure = 1; failure <= WOW_MAX_FAILURES; failure++) {
+    for (int failure = 1; failure <= 1000; failure++) {
       resetBoot(); sampleAvailable = !missing; badSample = !missing;
       assert(!tick());
-      assert(wowRtc.consecutiveFailures == failure);
-      assert(bool(wowRtc.armed) == (failure < WOW_MAX_FAILURES));
-      assert((timerUs != 0) == bool(wowRtc.armed));
+      assert(wowRtc.armed && timerUs == 2000000);
+      assert(wowRtc.baselineRaw == 1000);
     }
+    resetBoot(); sampleRaw = 1501;
+    assert(tick() && !wowRtc.armed);
   }
-  resetBoot(); arm();
-  for (int i = 0; i < 4; i++) { resetBoot(); badSample = true; assert(!tick()); }
-  resetBoot(); assert(!tick() && wowRtc.consecutiveFailures == 0);
-  resetBoot(); badSample = true; assert(!tick() && wowRtc.consecutiveFailures == 1);
   for (int interval = 1; interval <= 3; interval++) {
     resetBoot(); i_wow_interval = interval; arm();
-    for (int count = 1; count <= WOW_MAX_TICKS; count++) {
+    for (int count = 1; count <= 70000; count++) {
       resetBoot(); assert(!tick());
-      assert(wowRtc.tickCount == count);
-      assert(bool(wowRtc.armed) == (count < WOW_MAX_TICKS));
-      assert(timerUs == (wowRtc.armed ? wowIntervalUs[interval] : 0));
+      assert(wowRtc.armed);
+      assert(timerUs == wowIntervalUs[interval]);
     }
+    resetBoot(); sampleRaw = 1501;
+    assert(tick() && !wowRtc.armed);
   }
   for (int interval : {-1, 0, 4, 100}) {
     resetBoot(); i_wow_interval = interval; wowCaptureBaselineForSleep();
@@ -284,7 +279,7 @@ int main() {
   storageWorks = false;
   cycleWakeOnWeight();
   assert(i_wow_interval == 0 && actionMessage == "Save Failed");
-  std::puts("WoW runtime checks passed: button sweep, charging, cleanup, failures, recovery, cap, gates");
+  std::puts("WoW runtime checks passed: button sweep, charging, cleanup, failures, recovery, unlimited standby, gates");
 }
 """
 


### PR DESCRIPTION
## Summary
- Remove the 900-check session limit and five-consecutive-failures cutoff.
- Ignore invalid ADC readings and retry at the selected sleep interval without recapturing the baseline.
- Preserve bounded per-attempt sampling, the 50 g threshold, physical/charging wake behavior, and existing calibration and low-battery arming guards.
- Add no recurring battery checks or I2C work. This is user-selected ongoing standby and can exhaust the battery; the arming voltage guard is not a standby voltage cutoff.
- Remove unused RTC counters and update documentation.

## Verification
Passed on current main: test_wake_on_weight_runtime.py (with and without CONFIG_PM_ENABLE), test_wake_on_weight_contract.py, test_ai_docs_contract.py, and git diff --check.
Runtime coverage includes 70,000 checks per interval and wake after 1,000 consecutive invalid or missing readings.
No full firmware build or hardware flash performed locally for this change.

Separate from release-workflow PR #198.