### PR TITLE
Enable Preview 4 in custom builds

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -234,7 +234,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Create prospective release tag for development validation
-        if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3'
+        if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3' || inputs.firmware_ref == 'v3.1.14-preview.4'
         run: |
           if ! git show-ref --verify --quiet refs/tags/v3.1.14; then
             git tag v3.1.14 "${{ github.sha }}"

--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -72,8 +72,9 @@ test("ships 3.1.14 compatibility while main remains the cutover default", async 
   const shipped = JSON.parse(await readFile(
     new URL("../../../docs/custom-build/catalog.json", import.meta.url), "utf8",
   ));
-  assert.deepEqual(shipped.firmware_refs, ["v3.1.14", "v3.1.14-preview.3", "main"]);
+  assert.deepEqual(shipped.firmware_refs, ["v3.1.14", "v3.1.14-preview.3", "v3.1.14-preview.4", "main"]);
   assert.equal(firmwareRefLabel(shipped.firmware_refs[1]), "3.1.14-preview.3 (preview)");
+  assert.equal(firmwareRefLabel(shipped.firmware_refs[2]), "3.1.14-preview.4 (preview)");
   assert.equal(firmwareRefLabel(defaultSelection(shipped).firmware_ref), "main (development)");
   assert.equal(firmwareRefLabel(shipped.firmware_refs[0]), "3.1.14 (stable)");
 });

--- a/cloudflare/custom-build-worker/wrangler.toml
+++ b/cloudflare/custom-build-worker/wrangler.toml
@@ -5,7 +5,7 @@ workers_dev = true
 
 [vars]
 ALLOWED_ORIGIN = "https://decentespresso.github.io"
-ALLOWED_FIRMWARE_REFS = "main,v3.1.14,v3.1.14-preview.3"
+ALLOWED_FIRMWARE_REFS = "main,v3.1.14,v3.1.14-preview.3,v3.1.14-preview.4"
 BUILDER_REF = "main"
 GITHUB_REPOSITORY = "decentespresso/openscale"
 GITHUB_WORKFLOW = "custom-build.yml"

--- a/docs/custom-build/catalog.json
+++ b/docs/custom-build/catalog.json
@@ -1,9 +1,10 @@
 {
-  "catalog_revision": "9c45e0a71081cb3c7cddbd8e579df671dccbb71492b657c48c15fd8fb830d04a",
+  "catalog_revision": "88803f7d532ac74d47624e2c5d6450c195ef5d742ec82abf4dc8153cd8ebad74",
   "custom_ota_signing_key_generation": 1,
   "firmware_refs": [
     "v3.1.14",
     "v3.1.14-preview.3",
+    "v3.1.14-preview.4",
     "main"
   ],
   "features": [
@@ -16,6 +17,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "default": true
@@ -31,6 +33,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "default": true
@@ -46,6 +49,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "default": true
@@ -62,6 +66,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "default": true
@@ -75,6 +80,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "default": true
@@ -91,6 +97,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "default": true
@@ -106,6 +113,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "default": true
@@ -122,6 +130,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "hidden": true
@@ -135,6 +144,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     }
@@ -149,6 +159,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "requires": [
@@ -173,6 +184,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "requires": [
@@ -201,6 +213,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "requires": [],

--- a/docs/custom-build/service-catalog.json
+++ b/docs/custom-build/service-catalog.json
@@ -1,10 +1,11 @@
 {
   "schema": 2,
   "custom_ota_signing_key_generation": 1,
-  "catalog_revision": "9c45e0a71081cb3c7cddbd8e579df671dccbb71492b657c48c15fd8fb830d04a",
+  "catalog_revision": "88803f7d532ac74d47624e2c5d6450c195ef5d742ec82abf4dc8153cd8ebad74",
   "firmware_refs": [
     "v3.1.14",
     "v3.1.14-preview.3",
+    "v3.1.14-preview.4",
     "main"
   ],
   "platformio_environment": "esp32s3-custom",
@@ -18,6 +19,13 @@
     },
     "v3.1.14-preview.3": {
       "custom_version": "3.1.14-preview.3-custom",
+      "partition_schema": {
+        "path": "partitions/default_8MB.csv",
+        "sha256": "ab2f33c14eb855054613fd3a4ba85457ae281c6f371c25931ccc763bc79cb0e2"
+      }
+    },
+    "v3.1.14-preview.4": {
+      "custom_version": "3.1.14-preview.4-custom",
       "partition_schema": {
         "path": "partitions/default_8MB.csv",
         "sha256": "ab2f33c14eb855054613fd3a4ba85457ae281c6f371c25931ccc763bc79cb0e2"
@@ -37,6 +45,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -47,6 +56,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -57,6 +67,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -68,6 +79,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -76,6 +88,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -87,6 +100,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -97,6 +111,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -108,6 +123,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     },
@@ -116,6 +132,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ]
     }
@@ -126,6 +143,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "requires": [
@@ -248,6 +266,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "requires": [
@@ -274,6 +293,7 @@
       "firmware_refs": [
         "v3.1.14",
         "v3.1.14-preview.3",
+        "v3.1.14-preview.4",
         "main"
       ],
       "requires": [],
@@ -294,6 +314,9 @@
           "sha256": "e873624cbdae73d844d6c77dcf4d03001e35c4406fbee3ae0b3cf8c5d6b0db6c"
         },
         "v3.1.14-preview.3": {
+          "sha256": "e873624cbdae73d844d6c77dcf4d03001e35c4406fbee3ae0b3cf8c5d6b0db6c"
+        },
+        "v3.1.14-preview.4": {
           "sha256": "e873624cbdae73d844d6c77dcf4d03001e35c4406fbee3ae0b3cf8c5d6b0db6c"
         }
       },

--- a/plugins/default-web-apps/plugin.json
+++ b/plugins/default-web-apps/plugin.json
@@ -5,7 +5,7 @@
   "description": "Install the bundled on-device dashboard and scale tools.",
   "tooltip": "Adds the dashboard, Weigh Save, Dosing Assistant, and Quality Control Assistant. LittleFS, WebSocket, the web server, and WiFi are included automatically.",
   "version": "1.0.0",
-  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "main"],
+  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "v3.1.14-preview.4", "main"],
   "requires": ["littlefs", "websocket"],
   "depends_on": [],
   "conflicts": [],

