### PR TITLE
Separate release preparation from verified publication

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -1,6 +1,11 @@
 name: Custom firmware build
 
 on:
+  workflow_call:
+    inputs:
+      commit:
+        type: string
+        required: true
   pull_request:
     paths:
       - ".github/workflows/custom-build.yml"
@@ -160,13 +165,14 @@ jobs:
           --verify-plugin-environment "esp32s3-$PLUGIN_ID"
 
   compile_custom:
-    if: github.event_name == 'pull_request'
-    name: custom firmware (3.1.14 minimal)
+    if: github.event_name != 'workflow_dispatch' || inputs.commit != ''
+    name: custom firmware (candidate minimal)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.commit || github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Create prospective release tag
@@ -193,7 +199,7 @@ jobs:
           path = Path(".pio.nosync/pr-ci.json")
           path.parent.mkdir(parents=True, exist_ok=True)
           path.write_text(json.dumps({
-              "firmware_ref": "v3.1.14",
+              "firmware_ref": "main",
               "features": [],
               "plugins": [],
           }) + "\n", encoding="utf-8")
@@ -209,13 +215,16 @@ jobs:
             echo 'CUSTOM_OTA_KEY'
           } >> "$GITHUB_ENV"
       - name: Build minimal custom firmware and filesystem
+        env:
+          CANDIDATE_COMMIT: ${{ inputs.commit || github.sha }}
         run: >-
           python tools/build_custom_firmware.py
           --config .pio.nosync/pr-ci.json
-          --source-commit "$(git rev-parse --verify --end-of-options 'refs/tags/v3.1.14^{commit}')"
+          --source-commit "$CANDIDATE_COMMIT"
+          --builder-commit "$CANDIDATE_COMMIT"
 
   build:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.commit == ''
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,11 @@
 name: Build firmware
 
 on:
+  workflow_call:
+    inputs:
+      commit:
+        type: string
+        required: true
   push:
     branches:
       - main
@@ -16,7 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.commit || github.sha }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Create prospective release tag
         run: |
           if ! git show-ref --verify --quiet refs/tags/v3.1.14; then
@@ -25,10 +32,15 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
       - run: |
+          set -euo pipefail
           for test in tools/test_*.py; do
             python "$test"
           done