--- a/plugins/grind-by-weight/plugin.json
+++ b/plugins/grind-by-weight/plugin.json
@@ -5,7 +5,7 @@
   "description": "Stop a supported grinder automatically at the target dose.",
   "tooltip": "Enables the built-in grind-by-weight integration. Its recommended setup also selects Wifi Pull OTA and the default web apps.",
   "version": "1.0.0",
-  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "main"],
+  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "v3.1.14-preview.4", "main"],
   "requires": ["grinder"],
   "depends_on": [],
   "conflicts": ["pressensor"],

--- a/plugins/pressensor/plugin.json
+++ b/plugins/pressensor/plugin.json
@@ -5,11 +5,12 @@
   "description": "Show Pressensor pressure, weight, flow, and shot time on the scale.",
   "tooltip": "Connects to a selected Pressensor over BLE and adds pressure-aware shot timing without requiring WiFi or runtime LittleFS.",
   "version": "1.0.0",
-  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "main"],
+  "firmware_refs": ["v3.1.14", "v3.1.14-preview.3", "v3.1.14-preview.4", "main"],
   "requires": [],
   "conflicts": ["grind-by-weight"],
   "patches": {
     "v3.1.14-preview.3": "patches/main.patch",
+    "v3.1.14-preview.4": "patches/main.patch",
     "v3.1.14": "patches/main.patch",
     "main": "patches/main.patch"
   },

--- a/tools/configure_custom_build.py
+++ b/tools/configure_custom_build.py
@@ -18,7 +18,7 @@ DEFAULT_FIRMWARE_VERSION_PATTERN = re.compile(
     r'^\s*#define\s+HDS_FIRMWARE_VERSION\s+"([0-9]+\.[0-9]+\.[0-9]+(?:-[a-z0-9]+(?:[.-][a-z0-9]+)*)?)"\s*$',
     re.MULTILINE,
 )