+          node --test cloudflare/custom-build-worker/test/*.test.mjs
 
   native-tests:
     name: Native unit tests
@@ -37,6 +49,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit || github.sha }}
+          persist-credentials: false
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
@@ -51,6 +66,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit || github.sha }}
+          persist-credentials: false
 
       - uses: actions/cache@v6
         with:
@@ -115,6 +133,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit || github.sha }}
+          persist-credentials: false
 
       - uses: actions/cache@v6
         with:
@@ -131,3 +152,20 @@ jobs:
 
       - name: Build Energy Menu firmware
         run: pio run -e esp32s3-energy-menu
+
+  release-ready:
+    if: always()
+    needs: [ai-documentation, native-tests, build, energy-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          results = json.loads(os.environ["RESULTS"])
+          assert all(job["result"] == "success" for job in results.values()), results
+          PY

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,49 @@
+name: Publish firmware
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Verified draft release tag"
+        required: true
+      expected_commit:
+        description: "Full candidate SHA approved after hardware testing"
+        required: true
+      evidence_sha256:
+        description: "Evidence SHA-256 from the successful preparation summary"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: firmware-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: firmware-release
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - name: Verify approved bytes and publish without rebuilding
+        env:
+          TAG: ${{ inputs.tag }}
+          COMMIT: ${{ inputs.expected_commit }}
+          EVIDENCE_SHA256: ${{ inputs.evidence_sha256 }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          python tools/release_publication.py publish --tag "$TAG" --commit "$COMMIT" --evidence-sha256 "$EVIDENCE_SHA256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,7 @@ jobs:
             RELEASE_FLAGS=(--prerelease --latest=false)
           fi
           gh release create "$TAG" \
+            --verify-tag \
             --draft \
             "${RELEASE_FLAGS[@]}" \
             --title="$TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,24 +6,76 @@ on:
       tag:
         description: "Tag to release (must already exist on main)"
         required: true
+      expected_commit:
+        description: "Approved full candidate commit SHA"
+        required: true
+      previous_tag:
+        description: "Expected previous published stable tag; empty only for bootstrap"
+        default: v3.1.13
       bootstrap_catalog:
         description: "First release only: allow no previous stable catalog"
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
+concurrency:
+  group: firmware-release
+  cancel-in-progress: false
+
 jobs:
-  build-and-release:
+  resolve:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - env:
+          TAG: ${{ inputs.tag }}
+          COMMIT: ${{ inputs.expected_commit }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          python tools/release_publication.py candidate --tag "$TAG" --commit "$COMMIT"
+
+  preflight:
+    needs: resolve
+    uses: ./.github/workflows/nightly.yml
+    with:
+      commit: ${{ inputs.expected_commit }}
+
+  custom-preflight:
+    needs: resolve
+    uses: ./.github/workflows/custom-build.yml
+    with:
+      commit: ${{ inputs.expected_commit }}
+
+  build-and-release:
+    needs: [resolve, preflight, custom-preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: firmware-release
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ inputs.expected_commit }}
+          persist-credentials: false
 
       - name: Verify tag and checkout release commit
         env:
           TAG: ${{ github.event.inputs.tag }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
         run: |
           set -euo pipefail
           if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-(preview|rc)\.[0-9]+)?$ ]]; then
@@ -40,6 +92,7 @@ jobs:
             echo "Error: tag $TAG is not reachable from main"
             exit 1
           fi
+          test "$TAG_COMMIT" = "$EXPECTED_COMMIT"
           git checkout --detach "$TAG_COMMIT"
           if [[ "$TAG" == *-* ]] && ! grep -Fxq '#define HDS_OTA_RELEASE_RECOVERY_VERSION 1' include/pull_ota_version.h; then
             echo "Error: preview tag predates exact-version rollback lookup"
@@ -96,6 +149,7 @@ jobs:
       - name: Prepare release assets
         env:
           BOOTSTRAP_CATALOG: ${{ inputs.bootstrap_catalog }}
+          EXPECTED_PREVIOUS_TAG: ${{ inputs.previous_tag }}
           TAG: ${{ github.event.inputs.tag }}
           HDS_RELEASE_TAG: ${{ github.event.inputs.tag }}
           HDS_RELEASE_REPOSITORY: ${{ github.repository }}
@@ -130,6 +184,10 @@ jobs:
           done
           PREVIOUS_MANIFEST_ARGS=()
           PREVIOUS_TAG="$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""')"
+          if [ "$PREVIOUS_TAG" != "$EXPECTED_PREVIOUS_TAG" ]; then
+            echo "Error: previous stable release differs from the approved baseline"
+            exit 1
+          fi
           if [ -n "$PREVIOUS_TAG" ]; then
             mkdir -p previous-release
             for attempt in 1 2 3; do
@@ -167,7 +225,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          RELEASE_FLAGS=()
+          RELEASE_FLAGS=(--latest=false)
           if [[ "$TAG" == *-* ]]; then
             RELEASE_FLAGS=(--prerelease --latest=false)
           fi
@@ -184,4 +242,22 @@ jobs:
           gh release upload "$TAG" release-files/manifest.json
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir downloaded-release
           python tools/verify_release_assets.py --tag "$TAG" --download-dir downloaded-release
-          gh release edit "$TAG" --draft=false
+      - name: Sign release evidence
+        env:
+          TAG: ${{ inputs.tag }}
+          COMMIT: ${{ inputs.expected_commit }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          GH_TOKEN: ${{ github.token }}
+          HDS_OTA_SIGNING_KEY_PEM: ${{ secrets.HDS_OTA_SIGNING_KEY_PEM }}
+        run: |
+          set -euo pipefail
+          python tools/release_publication.py evidence --tag "$TAG" --commit "$COMMIT" --previous-tag "$PREVIOUS_TAG"
+      - name: Upload and verify evidence and draft bytes
+        env:
+          TAG: ${{ inputs.tag }}
+          COMMIT: ${{ inputs.expected_commit }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" downloaded-release/release-evidence.json downloaded-release/release-evidence.sig
+          python tools/release_publication.py verify-draft --tag "$TAG" --commit "$COMMIT"

--- a/docs/AI_BUILD_NOTES.md
+++ b/docs/AI_BUILD_NOTES.md
@@ -34,7 +34,7 @@ Do not add an environment merely because it exists. Changes limited to ADS1232 b
 - Firmware builds require OpenSSL through `OPENSSL`, `PATH`, or Git for Windows with `git.exe` on `PATH`; clean targets do not.
 - `plugins/default-web-apps/assets/` is the default LittleFS data directory.
 - `gzip_web_assets.py` generates deterministic `.gz` siblings before LittleFS image builds.
-- `git_rev_macro.py` injects `GIT_REV`; non-git source trees fall back to `nogit0`.
+- `git_rev_macro.py` requires a Git checkout and injects `GIT_REV`. Explicit `HDS_FIRMWARE_VERSION` overrides retain the release/custom identity; ordinary builds retain the version in `include/config.h`.
 - `CONFIG_ASYNC_TCP_RUNNING_CORE=1` pins AsyncTCP to core 1, and `CONFIG_ASYNC_TCP_STACK_SIZE=8192` gives the AsyncTCP task an 8 KiB stack.
 - `ELEGANTOTA_USE_ASYNC_WEBSERVER=1` is set; `ElegantOTA.loop()` runs in `loop()`.
 - `include/hds_features.h` keeps the normal `esp32s3` feature defaults. `esp32s3-custom` reads `custom-build.json` through `tools/configure_custom_build.py` and stages generated headers and filesystem data under `.pio.nosync`.

--- a/docs/AI_OTA_NOTES.md
+++ b/docs/AI_OTA_NOTES.md
@@ -118,6 +118,12 @@ Catalog manifests merge the previous latest stable signed manifest, dedupe by mo
 
 Release preparation requires the automatically selected previous stable catalog and its valid signature. Downloads get three attempts, five seconds apart, with partial files removed before each attempt. Retrieval or verification failure aborts the release. The explicit `bootstrap_catalog` workflow input permits an empty release history only; it never bypasses a failed download or signature check for an existing stable release.
 
+The selected previous tag must also match the operator's `previous_tag` input.
+Preparation verifies the previous catalog identity and preserved compatible history,
+then stops at a signed draft. A separate `publish-release.yml` dispatch verifies
+the approved evidence digest, successful preparation run, and unchanged assets
+before publication. Neither publication nor approval rebuilds firmware.
+
 When the installed release has aged out of the latest catalog, firmware fetches that release's own signed manifest using both supported tag forms. It accepts only the compatible top-level release entry with the exact installed version and required LittleFS metadata. Firmware rollback remains local in the other app slot; this fallback supplies the signed asset metadata needed to restore the single shared LittleFS partition.
 
 Recovery lookup preserves preview/RC suffixes and must not substitute stable assets with the same numeric version. A hosted custom build, including one based on `main`, instead uses its embedded combination hash and published `ota-manifest.json`/`ota-manifest.sig`. Firmware containing the forward-recovery path can update without published source recovery assets when the signed target manifest declares `forward_recovery: 1`. Older source firmware, including preview 3, still needs its supported recovery assets or USB; these changes cannot alter already-flashed firmware.

--- a/docs/AI_RELEASE_NOTES.md
+++ b/docs/AI_RELEASE_NOTES.md
@@ -19,10 +19,23 @@ repository secrets or variables without explicit user authorization.
 `main` is the releasable branch. Stable releases use a numeric `vX.Y.Z` or
 `X.Y.Z` tag on a known-good commit reachable from `main`.
 
-`.github/workflows/release.yml` is the source of truth for release mechanics.
-The workflow also accepts `vX.Y.Z-preview.N` and `vX.Y.Z-rc.N` tags, publishing
-them as prereleases without changing latest. All releases publish signed
-recovery assets; preview/RC entries stay out of the stable OTA catalog.
+`.github/workflows/release.yml` prepares a verified signed draft. It requires
+the approved full candidate SHA and expected previous stable tag, and reuses
+`nightly.yml` and the minimal custom build from `custom-build.yml` against that
+exact candidate before signing. It never publishes automatically.
+
+`.github/workflows/publish-release.yml` separately approves existing draft bytes
+using the evidence SHA-256 from a successful preparation run. It rechecks the
+tag, signed inventory, previous stable catalog, and draft asset metadata without
+rebuilding or signing. Both workflows run from `main` and share concurrency.
+
+Preview/RC tags (`vX.Y.Z-preview.N`, `vX.Y.Z-rc.N`) remain prereleases and never
+become latest. Stable publication explicitly selects latest. All releases publish
+signed recovery assets; preview/RC entries stay out of the stable OTA catalog.
+
+Administrators must configure required reviewers and branch restrictions on the
+`firmware-release` environment; naming it in YAML alone does not enforce approval.
+See `docs/release-3.1.14-checklist.md` for operational and hardware sign-off.
 
 For OTA signing, manifests, compatibility, picker, and rollback invariants,
 also read `docs/AI_OTA_NOTES.md`.
@@ -89,8 +102,8 @@ Review `README.md` and related documentation when the release changes:
 - build, flashing, recovery, OTA, downgrade, or rollback;
 - required manual actions and known limitations.
 
-The workflow publishes generated GitHub notes after its checks. Ensure PR titles
-and user-facing documentation are accurate before dispatch.
+Preparation generates draft notes. Review them and the user-facing documentation
+before approving publication.
 
 Do not expose signing-key material or non-public credentials.
 
@@ -110,7 +123,8 @@ release still:
 - generates and verifies the new signed catalog;
 - uploads all required assets in the intended order;
 - downloads draft assets and verifies their signatures, manifest sizes/hashes, and agreement with build outputs, including all four USB ZIP images;
-- publishes only after asset and signature checks pass.
+- signs an inventory binding the candidate, repository, previous stable, preparation run, and all six release assets;
+- stops at a verified draft, then publishes only through separately approved evidence from a successful preparation run.
 
 Do not hand-edit generated manifests or signatures. Do not weaken HTTPS,
 signature, hash, size, schema, compatibility, or rollback checks.
@@ -134,6 +148,7 @@ python tools/test_release_workflow_contract.py
 python tools/test_generate_release_manifest.py
 python tools/test_release_catalog_download.py
 python tools/test_verify_release_assets.py
+python tools/test_release_publication.py
 python tools/test_pull_ota_contract.py
 python tools/test_ota_rollback_contract.py
 python tools/test_ota_public_key_header.py
@@ -180,15 +195,22 @@ Before tagging, confirm:
 Only after explicit authorization:
 
 1. Create and push the stable tag on the approved commit.
-2. Dispatch `Release firmware` with that exact tag.
-3. Inspect the complete workflow result and raw failures.
-4. Confirm the release points to the intended commit.
-5. Confirm the legacy ZIP, required OTA assets, and `dependencies.txt` are present.
-6. Confirm the release is neither draft nor prerelease.
-7. Check the manifest version, hardware, environment, partitions, assets, and
-   minimum supported source version.
-8. Verify installation through relevant user and OTA paths.
-9. Record limitations or rollback actions.
+2. Dispatch `Release firmware` from `main` with the tag, `expected_commit`, and
+   `previous_tag`. The expected baseline for 3.1.14 is `v3.1.13` while it remains
+   the most recently published stable release.
+3. Inspect the successful preparation run and record its evidence SHA-256.
+4. Confirm the draft contains the legacy ZIP, required OTA assets,
+   `dependencies.txt`, `release-evidence.json`, and `release-evidence.sig`.
+5. Test the exact final draft binaries by USB and record hardware sign-off.
+6. Dispatch `Publish firmware` from `main` with the same tag and commit and the
+   approved `evidence_sha256`. Approve the protected environment.
+7. Confirm stable/latest or preview/prerelease classification as appropriate.
+8. Check manifest compatibility and test the real production OTA path.
+9. Record results, limitations, and recovery actions.
+
+If preparation fails after creating a draft, leave it unpublished. Investigate
+before explicitly cleaning up that unpublished draft and rerunning preparation.
+Do not bypass the successful-run check with manual publication.
 
 Do not delete or replace published assets without evaluating signed catalog,
 downgrade, and rollback consequences.

--- a/docs/AI_RELEASE_NOTES.md
+++ b/docs/AI_RELEASE_NOTES.md
@@ -123,6 +123,8 @@ release still:
 - generates and verifies the new signed catalog;
 - uploads all required assets in the intended order;
 - downloads draft assets and verifies their signatures, manifest sizes/hashes, and agreement with build outputs, including all four USB ZIP images;
+- validates model/PCB, chip/environment, flash and partition contracts, canonical URLs, forward recovery, and a minimum source version that permits the previous stable before signing evidence;
+- uses `--verify-tag` for both draft creation and publication so missing remote tags are not implicitly recreated;
 - signs an inventory binding the candidate, repository, previous stable, preparation run, and all six release assets;
 - stops at a verified draft, then publishes only through separately approved evidence from a successful preparation run.
 

--- a/docs/release-3.1.14-checklist.md
+++ b/docs/release-3.1.14-checklist.md
@@ -1,0 +1,71 @@
+# 3.1.14 Release Checklist
+
+This is an operator checklist, not evidence that the checks have passed.
+Release preparation does not publish firmware or deploy the custom-build service.
+
+## Administrator Setup
+
+- Protect `main` with review and required CI, including `release-ready` and the
+  candidate minimal custom build. Review bypass permissions.
+- Restrict release-tag creation and prohibit replacement of published tags.
+- Configure required reviewers for `firmware-release`, restrict it to `main`,
+  and prevent self-approval where available. YAML alone does not configure this.
+- Confirm the official signing secret matches a committed public key and has an
+  offline backup. Record only its identifier, never private key material.
+- Review artifact retention. Keep official and custom recovery assets available.
+
+## Automated Preparation
+
+- Record the approved candidate SHA, previous stable tag, supported hardware,
+  optional-feature scope, and included changes.
+- Create the immutable release tag only after explicit release authorization.
+- Dispatch `Release firmware` from `main` with `tag`, `expected_commit`, and
+  `previous_tag`. Use `v3.1.13` for the 3.1.14 baseline while it is still the most
+  recently published stable release.
+- Verify the candidate's Python/Node contracts, native tests, standard and energy
+  firmware builds, and minimal custom firmware/filesystem build all succeed.
+  Existing workflows are reused; no additional eight-profile matrix runs on PRs.
+- Require successful previous-catalog downloads and signatures. A genuine empty
+  history needs explicit `bootstrap_catalog=true` and an empty `previous_tag`;
+  bootstrap never bypasses a failed download for an existing release.
+- Record the successful preparation run, attempt, candidate SHA, and evidence
+  SHA-256 shown after the uploaded draft has been downloaded and verified.
+- Check the draft contains the USB ZIP, firmware, LittleFS, dependency inventory,
+  manifest/signature, and evidence/signature. The ZIP has all four build images.
+
+## Hardware And Service Sign-Off
+
+- Test the exact final draft binaries by USB, recording their evidence digest.
+  Check calibration/tare, buttons, BLE, WiFi, sleep/wake, charging, settings
+  preservation, and each advertised optional feature on applicable hardware.
+- Exercise changed OTA/recovery paths, including interrupted firmware and
+  LittleFS writes, failed restore, minimal HTTP fallback, and menu repair.
+  Verify no boot loop, no falsely reported success, and preserved credentials.
+- Record the approved Worker, builder, and configurator/catalog revisions.
+  Deploy service support before firmware relies on new fields. This workflow
+  does not perform that deployment.
+- Verify pairing, assignment, install progress/failure/completion, already-installed
+  behavior, and service outages. Keep installed custom builds needed for recovery.
+- Treat an RC USB test as separate from the production 3.1.13-to-3.1.14 OTA path.
+  The unmodified stable picker cannot access an unpublished draft or an RC.
+
+## Publish And Verify
+
+- Review draft release notes and record hardware approval against the digest.
+- Dispatch `Publish firmware` from `main` with the same tag and candidate SHA,
+  plus the approved `evidence_sha256`. Approve its protected environment.
+- Publication verifies the signed inventory, successful preparation run,
+  unchanged tag, previous stable, and draft assets. It does not rebuild or sign.
+- Confirm stable 3.1.14 becomes latest. Preview/RC releases must remain prerelease
+  and must not replace latest.
+- Immediately test the actual 3.1.13-to-3.1.14 production OTA transition and
+  supported custom transitions. Record results and limitations.
+- Establish ownership for post-release failures and a tested withdrawal process.
+  Use a new version for corrected firmware rather than replacing published bytes.
+
+A failed preparation may leave a draft. Leave it unpublished, investigate, and
+explicitly review cleanup before retrying. Do not manually bypass its failed run.
+
+Development-version naming and OTA picker behavior are unchanged by these
+workflow changes. Ordinary local builds still use the source version; do not
+mistake a local build's displayed version for proof that it is an official release.

--- a/tools/release_publication.py
+++ b/tools/release_publication.py
@@ -1,0 +1,219 @@
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+
+from generate_release_manifest import RELEASE_VERSION_RE, STABLE_VERSION_RE, sign_manifest_from_environment, version_key
+from verify_release_assets import fileRecord, requireEqual, signedJson, verifyAssets
+
+
+ROOT = Path(__file__).resolve().parents[1]
+KEY_DIR = ROOT / "keys/ota"
+EVIDENCE_NAMES = ("release-evidence.json", "release-evidence.sig")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def run(command, cwd=ROOT):
+    return subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True,
+                          stdin=subprocess.DEVNULL, timeout=120).stdout.strip()
+
+
+def releaseNames(tag):
+    require(RELEASE_VERSION_RE.fullmatch(tag) is not None, "Invalid release tag")
+    return (f"HDS_FW_{tag}.zip", "firmware.bin", "littlefs.bin", "dependencies.txt", "manifest.json", "manifest.sig")
+
+
+def verifyCandidate(tag, commit):
+    releaseNames(tag)
+    require(re.fullmatch(r"[0-9a-f]{40}", commit) is not None, "Expected a full candidate SHA")
+    run(["git", "fetch", "--force", "origin", "main:refs/remotes/origin/main", f"refs/tags/{tag}:refs/tags/{tag}"])
+    actual = run(["git", "rev-parse", "--verify", "--end-of-options", f"refs/tags/{tag}^{{commit}}"])
+    requireEqual(actual, commit, "Tag does not match the approved commit")
+    run(["git", "merge-base", "--is-ancestor", commit, "origin/main"])
+
+
+def githubJson(repository, resource):
+    return json.loads(run(["gh", "api", f"repos/{repository}/{resource}"]))
+
+
+def latestStable(repository):
+    releases = json.loads(run(["gh", "release", "list", "--repo", repository,
+                               "--exclude-drafts", "--exclude-pre-releases", "--limit", "1", "--json", "tagName"]))
+    return releases[0]["tagName"] if releases else ""
+
+
+def downloadAssets(repository, tag, names, directory):
+    releaseNames(tag)
+    for attempt in range(3):
+        try:
+            with tempfile.TemporaryDirectory() as stagingDirectory:
+                staging = Path(stagingDirectory)
+                command = ["gh", "release", "download", tag, "--repo", repository, "--dir", str(staging)]
+                for name in names:
+                    command.extend(["--pattern", name])
+                run(command)
+                requireEqual(sorted(path.name for path in staging.iterdir()), sorted(names), "Incomplete asset download")
+                for name in names:
+                    require(fileRecord(staging / name)["size"] > 0, f"Empty asset: {name}")
+                directory.mkdir(parents=True, exist_ok=True)
+                for name in names:
+                    shutil.copyfile(staging / name, directory / name)
+            return
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError):
+            if attempt == 2:
+                raise
+            time.sleep(5)
+
+
+def previousCatalog(directory, tag):
+    if not tag:
+        return {}
+    require(STABLE_VERSION_RE.fullmatch(tag) is not None, "Previous tag must be stable")
+    previous = signedJson(directory / "manifest.json", directory / "manifest.sig", KEY_DIR)
+    requireEqual(previous.get("version"), tag.removeprefix("v"), "Wrong previous stable catalog")
+    entries = previous.get("releases", [previous])
+    require(isinstance(entries, list) and any(isinstance(entry, dict) and entry.get("version") == previous["version"]
+            for entry in entries), "Previous catalog omits its own release")
+    return previous
+
+
+def verifyPreviousVersion(tag, previousTag):
+    if previousTag:
+        require(version_key(tag.split("-", 1)[0]) > version_key(previousTag), "Candidate must be newer than previous stable")
+
+
+def inventory(directory, tag):
+    return {name: fileRecord(directory / name) for name in releaseNames(tag)}
+
+
+def prepareEvidence(args):
+    verifyCandidate(args.tag, args.commit)
+    requireEqual(run(["git", "rev-parse", "HEAD"]), args.commit, "Build checkout differs from candidate")
+    requireEqual(latestStable(args.repository), args.previous_tag, "Previous stable changed during preparation")
+    verifyPreviousVersion(args.tag, args.previous_tag)
+    previous = previousCatalog(args.previous_directory, args.previous_tag)
+    verifyAssets(args.directory, args.expected_dir, args.build_dir, KEY_DIR, args.tag, previous)
+    evidence = {
+        "schema": 1, "tag": args.tag, "commit": args.commit, "previous_tag": args.previous_tag,
+        "repository": args.repository, "artifacts": inventory(args.directory, args.tag),
+        "run_id": int(os.environ["GITHUB_RUN_ID"]), "run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+        "workflow_commit": os.environ["GITHUB_WORKFLOW_SHA"],
+    }
+    path = args.directory / EVIDENCE_NAMES[0]
+    path.write_text(json.dumps(evidence, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+    require(sign_manifest_from_environment(path, args.directory / EVIDENCE_NAMES[1]), "Missing signing key")
+    verifyEvidence(args.directory, args, fileRecord(path)["sha256"])
+
+
+def verifyEvidence(directory, args, digest):
+    require(re.fullmatch(r"[0-9a-f]{64}", digest) is not None, "Expected an approved SHA-256 digest")
+    path = directory / EVIDENCE_NAMES[0]
+    requireEqual(fileRecord(path)["sha256"], digest, "Approved evidence digest differs")
+    evidence = signedJson(path, directory / EVIDENCE_NAMES[1], KEY_DIR)
+    requireEqual((evidence.get("schema"), evidence.get("tag"), evidence.get("commit"), evidence.get("repository")),
+                 (1, args.tag, args.commit, args.repository), "Evidence identity differs")
+    requireEqual(evidence.get("artifacts"), inventory(directory, args.tag), "Assets differ from signed evidence")
+    for field in ("run_id", "run_attempt"):
+        require(type(evidence.get(field)) is int and evidence[field] > 0, "Invalid preparation run")
+    require(isinstance(evidence.get("workflow_commit"), str) and
+            re.fullmatch(r"[0-9a-f]{40}", evidence["workflow_commit"]) is not None, "Invalid workflow SHA")
+    previous = evidence.get("previous_tag")
+    require(isinstance(previous, str) and (not previous or STABLE_VERSION_RE.fullmatch(previous)), "Invalid previous tag")
+    return evidence
+
+
+def draftMetadata(args):
+    release = githubJson(args.repository, f"releases/tags/{args.tag}")
+    require(release.get("draft") is True, "Release is not a draft")
+    requireEqual(release.get("tag_name"), args.tag, "Draft tag differs")
+    require(release.get("prerelease") is ("-" in args.tag), "Draft classification differs")
+    requireEqual(sorted(asset["name"] for asset in release["assets"]),
+                 sorted((*releaseNames(args.tag), *EVIDENCE_NAMES)), "Draft asset set differs")
+    return release
+
+
+def assetSnapshot(release):
+    return sorted(tuple(asset.get(field) for field in ("name", "id", "size", "digest", "updated_at"))
+                  for asset in release["assets"])
+
+
+def validateRun(evidence, workflowRun):
+    expected = {
+        "id": evidence["run_id"], "run_attempt": evidence["run_attempt"],
+        "event": "workflow_dispatch", "head_branch": "main", "head_sha": evidence["workflow_commit"],
+        "path": ".github/workflows/release.yml", "status": "completed", "conclusion": "success",
+    }
+    require(all(workflowRun.get(key) == value for key, value in expected.items()), "Preparation run did not succeed for this evidence")
+
+
+def verifyDraft(args, publish=False):
+    verifyCandidate(args.tag, args.commit)
+    release = draftMetadata(args)
+    with tempfile.TemporaryDirectory() as temporaryDirectory:
+        directory = Path(temporaryDirectory)
+        downloadAssets(args.repository, args.tag, (*releaseNames(args.tag), *EVIDENCE_NAMES), directory)
+        digest = args.evidence_sha256 if publish else fileRecord(args.directory / EVIDENCE_NAMES[0])["sha256"]
+        evidence = verifyEvidence(directory, args, digest)
+        requireEqual(latestStable(args.repository), evidence["previous_tag"], "Previous stable changed")
+        verifyPreviousVersion(args.tag, evidence["previous_tag"])
+        previousDir = directory / "previous"
+        if evidence["previous_tag"]:
+            downloadAssets(args.repository, evidence["previous_tag"], ("manifest.json", "manifest.sig"), previousDir)
+        previous = previousCatalog(previousDir, evidence["previous_tag"])
+        verifyAssets(directory, None, None if publish else args.build_dir, KEY_DIR, args.tag, previous)
+        if not publish:
+            for name in (*releaseNames(args.tag), *EVIDENCE_NAMES):
+                requireEqual(fileRecord(directory / name), fileRecord(args.directory / name), f"Uploaded bytes differ: {name}")
+            summary = f"Verified draft {args.tag} at {args.commit}.\n\nEvidence SHA-256: `{digest}`\n\nTest these exact binaries, then approve a separate Publish firmware run.\n"
+            print(summary)
+            if os.environ.get("GITHUB_STEP_SUMMARY"):
+                with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+                    handle.write(summary)
+            return
+        workflowRun = githubJson(args.repository, f"actions/runs/{evidence['run_id']}")
+        validateRun(evidence, workflowRun)
+        verifyCandidate(args.tag, args.commit)
+        current = draftMetadata(args)
+        requireEqual(current["id"], release["id"], "Draft was replaced")
+        requireEqual(assetSnapshot(current), assetSnapshot(release), "Draft assets changed during verification")
+        requireEqual(latestStable(args.repository), evidence["previous_tag"], "Previous stable changed during verification")
+        run(["gh", "release", "edit", args.tag, "--repo", args.repository, "--draft=false",
+             "--latest=false" if "-" in args.tag else "--latest=true"])
+        print(f"Published verified release {args.tag} at {args.commit}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("candidate", "evidence", "verify-draft", "publish"))
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", "decentespresso/openscale"))
+    parser.add_argument("--previous-tag", default="")
+    parser.add_argument("--directory", type=Path, default=Path("downloaded-release"))
+    parser.add_argument("--expected-dir", type=Path, default=Path("release-files"))
+    parser.add_argument("--build-dir", type=Path, default=Path(".pio.nosync/build/esp32s3"))
+    parser.add_argument("--previous-directory", type=Path, default=Path("previous-release"))
+    parser.add_argument("--evidence-sha256", default="")
+    args = parser.parse_args()
+    releaseNames(args.tag)
+    require(re.fullmatch(r"[0-9a-f]{40}", args.commit) is not None, "Expected a full candidate SHA")
+    require(re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", args.repository) is not None, "Invalid repository")
+    if args.command == "candidate":
+        verifyCandidate(args.tag, args.commit)
+    elif args.command == "evidence":
+        prepareEvidence(args)
+    else:
+        verifyDraft(args, publish=args.command == "publish")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/release_publication.py
+++ b/tools/release_publication.py
@@ -101,7 +101,7 @@ def prepareEvidence(args):
     requireEqual(latestStable(args.repository), args.previous_tag, "Previous stable changed during preparation")
     verifyPreviousVersion(args.tag, args.previous_tag)
     previous = previousCatalog(args.previous_directory, args.previous_tag)
-    verifyAssets(args.directory, args.expected_dir, args.build_dir, KEY_DIR, args.tag, previous)
+    verifyAssets(args.directory, args.expected_dir, args.build_dir, KEY_DIR, args.tag, previous, args.repository)
     evidence = {
         "schema": 1, "tag": args.tag, "commit": args.commit, "previous_tag": args.previous_tag,
         "repository": args.repository, "artifacts": inventory(args.directory, args.tag),
@@ -169,7 +169,7 @@ def verifyDraft(args, publish=False):
         if evidence["previous_tag"]:
             downloadAssets(args.repository, evidence["previous_tag"], ("manifest.json", "manifest.sig"), previousDir)
         previous = previousCatalog(previousDir, evidence["previous_tag"])
-        verifyAssets(directory, None, None if publish else args.build_dir, KEY_DIR, args.tag, previous)
+        verifyAssets(directory, None, None if publish else args.build_dir, KEY_DIR, args.tag, previous, args.repository)
         if not publish:
             for name in (*releaseNames(args.tag), *EVIDENCE_NAMES):
                 requireEqual(fileRecord(directory / name), fileRecord(args.directory / name), f"Uploaded bytes differ: {name}")
@@ -186,7 +186,7 @@ def verifyDraft(args, publish=False):
         requireEqual(current["id"], release["id"], "Draft was replaced")
         requireEqual(assetSnapshot(current), assetSnapshot(release), "Draft assets changed during verification")
         requireEqual(latestStable(args.repository), evidence["previous_tag"], "Previous stable changed during verification")
-        run(["gh", "release", "edit", args.tag, "--repo", args.repository, "--draft=false",
+        run(["gh", "release", "edit", args.tag, "--repo", args.repository, "--verify-tag", "--draft=false",
              "--latest=false" if "-" in args.tag else "--latest=true"])
         print(f"Published verified release {args.tag} at {args.commit}")
 

--- a/tools/test_plugin_ci_contract.py
+++ b/tools/test_plugin_ci_contract.py
@@ -100,14 +100,19 @@ def main():
         {"plugin": "transitive", "firmware_ref": "v1.2.3"},
     ]
     compileCustom = customWorkflow.split("\n  compile_custom:\n", 1)[1].split("\n  build:\n", 1)[0]
-    assert compileCustom.lstrip().startswith("if: github.event_name == 'pull_request'")
+    assert compileCustom.lstrip().startswith("if: github.event_name != 'workflow_dispatch' || inputs.commit != ''")
     assert '"features": []' in compileCustom
     assert '"plugins": []' in compileCustom
-    assert '"firmware_ref": "v3.1.14"' in compileCustom
+    assert '"firmware_ref": "main"' in compileCustom
     assert "--config .pio.nosync/pr-ci.json" in compileCustom
     assert 'git tag v3.1.14 "${{ github.sha }}"' in verifyPlugins
     assert 'git tag v3.1.14 "${{ github.sha }}"' in compileCustom
-    assert "--source-commit \"$(git rev-parse --verify --end-of-options 'refs/tags/v3.1.14^{commit}')\"" in compileCustom
+    assert '--source-commit "$CANDIDATE_COMMIT"' in compileCustom
+    assert '--builder-commit "$CANDIDATE_COMMIT"' in compileCustom
+    assert 'ref: ${{ inputs.commit || github.sha }}' in compileCustom
+    assert 'CANDIDATE_COMMIT: ${{ inputs.commit || github.sha }}' in compileCustom
+    assert 'refs/tags/v3.1.14^{commit}' not in compileCustom
+    assert "if: github.event_name == 'workflow_dispatch' && inputs.commit == ''" in dispatchBuild
     with tempfile.TemporaryDirectory() as directory:
         subprocess.run(
             ["git", "clone", "--quiet", "--no-checkout", str(ROOT), directory],

--- a/tools/test_release_catalog_download.py
+++ b/tools/test_release_catalog_download.py
@@ -61,6 +61,7 @@ def main():
         ("both_fail", True, False, 3),
         ("invalid_signature", True, False, 2),
         ("list_failure", True, False, 0),
+        ("wrong_previous", False, False, 0),
     )
     with tempfile.TemporaryDirectory() as directory:
         base = Path(directory)
@@ -88,6 +89,7 @@ def main():
                 [BASH, "-c", script], cwd=case, capture_output=True, text=True,
                 env={**os.environ, "SCENARIO": scenario, "STABLE_TAG": "v3.1.13",
                      "BOOTSTRAP_CATALOG": str(bootstrap).lower(), "TAG": "v3.1.14",
+                     "EXPECTED_PREVIOUS_TAG": "" if scenario == "empty" else "v3.1.12" if scenario == "wrong_previous" else "v3.1.13",
                      "GITHUB_REPOSITORY": "decentespresso/openscale",
                      "TEST_PYTHON": Path(sys.executable).as_posix(),
                      "HDS_OTA_SIGNING_KEY_FILE": str(base / "private.pem")},

--- a/tools/test_release_publication.py
+++ b/tools/test_release_publication.py
@@ -1,0 +1,226 @@
+import copy
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+import zipfile
+
+from generate_release_manifest import build_catalog_manifest, build_manifest, sign_manifest, write_manifest
+import release_publication as release
+from verify_release_assets import fileRecord, verifyAssets
+
+
+class PublicationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.keys = tempfile.TemporaryDirectory()
+        cls.keyDir = Path(cls.keys.name)
+        cls.private = cls.keyDir / "private.pem"
+        subprocess.run(["openssl", "genpkey", "-algorithm", "RSA", "-pkeyopt", "rsa_keygen_bits:2048",
+                        "-out", str(cls.private)], check=True, capture_output=True)
+        public = cls.keyDir / "hds_ota_manifest_public_key_1.pem"
+        subprocess.run(["openssl", "pkey", "-in", str(cls.private), "-pubout", "-out", str(public)],
+                       check=True, capture_output=True)
+        for index in (2, 3):
+            shutil.copyfile(public, cls.keyDir / f"hds_ota_manifest_public_key_{index}.pem")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.keys.cleanup()
+
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name)
+        self.previousDir = self.directory / "previous"
+        self.previousDir.mkdir()
+        self.args = SimpleNamespace(tag="v3.1.14", commit="a" * 40, repository="decentespresso/openscale",
+                                    previous_tag="v3.1.13", directory=self.directory, expected_dir=self.directory,
+                                    build_dir=self.directory, previous_directory=self.previousDir, evidence_sha256="")
+        self.enterContext(patch.object(release, "KEY_DIR", self.keyDir))
+        self.enterContext(patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": "", "HDS_OTA_SIGNING_KEY_FILE": ""}))
+        self.createAssets()
+
+    def signJson(self, value, directory, name):
+        write_manifest(value, directory / f"{name}.json")
+        sign_manifest(directory / f"{name}.json", directory / f"{name}.sig", self.private)
+
+    def createAssets(self):
+        for name, data in (("firmware.bin", b"FW: " + self.args.tag.removeprefix("v").encode() + b"\0"),
+                           ("littlefs.bin", b"filesystem"), ("bootloader.bin", b"bootloader"),
+                           ("partitions.bin", b"partitions"), ("dependencies.txt", b"dependencies")):
+            (self.directory / name).write_bytes(data)
+        self.previous = build_manifest(self.directory, "v3.1.13", self.args.repository, "hds", "3.0.0")
+        self.signJson(self.previous, self.previousDir, "manifest")
+        self.manifest = build_catalog_manifest(
+            build_manifest(self.directory, self.args.tag, self.args.repository, "hds", "3.0.0"),
+            [self.previous], "v3.1.13")
+        self.signJson(self.manifest, self.directory, "manifest")
+        with zipfile.ZipFile(self.directory / f"HDS_FW_{self.args.tag}.zip", "w") as archive:
+            for name in ("firmware.bin", "bootloader.bin", "partitions.bin", "littlefs.bin"):
+                archive.write(self.directory / name, name)
+        self.evidence = {
+            "schema": 1, "tag": self.args.tag, "commit": self.args.commit, "repository": self.args.repository,
+            "previous_tag": "v3.1.13", "run_id": 123, "run_attempt": 1, "workflow_commit": "b" * 40,
+            "artifacts": release.inventory(self.directory, self.args.tag),
+        }
+        self.signEvidence()
+
+    def signEvidence(self):
+        self.signJson(self.evidence, self.directory, "release-evidence")
+        self.args.evidence_sha256 = fileRecord(self.directory / "release-evidence.json")["sha256"]
+
+    def testPreviousCatalogHasExpectedIdentity(self):
+        self.assertEqual(release.previousCatalog(self.previousDir, "v3.1.13"), self.previous)
+        with self.assertRaisesRegex(ValueError, "Wrong previous"):
+            release.previousCatalog(self.previousDir, "v3.1.12")
+        (self.previousDir / "manifest.sig").write_bytes(b"invalid")
+        with self.assertRaisesRegex(ValueError, "signature"):
+            release.previousCatalog(self.previousDir, "v3.1.13")
+
+    def testEntireCompatibleHistoryIsPreserved(self):
+        verifyAssets(self.directory, None, self.directory, self.keyDir, self.args.tag, self.previous)
+        self.assertEqual(self.manifest["releases"][1], self.previous)
+        for entries in (self.manifest["releases"][:1], [self.manifest["releases"][0], {**self.previous, "min_from": "3.1.0"}]):
+            self.signJson({**self.manifest, "releases": entries}, self.directory, "manifest")
+            with self.assertRaisesRegex(ValueError, "history"):
+                verifyAssets(self.directory, None, None, self.keyDir, self.args.tag, self.previous)
+
+    def testPreviousCatalogMustContainItsOwnRelease(self):
+        self.signJson({**self.previous, "releases": []}, self.previousDir, "manifest")
+        with self.assertRaisesRegex(ValueError, "omits its own"):
+            release.previousCatalog(self.previousDir, "v3.1.13")
+
+    def testCandidateCannotReplaceANewerOrEqualStable(self):
+        release.verifyPreviousVersion("v3.1.14", "v3.1.13")
+        release.verifyPreviousVersion("v3.1.14-rc.1", "v3.1.13")
+        release.verifyPreviousVersion("v3.1.14", "")
+        for tag in ("v3.1.12", "v3.1.13", "v3.1.13-rc.1"):
+            with self.subTest(tag=tag), self.assertRaisesRegex(ValueError, "newer"):
+                release.verifyPreviousVersion(tag, "v3.1.13")
+
+    def testEvidenceIdentityCannotBeSubstituted(self):
+        for field, value in (("tag", "v3.1.15"), ("commit", "c" * 40),
+                             ("repository", "other/repository"), ("schema", 2)):
+            with self.subTest(field=field):
+                self.createAssets()
+                self.evidence[field] = value
+                self.signEvidence()
+                with self.assertRaisesRegex(ValueError, "identity"):
+                    release.verifyEvidence(self.directory, self.args, self.args.evidence_sha256)
+
+    def testDownloadRetriesUseFreshCompletePairs(self):
+        for mode in ("both_fail", "missing_json", "missing_sig", "retry"):
+            with self.subTest(mode=mode):
+                attempts = []
+                def download(command):
+                    directory = Path(command[command.index("--dir") + 1])
+                    attempts.append(directory)
+                    if mode == "both_fail" or (mode == "retry" and len(attempts) == 1):
+                        raise subprocess.CalledProcessError(1, command)
+                    for name in ("manifest.json", "manifest.sig"):
+                        if mode != "missing_" + name.split(".")[1]:
+                            shutil.copyfile(self.previousDir / name, directory / name)
+                    return ""
+                with patch.object(release, "run", side_effect=download), patch.object(release.time, "sleep"):
+                    if mode == "retry":
+                        release.downloadAssets(self.args.repository, "v3.1.13", ("manifest.json", "manifest.sig"), self.directory / mode)
+                        self.assertEqual(len(attempts), 2)
+                    else:
+                        with self.assertRaises((ValueError, subprocess.CalledProcessError)):
+                            release.downloadAssets(self.args.repository, "v3.1.13", ("manifest.json", "manifest.sig"), self.directory / mode)
+                        self.assertEqual(len(attempts), 3)
+                self.assertEqual(len(set(attempts)), len(attempts))
+
+    def testCandidateRejectsMovedOrMalformedTags(self):
+        for tag, commit in (("--bad", self.args.commit), (self.args.tag, "main")):
+            with patch.object(release, "run") as command, self.assertRaises(ValueError):
+                release.verifyCandidate(tag, commit)
+            command.assert_not_called()
+        with patch.object(release, "run", side_effect=["", "c" * 40]), self.assertRaisesRegex(ValueError, "approved commit"):
+            release.verifyCandidate(self.args.tag, self.args.commit)
+
+    def testEvidencePreparationUsesVerifiedBuildAndRealSignature(self):
+        environment = {"HDS_OTA_SIGNING_KEY_PEM": self.private.read_text(), "GITHUB_RUN_ID": "123",
+                       "GITHUB_RUN_ATTEMPT": "1", "GITHUB_WORKFLOW_SHA": "b" * 40}
+        with patch.dict(os.environ, environment), patch.object(release, "verifyCandidate"), \
+             patch.object(release, "latestStable", return_value="v3.1.13"), \
+             patch.object(release, "run", return_value=self.args.commit):
+            release.prepareEvidence(self.args)
+        digest = fileRecord(self.directory / "release-evidence.json")["sha256"]
+        self.assertEqual(release.verifyEvidence(self.directory, self.args, digest), self.evidence)
+
+    def publicationHarness(self, mode="success", publish=True):
+        names = (*release.releaseNames(self.args.tag), *release.EVIDENCE_NAMES)
+        draft = {"id": 42, "draft": True, "prerelease": "-" in self.args.tag, "tag_name": self.args.tag,
+                 "assets": [{"id": index, "name": name, **fileRecord(self.directory / name)} for index, name in enumerate(names)]}
+        current = copy.deepcopy(draft)
+        if mode == "changed_assets":
+            current["assets"][0]["id"] += 100
+        if mode == "replaced_draft":
+            current["id"] += 1
+        if mode == "not_draft":
+            draft["draft"] = False
+        if mode == "extra_asset":
+            draft["assets"].append({"id": 99, "name": "unexpected"})
+        if mode == "bad_digest":
+            self.args.evidence_sha256 = "0" * 64
+        if mode == "bad_signature":
+            (self.directory / "release-evidence.sig").write_bytes(b"invalid")
+        workflowRun = {"id": 123, "run_attempt": 1, "event": "workflow_dispatch", "head_branch": "main",
+                       "head_sha": "b" * 40, "path": ".github/workflows/release.yml", "status": "completed", "conclusion": "success"}
+        for field in ("conclusion", "status", "head_sha", "path", "run_attempt"):
+            if mode == field:
+                workflowRun[field] = "wrong"
+        def download(repository, tag, requested, directory):
+            source = self.previousDir if tag == "v3.1.13" else self.directory
+            directory.mkdir(parents=True, exist_ok=True)
+            for name in requested:
+                shutil.copyfile(source / name, directory / name)
+            if mode in release.releaseNames(self.args.tag) and tag == self.args.tag:
+                (directory / mode).write_bytes(b"changed")
+        responses = [draft, workflowRun, current] if publish else [draft]
+        latest = ["v3.1.13", "v3.1.14" if mode == "changed_latest" else "v3.1.13"]
+        with patch.object(release, "verifyCandidate"), patch.object(release, "downloadAssets", side_effect=download), \
+             patch.object(release, "githubJson", side_effect=responses), patch.object(release, "latestStable", side_effect=latest), \
+             patch.object(release, "run") as command, patch.object(release, "sign_manifest_from_environment") as sign, \
+             contextlib.redirect_stdout(io.StringIO()):
+            if mode != "success":
+                with self.assertRaises(ValueError):
+                    release.verifyDraft(self.args, publish=publish)
+                command.assert_not_called()
+            else:
+                release.verifyDraft(self.args, publish=publish)
+                if publish:
+                    command.assert_called_once_with(["gh", "release", "edit", self.args.tag, "--repo", self.args.repository,
+                                                    "--draft=false", "--latest=false" if "-" in self.args.tag else "--latest=true"])
+                else:
+                    command.assert_not_called()
+            sign.assert_not_called()
+
+    def testPreparationNeverPublishes(self):
+        self.publicationHarness(publish=False)
+
+    def testPublishApprovesExistingBytesWithoutSigning(self):
+        self.publicationHarness()
+        self.args.tag = "v3.1.14-rc.1"
+        self.createAssets()
+        self.publicationHarness()
+
+    def testFailuresNeverPublish(self):
+        for mode in ("conclusion", "status", "head_sha", "path", "run_attempt", "bad_digest", "bad_signature",
+                     "changed_assets", "replaced_draft", "changed_latest", "not_draft", "extra_asset", *release.releaseNames(self.args.tag)):
+            with self.subTest(mode=mode):
+                self.createAssets()
+                self.publicationHarness(mode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_release_publication.py
+++ b/tools/test_release_publication.py
@@ -1,8 +1,10 @@
 import copy
 import contextlib
+import csv
 import io
 import json
 import os
+import re
 from pathlib import Path
 import shutil
 import subprocess
@@ -12,8 +14,9 @@ import unittest
 from unittest.mock import patch
 import zipfile
 
-from generate_release_manifest import build_catalog_manifest, build_manifest, sign_manifest, write_manifest
+from generate_release_manifest import DEFAULT_FS_PARTITION_SIZE, build_catalog_manifest, build_manifest, detect_pcb_version, sign_manifest, write_manifest
 import release_publication as release
+import generate_release_manifest as manifestTool
 from verify_release_assets import fileRecord, verifyAssets
 
 
@@ -54,13 +57,14 @@ class PublicationTests(unittest.TestCase):
 
     def createAssets(self):
         for name, data in (("firmware.bin", b"FW: " + self.args.tag.removeprefix("v").encode() + b"\0"),
-                           ("littlefs.bin", b"filesystem"), ("bootloader.bin", b"bootloader"),
+                           ("littlefs.bin", bytes(DEFAULT_FS_PARTITION_SIZE)), ("bootloader.bin", b"bootloader"),
                            ("partitions.bin", b"partitions"), ("dependencies.txt", b"dependencies")):
             (self.directory / name).write_bytes(data)
         self.previous = build_manifest(self.directory, "v3.1.13", self.args.repository, "hds", "3.0.0")
         self.signJson(self.previous, self.previousDir, "manifest")
         self.manifest = build_catalog_manifest(
-            build_manifest(self.directory, self.args.tag, self.args.repository, "hds", "3.0.0"),
+            build_manifest(self.directory, self.args.tag, self.args.repository, "hds", "3.0.0",
+                           pcb=detect_pcb_version(release.ROOT / "include/config.h"), forward_recovery=1),
             [self.previous], "v3.1.13")
         self.signJson(self.manifest, self.directory, "manifest")
         with zipfile.ZipFile(self.directory / f"HDS_FW_{self.args.tag}.zip", "w") as archive:
@@ -97,6 +101,61 @@ class PublicationTests(unittest.TestCase):
         self.signJson({**self.previous, "releases": []}, self.previousDir, "manifest")
         with self.assertRaisesRegex(ValueError, "omits its own"):
             release.previousCatalog(self.previousDir, "v3.1.13")
+
+    def testResignedIncompatibleManifestsAreRejectedBeforeEvidence(self):
+        changes = {
+            "model": "wrong", "pcb": "PCB: 7.2", "chip": "esp32", "environment": "wrong",
+            "partition_schema": "wrong", "flash_size": 16777216, "app_partition_min_size": 8388608,
+            "fs_partition_label": "wrong", "fs_partition_size": 1, "fs_schema": 2,
+            "min_from": "3.1.14", "forward_recovery": 0,
+            "release_notes_url": "https://example.invalid/notes",
+            "firmware.url": "https://github.com/decentespresso/openscale/releases/download/v3.1.13/firmware.bin",
+            "littlefs.url": "https://example.invalid/littlefs.bin",
+            "firmware.size": 8388608, "littlefs.size": 1,
+        }
+        original = copy.deepcopy(self.manifest)
+        for field, value in changes.items():
+            with self.subTest(field=field):
+                current = {key: copy.deepcopy(item) for key, item in original.items() if key != "releases"}
+                if "." in field:
+                    asset, key = field.split(".")
+                    current[asset][key] = value
+                else:
+                    current[field] = value
+                manifest = build_catalog_manifest(current, [self.previous], "v3.1.13")
+                self.signJson(manifest, self.directory, "manifest")
+                with patch.object(release, "verifyCandidate"), patch.object(release, "run", return_value=self.args.commit), \
+                     patch.object(release, "latestStable", return_value="v3.1.13"), \
+                     patch.object(release, "sign_manifest_from_environment") as sign:
+                    with self.assertRaises(ValueError):
+                        release.prepareEvidence(self.args)
+                    sign.assert_not_called()
+
+    def testReleaseDefaultsMatchFirmwareAndPartitionLayout(self):
+        source = (release.ROOT / "include/pull_ota.h").read_text(encoding="utf-8")
+        for name in ("CHIP", "ENVIRONMENT", "PARTITION_SCHEMA", "FLASH_SIZE", "APP_PARTITION_MIN_SIZE",
+                     "FS_PARTITION_LABEL", "FS_PARTITION_SIZE", "FS_SCHEMA"):
+            value = getattr(manifestTool, "DEFAULT_" + name)
+            literal = json.dumps(value)
+            self.assertRegex(source, rf'\bHDS_OTA_{name}\s*=\s*{re.escape(literal)};')
+        lines = (release.ROOT / "partitions/default_8MB.csv").read_text().splitlines()
+        rows = [tuple(field.strip() for field in row) for row in csv.reader(line for line in lines if not line.startswith("#"))]
+        self.assertEqual(min(int(row[4], 0) for row in rows if row[1] == "app"), manifestTool.DEFAULT_APP_PARTITION_MIN_SIZE)
+        filesystem = next(row for row in rows if row[0] == manifestTool.DEFAULT_FS_PARTITION_LABEL)
+        self.assertEqual(int(filesystem[4], 0), manifestTool.DEFAULT_FS_PARTITION_SIZE)
+        self.assertEqual(max(int(row[3], 0) + int(row[4], 0) for row in rows), manifestTool.DEFAULT_FLASH_SIZE)
+
+    def testMinimumSourceIncludesPreviousStable(self):
+        for minimum in ("", "3.0.0", "3.1.13", "3.1.14", "invalid", None):
+            with self.subTest(minimum=minimum):
+                current = {key: value for key, value in self.manifest.items() if key != "releases"}
+                current["min_from"] = minimum
+                self.signJson(build_catalog_manifest(current, [self.previous], "v3.1.13"), self.directory, "manifest")
+                if minimum in ("", "3.0.0", "3.1.13"):
+                    verifyAssets(self.directory, None, self.directory, self.keyDir, self.args.tag, self.previous)
+                else:
+                    with self.assertRaisesRegex(ValueError, "min_from"):
+                        verifyAssets(self.directory, None, None, self.keyDir, self.args.tag, self.previous)
 
     def testCandidateCannotReplaceANewerOrEqualStable(self):
         release.verifyPreviousVersion("v3.1.14", "v3.1.13")
@@ -200,7 +259,7 @@ class PublicationTests(unittest.TestCase):
                 release.verifyDraft(self.args, publish=publish)
                 if publish:
                     command.assert_called_once_with(["gh", "release", "edit", self.args.tag, "--repo", self.args.repository,
-                                                    "--draft=false", "--latest=false" if "-" in self.args.tag else "--latest=true"])
+                                                    "--verify-tag", "--draft=false", "--latest=false" if "-" in self.args.tag else "--latest=true"])
                 else:
                     command.assert_not_called()
             sign.assert_not_called()

--- a/tools/test_release_workflow_contract.py
+++ b/tools/test_release_workflow_contract.py
@@ -70,6 +70,7 @@ def main():
     assert_contains(text, 'grep -aFq "FW: $HDS_FIRMWARE_VERSION" .pio.nosync/build/esp32s3/firmware.bin')
     assert_contains(text, "python tools/generate_release_manifest.py --tag \"$TAG\" --output-dir release-files --catalog --catalog-min-version v3.1.13")
     assert_contains(text, "gh release create")
+    assert_contains(text.split('gh release create "$TAG"', 1)[1].split('gh release upload', 1)[0], '--verify-tag')
     assert_contains(text, "--draft")
     assert_contains(text, "gh release upload")
     assert_contains(text, "release-files/littlefs.bin")

--- a/tools/test_release_workflow_contract.py
+++ b/tools/test_release_workflow_contract.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import configparser
 import re
+import textwrap
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -77,11 +78,12 @@ def main():
     assert_contains(text, "verifyManifestSignature previous-release/manifest.json previous-release/manifest.sig")
     assert_contains(text, "release-files/dependencies.txt")
     assert_contains(text, "verifyManifestSignature release-files/manifest.json release-files/manifest.sig")
-    assert_contains(text, "gh release edit")
-    assert_contains(text, "--draft=false")
+    assert_not_contains(text, "gh release edit")
+    assert_not_contains(text, "--draft=false")
     assert_contains(text, 'gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir downloaded-release')
     assert_before(text, 'gh release upload "$TAG" release-files/manifest.json', 'python tools/verify_release_assets.py')
-    assert_before(text, 'python tools/verify_release_assets.py', 'gh release edit "$TAG" --draft=false')
+    assert_before(text, 'python tools/verify_release_assets.py', 'python tools/release_publication.py evidence')
+    assert_before(text, 'python tools/release_publication.py evidence', 'python tools/release_publication.py verify-draft')
     assert_before(text, "openssl dgst -sha256 -verify", "python tools/generate_release_manifest.py")
     assert_before(text, "tag $TAG predates the three-key OTA migration", "python tools/write_ota_public_key_header.py")
     assert_before(text, "tag $TAG predates the release version injection migration", "python tools/write_ota_public_key_header.py")
@@ -92,7 +94,35 @@ def main():
     assert_before(text, "python tools/generate_release_manifest.py", "verifyManifestSignature release-files/manifest.json")
     assert_before(text, "verifyManifestSignature release-files/manifest.json", "gh release create")
     assert_before(text, "release-files/manifest.sig", "release-files/manifest.json")
-    assert_before(text, "release-files/manifest.json", "gh release edit")
+    publish = (ROOT / ".github/workflows/publish-release.yml").read_text(encoding="utf-8")
+    assert_contains(text, 'needs: [resolve, preflight, custom-preflight]')
+    assert_contains(text, 'uses: ./.github/workflows/nightly.yml')
+    assert_contains(text, 'uses: ./.github/workflows/custom-build.yml')
+    assert text.count('commit: ${{ inputs.expected_commit }}') >= 2
+    assert_contains(text, 'test "$TAG_COMMIT" = "$EXPECTED_COMMIT"')
+    assert_contains(text, 'if [ "$PREVIOUS_TAG" != "$EXPECTED_PREVIOUS_TAG" ]')
+    for workflow in (text, publish):
+        for value in ('environment: firmware-release', 'group: firmware-release', 'cancel-in-progress: false',
+                      'test "$GITHUB_REF" = refs/heads/main', 'persist-credentials: false'):
+            assert_contains(workflow, value)
+    assert_contains(publish, 'python tools/release_publication.py publish')
+    assert_contains(publish, '--evidence-sha256 "$EVIDENCE_SHA256"')
+    assert_not_contains(publish, 'pio run')
+    assert_not_contains(publish, 'HDS_OTA_SIGNING_KEY_PEM')
+    assert_contains(nightly, 'workflow_call:')
+    assert nightly.count('ref: ${{ inputs.commit || github.sha }}') == 4
+    assert_contains(nightly, 'needs: [ai-documentation, native-tests, build, energy-build]')
+    assert_contains(nightly, 'if: always()')
+    assert_contains(nightly, 'node --test cloudflare/custom-build-worker/test/*.test.mjs')
+    gate = nightly.split('\n  release-ready:\n', 1)[1].split("python - <<'PY'\n", 1)[1]
+    gate = textwrap.dedent(gate.rsplit('\n          PY', 1)[0])
+    jobs = ('ai-documentation', 'native-tests', 'build', 'energy-build')
+    for changedJob in jobs:
+        for result in ('success', 'failure', 'cancelled', 'skipped'):
+            results = {job: {'result': result if job == changedJob else 'success'} for job in jobs}
+            checked = subprocess.run([sys.executable, '-c', gate], capture_output=True, text=True,
+                                     env={**os.environ, 'RESULTS': json.dumps(results)})
+            assert (checked.returncode == 0) == (result == 'success'), (changedJob, result, checked.stderr)
     assert_not_contains(text, "git rev-parse ${{ github.event.inputs.tag }}")
     assert_not_contains(text, "gh release create ${{ github.event.inputs.tag }}")
     assert_not_contains(text, '--tag "${{ github.event.inputs.tag }}"')

--- a/tools/test_verify_release_assets.py
+++ b/tools/test_verify_release_assets.py
@@ -7,7 +7,7 @@ import tempfile
 import textwrap
 import zipfile
 
-from generate_release_manifest import build_manifest, sign_manifest, write_manifest
+from generate_release_manifest import DEFAULT_FS_PARTITION_SIZE, build_manifest, detect_pcb_version, sign_manifest, write_manifest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -59,12 +59,17 @@ def main():
                 shutil.copyfile(public, case / f"keys/ota/hds_ota_manifest_public_key_{index}.pem")
             shutil.copyfile(ROOT / "tools/verify_release_assets.py", case / "tools/verify_release_assets.py")
             shutil.copyfile(ROOT / "tools/generate_release_manifest.py", case / "tools/generate_release_manifest.py")
+            (case / "include").mkdir()
+            for name in ("config.h", "pull_ota_version.h"):
+                shutil.copyfile(ROOT / "include" / name, case / "include" / name)
             for name in names:
                 (build / name).write_bytes(name.encode())
             tag = "v3.1.14-preview.4" if scenario == "preview" else "v3.1.14"
             version = tag.removeprefix("v") + ("-dev.abc" if scenario == "wrong_embedded_version" else "")
             (build / "firmware.bin").write_bytes(b"FW: " + version.encode() + b"\0")
-            manifest = build_manifest(build, tag, "decentespresso/openscale", "hds", "3.0.0")
+            (build / "littlefs.bin").write_bytes(bytes(DEFAULT_FS_PARTITION_SIZE))
+            manifest = build_manifest(build, tag, "decentespresso/openscale", "hds", "3.0.0",
+                                      pcb=detect_pcb_version(ROOT / "include/config.h"), forward_recovery=1)
             if scenario == "wrong_version":
                 manifest = {**manifest, "version": "3.1.13"}
             if scenario in ("wrong_size", "wrong_hash"):

--- a/tools/test_verify_release_assets.py
+++ b/tools/test_verify_release_assets.py
@@ -31,6 +31,7 @@ python() { "$TEST_PYTHON" "$@"; }
 def main():
     workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     publication = workflow.split('          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir downloaded-release', 1)[1]
+    publication = publication.split("\n      - name:", 1)[0]
     script = "set -euo pipefail\n" + MOCK + 'gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir downloaded-release\n' + textwrap.dedent(publication)
     names = ("firmware.bin", "bootloader.bin", "partitions.bin", "littlefs.bin")
     scenarios = (
@@ -39,6 +40,7 @@ def main():
         "firmware.bin", "littlefs.bin", "missing_firmware", "missing_signature",
         "missing_zip", "zip_firmware.bin", "zip_bootloader.bin", "zip_partitions.bin",
         "zip_littlefs.bin", "zip_missing", "zip_extra", "zip_invalid",
+        "wrong_embedded_version",
     )
     with tempfile.TemporaryDirectory() as directory:
         base = Path(directory)
@@ -56,9 +58,12 @@ def main():
             for index in range(1, 4):
                 shutil.copyfile(public, case / f"keys/ota/hds_ota_manifest_public_key_{index}.pem")
             shutil.copyfile(ROOT / "tools/verify_release_assets.py", case / "tools/verify_release_assets.py")
+            shutil.copyfile(ROOT / "tools/generate_release_manifest.py", case / "tools/generate_release_manifest.py")
             for name in names:
                 (build / name).write_bytes(name.encode())
             tag = "v3.1.14-preview.4" if scenario == "preview" else "v3.1.14"
+            version = tag.removeprefix("v") + ("-dev.abc" if scenario == "wrong_embedded_version" else "")
+            (build / "firmware.bin").write_bytes(b"FW: " + version.encode() + b"\0")
             manifest = build_manifest(build, tag, "decentespresso/openscale", "hds", "3.0.0")
             if scenario == "wrong_version":
                 manifest = {**manifest, "version": "3.1.13"}
@@ -102,7 +107,7 @@ def main():
             )
             success = scenario in ("success", "preview")
             assert (result.returncode == 0) == success, (scenario, result.stdout, result.stderr)
-            assert (case / "published").exists() == success, scenario
+            assert not (case / "published").exists(), scenario
     print("uploaded release asset verification tests passed")
 
 

--- a/tools/verify_release_assets.py
+++ b/tools/verify_release_assets.py
@@ -5,15 +5,15 @@ from pathlib import Path
 import subprocess
 import zipfile
 
+from generate_release_manifest import MAX_MANIFEST_BYTES, build_catalog_manifest
+
 
 def requireEqual(actual, expected, description):
     if actual != expected:
         raise ValueError(description)
 
 
-def verifyAssets(downloadDir, expectedDir, buildDir, keyDir, tag):
-    manifestPath = downloadDir / "manifest.json"
-    signaturePath = downloadDir / "manifest.sig"
+def verifySignature(manifestPath, signaturePath, keyDir):
     verified = any(
         subprocess.run(
             ["openssl", "dgst", "-sha256", "-verify", str(keyDir / f"hds_ota_manifest_public_key_{index}.pem"),
@@ -23,27 +23,70 @@ def verifyAssets(downloadDir, expectedDir, buildDir, keyDir, tag):
         for index in range(1, 4)
     )
     if not verified:
-        raise ValueError("Downloaded manifest signature is invalid")
-    for name in ("manifest.json", "manifest.sig", "dependencies.txt"):
-        requireEqual((downloadDir / name).read_bytes(), (expectedDir / name).read_bytes(),
-                     f"Downloaded {name} differs from prepared release")
-    manifest = json.loads(manifestPath.read_bytes())
+        raise ValueError(f"Downloaded signature is invalid: {manifestPath.name}")
+
+
+def signedJson(path, signaturePath, keyDir):
+    if not 0 < path.stat().st_size <= MAX_MANIFEST_BYTES:
+        raise ValueError("Signed JSON has invalid size")
+    verifySignature(path, signaturePath, keyDir)
+    value = json.loads(path.read_bytes())
+    if not isinstance(value, dict):
+        raise ValueError("Signed JSON must be an object")
+    return value
+
+
+def fileRecord(path):
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"Missing regular asset: {path.name}")
+    with path.open("rb") as handle:
+        digest = hashlib.file_digest(handle, "sha256").hexdigest()
+    return {"size": path.stat().st_size, "sha256": digest}
+
+
+def verifyCatalog(manifest, previous):
+    current = {key: value for key, value in manifest.items() if key != "releases"}
+    expected = build_catalog_manifest(current, [previous] if previous else [], "v3.1.13")
+    requireEqual(manifest.get("releases"), expected["releases"], "Signed catalog history changed")
+
+
+def verifyAssets(downloadDir, expectedDir, buildDir, keyDir, tag, previous=None):
+    manifest = signedJson(downloadDir / "manifest.json", downloadDir / "manifest.sig", keyDir)
+    if expectedDir is not None:
+        for name in ("manifest.json", "manifest.sig", "dependencies.txt"):
+            requireEqual((downloadDir / name).read_bytes(), (expectedDir / name).read_bytes(),
+                         f"Downloaded {name} differs from prepared release")
     requireEqual(manifest["version"], tag.removeprefix("v"), "Downloaded manifest has wrong version")
+    if previous is not None:
+        verifyCatalog(manifest, previous)
+    if manifest["littlefs"].get("required") is not True:
+        raise ValueError("LittleFS must remain required")
+    if (downloadDir / "dependencies.txt").stat().st_size == 0:
+        raise ValueError("Dependency inventory is empty")
     for asset in ("firmware", "littlefs"):
         name = f"{asset}.bin"
         data = (downloadDir / name).read_bytes()
         requireEqual(len(data), manifest[asset]["size"], f"Downloaded {name} has wrong size")
         requireEqual(hashlib.sha256(data).hexdigest(), manifest[asset]["sha256"],
                      f"Downloaded {name} has wrong SHA-256")
-        requireEqual(data, (buildDir / name).read_bytes(), f"Downloaded {name} differs from build")
+        if asset == "firmware" and b"FW: " + manifest["version"].encode("ascii") + b"\0" not in data:
+            raise ValueError("Firmware does not contain the exact release version")
+        if buildDir is not None:
+            requireEqual(data, (buildDir / name).read_bytes(), f"Downloaded {name} differs from build")
     with zipfile.ZipFile(downloadDir / f"HDS_FW_{tag}.zip") as archive:
         names = ("firmware.bin", "bootloader.bin", "partitions.bin", "littlefs.bin")
         requireEqual(sorted(archive.namelist()), sorted(names), "Downloaded ZIP has unexpected entries")
         for name in names:
             entry = archive.getinfo(name)
-            expected = (buildDir / name).read_bytes()
-            requireEqual(entry.file_size, len(expected), f"ZIP {name} has wrong size")
-            requireEqual(archive.read(entry), expected, f"ZIP {name} differs from build")
+            if not 0 < entry.file_size <= 8388608:
+                raise ValueError(f"ZIP {name} has invalid size")
+            data = archive.read(entry)
+            if name in ("firmware.bin", "littlefs.bin"):
+                requireEqual(data, (downloadDir / name).read_bytes(), f"ZIP {name} differs from OTA asset")
+            if buildDir is not None:
+                expected = (buildDir / name).read_bytes()
+                requireEqual(entry.file_size, len(expected), f"ZIP {name} has wrong size")
+                requireEqual(data, expected, f"ZIP {name} differs from build")
 
 
 def main():

--- a/tools/verify_release_assets.py
+++ b/tools/verify_release_assets.py
@@ -1,11 +1,16 @@
 import argparse
 import hashlib
 import json
+import os
 from pathlib import Path
 import subprocess
 import zipfile
 
 from generate_release_manifest import MAX_MANIFEST_BYTES, build_catalog_manifest
+import generate_release_manifest as releaseManifest
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def requireEqual(actual, expected, description):
@@ -50,13 +55,55 @@ def verifyCatalog(manifest, previous):
     requireEqual(manifest.get("releases"), expected["releases"], "Signed catalog history changed")
 
 
-def verifyAssets(downloadDir, expectedDir, buildDir, keyDir, tag, previous=None):
+def verifyCompatibility(manifest, tag, repository, previous):
+    configPath = ROOT / "include/config.h"
+    expected = {
+        "model": releaseManifest.DEFAULT_MODEL,
+        "pcb": releaseManifest.detect_pcb_version(configPath),
+        "chip": releaseManifest.DEFAULT_CHIP,
+        "environment": releaseManifest.DEFAULT_ENVIRONMENT,
+        "partition_schema": releaseManifest.DEFAULT_PARTITION_SCHEMA,
+        "flash_size": releaseManifest.DEFAULT_FLASH_SIZE,
+        "app_partition_min_size": releaseManifest.DEFAULT_APP_PARTITION_MIN_SIZE,
+        "fs_partition_label": releaseManifest.DEFAULT_FS_PARTITION_LABEL,
+        "fs_partition_size": releaseManifest.DEFAULT_FS_PARTITION_SIZE,
+        "fs_schema": releaseManifest.DEFAULT_FS_SCHEMA,
+        "forward_recovery": releaseManifest.forward_recovery_version(configPath),
+        "release_notes_url": releaseManifest.github_release_notes_url(repository, tag),
+    }
+    if not expected["pcb"] or expected["forward_recovery"] != 1:
+        raise ValueError("Release source lacks the expected PCB or forward recovery capability")
+    for field, value in expected.items():
+        if type(manifest.get(field)) is not type(value) or manifest[field] != value:
+            raise ValueError(f"Invalid OTA compatibility field: {field}")
+    minimum = manifest.get("min_from")
+    previousVersion = previous["version"] if previous else releaseManifest.DEFAULT_CATALOG_MIN_VERSION
+    if not isinstance(minimum, str) or (minimum and (
+            releaseManifest.STABLE_VERSION_RE.fullmatch(minimum) is None or
+            releaseManifest.version_key(minimum) > releaseManifest.version_key(previousVersion))):
+        raise ValueError("min_from excludes the supported previous stable release")
+    for asset in ("firmware", "littlefs"):
+        metadata = manifest.get(asset)
+        if not isinstance(metadata, dict):
+            raise ValueError(f"Missing OTA asset: {asset}")
+        requireEqual(metadata.get("url"), releaseManifest.github_release_download_url(repository, tag, f"{asset}.bin"),
+                     f"Invalid canonical OTA URL: {asset}")
+        if type(metadata.get("size")) is not int or metadata["size"] <= 0:
+            raise ValueError(f"Invalid OTA asset size: {asset}")
+    if manifest["firmware"]["size"] > expected["app_partition_min_size"]:
+        raise ValueError("Firmware exceeds the OTA app partition")
+    requireEqual(manifest["littlefs"]["size"], expected["fs_partition_size"], "LittleFS image does not fill its partition")
+
+
+def verifyAssets(downloadDir, expectedDir, buildDir, keyDir, tag, previous=None,
+                 repository=releaseManifest.DEFAULT_REPOSITORY):
     manifest = signedJson(downloadDir / "manifest.json", downloadDir / "manifest.sig", keyDir)
     if expectedDir is not None:
         for name in ("manifest.json", "manifest.sig", "dependencies.txt"):
             requireEqual((downloadDir / name).read_bytes(), (expectedDir / name).read_bytes(),
                          f"Downloaded {name} differs from prepared release")
     requireEqual(manifest["version"], tag.removeprefix("v"), "Downloaded manifest has wrong version")
+    verifyCompatibility(manifest, tag, repository, previous)
     if previous is not None:
         verifyCatalog(manifest, previous)
     if manifest["littlefs"].get("required") is not True:
@@ -96,8 +143,9 @@ def main():
     parser.add_argument("--expected-dir", type=Path, default=Path("release-files"))
     parser.add_argument("--build-dir", type=Path, default=Path(".pio.nosync/build/esp32s3"))
     parser.add_argument("--key-dir", type=Path, default=Path("keys/ota"))
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", releaseManifest.DEFAULT_REPOSITORY))
     args = parser.parse_args()
-    verifyAssets(args.download_dir, args.expected_dir, args.build_dir, args.key_dir, args.tag)
+    verifyAssets(args.download_dir, args.expected_dir, args.build_dir, args.key_dir, args.tag, repository=args.repository)
     print("Downloaded release assets verified")
 
 


### PR DESCRIPTION
## Summary

- Separate signed draft preparation from explicit publication. Publication approves the evidence SHA-256 and verifies the successful originating preparation run, exact candidate, signed asset inventory, previous stable, and unchanged draft assets without rebuilding or signing.
- Reuse existing Python/Node, native, standard/energy, and minimal custom CI against the exact candidate commit. Add an aggregate release-ready gate without introducing a duplicate eight-profile PR matrix.
- Fix minimal custom PR builds to pin both candidate source and builder instead of resolving the eventual v3.1.14 tag.
- Extend #198's existing verifier and preserve its executable failure scenarios. Check exact embedded firmware version, expected previous catalog identity, and compatible catalog history including 3.1.13.
- Add a 3.1.14 release checklist and update release documentation. Development version naming, OTA picker behavior, and runtime firmware are unchanged.

## Validation Completed Before Review Fixes (01c1c52)

- Python contract checks passed. The unchanged plugin catalog test initially lacked the prospective v3.1.14 fixture; it passed in an isolated local clone with that fixture, without creating a tag in the working repository or on GitHub.
- 44 Node tests passed.
- 78 native test cases passed.
- Release publication regression tests use real temporary RSA signatures and mocked GitHub calls; no release was created or published by tests.
- Actionlint passed for all four affected workflows.
- YAML parsing and bash syntax checks passed for 43 run blocks.
- git diff --check passed.

## Review Fixes (91c7748)

- Finding 1: validate the full OTA compatibility contract, previous-stable eligibility, canonical URLs, and image partition sizes before signing evidence and again before publication. Re-signed incompatible manifests are rejected by executable regression tests.
- Finding 4: require existing tags with --verify-tag during draft creation and publication.
- Focused publication, uploaded-asset, workflow, catalog-download, manifest-generator, and documentation tests passed locally; actionlint and git diff --check passed. New-head GitHub Actions validation is pending.

## Draft: Remaining Release Gates

- [x] GitHub Actions validation passed for 01c1c52: Python/Node contracts, native tests, standard firmware/filesystem, energy firmware, candidate minimal custom firmware/filesystem, and release-ready. [Build firmware run](https://github.com/decentespresso/openscale/actions/runs/34484943625); [custom build run](https://github.com/decentespresso/openscale/actions/runs/34484942735). OTA checks also passed.
- [ ] Hardware sign-off against the exact final draft binaries and evidence digest, including OTA and recovery paths.
- [ ] Administrator configuration: API audit confirmed firmware-release does not exist, main is unprotected, and no repository rulesets are configured. The current account has maintain=true and admin=false; a repository administrator must configure required reviewers, main-only environment restrictions, and branch/tag protection and required checks.
- [x] Deployment impact reviewed: this PR changes no Worker or catalog code and requires no production service deployment. The public configurator catalog matches the repository, and a status-only Worker request with that catalog revision returned HTTP 200 without queuing a build. Hardware service-flow verification remains part of final release sign-off.

This PR does not configure repository protections, change secrets, deploy services, create release tags, dispatch release workflows, or publish firmware. Environment declarations alone do not enable reviewer protection.