-FIRMWARE_REFS = ("v3.1.14", "v3.1.14-preview.3", "main")
+FIRMWARE_REFS = ("v3.1.14", "v3.1.14-preview.3", "v3.1.14-preview.4", "main")
 FEATURES = {
     "wifi": ("HDS_FEATURE_WIFI", (), FIRMWARE_REFS),
     "mdns": ("HDS_FEATURE_MDNS", ("wifi",), FIRMWARE_REFS),

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -237,7 +237,7 @@ def main():
     assert pageCatalog["catalog_revision"] == serviceCatalog["catalog_revision"]
     assert len(pageCatalog["catalog_revision"]) == 64
     assert generatedCatalog["firmware_refs"] == list(customBuild.FIRMWARE_REFS)
-    assert customBuild.FIRMWARE_REFS == ("v3.1.14", "v3.1.14-preview.3", "main")
+    assert customBuild.FIRMWARE_REFS == ("v3.1.14", "v3.1.14-preview.3", "v3.1.14-preview.4", "main")
     assert pageCatalog["custom_ota_signing_key_generation"] == 1
     assert serviceCatalog["custom_ota_signing_key_generation"] == 1
     assert all(
@@ -305,6 +305,8 @@ def main():
         "v3.1.14-preview.3", '#define HDS_FIRMWARE_VERSION "3.1.14"'
     ) == "3.1.14-preview.3-custom"
     assert serviceCatalog["firmware"]["v3.1.14-preview.3"]["custom_version"] == "3.1.14-preview.3-custom"
+    assert customBuild.customFirmwareVersion("v3.1.14-preview.4", "") == "3.1.14-preview.4-custom"
+    assert serviceCatalog["firmware"]["v3.1.14-preview.4"]["custom_version"] == "3.1.14-preview.4-custom"
     assert customBuild.customFirmwareVersion(
         "main", '#define HDS_FIRMWARE_VERSION "3.1.14"'
     ) == "3.1.14-custom"

--- a/tools/test_plugin_ci_contract.py
+++ b/tools/test_plugin_ci_contract.py
@@ -51,7 +51,7 @@ def main():
     assert "compile-matrix:" not in customWorkflow
     dispatchBuild = customWorkflow.split("\n  build:\n", 1)[1]
     assert dispatchBuild.lstrip().startswith("if: github.event_name == 'workflow_dispatch'")
-    assert "if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3'" in dispatchBuild
+    assert "if: inputs.firmware_ref == 'main' || inputs.firmware_ref == 'v3.1.14-preview.3' || inputs.firmware_ref == 'v3.1.14-preview.4'" in dispatchBuild
     assert 'git tag v3.1.14 "${{ github.sha }}"' in dispatchBuild
 
     assert "dependency-build:" not in otaWorkflow
@@ -64,9 +64,10 @@ def main():
     assert manifest["patches"] == {
         "v3.1.14": "patches/main.patch",
         "v3.1.14-preview.3": "patches/main.patch",
+        "v3.1.14-preview.4": "patches/main.patch",
         "main": "patches/main.patch",
     }
-    assert workerConfig["vars"]["ALLOWED_FIRMWARE_REFS"] == "main,v3.1.14,v3.1.14-preview.3"
+    assert workerConfig["vars"]["ALLOWED_FIRMWARE_REFS"] == "main,v3.1.14,v3.1.14-preview.3,v3.1.14-preview.4"
     assert workerConfig["vars"]["BUILDER_REF"] == "main"
     assert changedPlugins.changedPluginIds([
         "plugins/pressensor/plugin.json",
@@ -79,6 +80,7 @@ def main():
         {"plugin": "pressensor", "firmware_ref": "main"},
         {"plugin": "pressensor", "firmware_ref": "v3.1.14"},
         {"plugin": "pressensor", "firmware_ref": "v3.1.14-preview.3"},
+        {"plugin": "pressensor", "firmware_ref": "v3.1.14-preview.4"},
     ]
     assert changedPlugins.changedPluginMatrix([
         "plugins/default-web-apps/assets/index.html"


### PR DESCRIPTION
## Summary

- Add published v3.1.14-preview.4 to the custom-build version list, all existing plugin approvals, and the Worker allowlist. Preserve preview.3 and the current default.
- Regenerate browser and service catalogs with the same revision and exact preview.4-custom identity.
- Enable the existing prospective-stable test fixture for preview.4 dispatches, so contract validation does not require the unpublished stable tag.

## Validation

- Plugin catalog, custom-build execution, and plugin CI contracts passed locally. The prospective stable tag exists only in an isolated test clone, not the release repository or GitHub.
- All 43 Node configurator, Worker, fleet, and retention tests passed.
- Pressensor patch passes strict git apply checking against the exact published preview.4 commit.
- Actionlint and git diff --check passed.
- CI validates the changed patch-plugin mappings, including preview.4.

## Deployment

Deploy the overlapping Worker allowlist, merge the catalogs into the trusted builder branch, and verify the published Pages catalog and a status-only preview.4 request. No release assets or tags are changed.