### PR TITLE
Allow saving builds before pairing a scale

### DIFF
--- a/cloudflare/custom-build-worker/src/fleet.mjs
+++ b/cloudflare/custom-build-worker/src/fleet.mjs
@@ -411,10 +411,10 @@ async function addBuild(request, storage, env) {
   const ownerFleetId = await fleetId(request);
   const body = requireObject(await readJson(request), ["combination_hash"]);
   const key = `fleet:${ownerFleetId}`;
-  if (!(await storage.get(key))) throw new FleetError(404, "fleet_not_found");
   const reference = await readyBuildReference(env, body.combination_hash);
   return storage.transaction(async transaction => {
     const fleet = await transaction.get(key);
+    if (!fleet) await enforcePairCreationRate(request, transaction, Date.now());
     const builds = fleetBuilds(fleet);
     const existing = builds.find(build => build.combination_hash === reference.combination_hash);
     if (existing) return {...existing, state: "ready"};

--- a/cloudflare/custom-build-worker/src/worker.mjs
+++ b/cloudflare/custom-build-worker/src/worker.mjs
@@ -561,7 +561,8 @@ async function fleetApi(request, env) {
   const response = await fleetCoordinatorResponse(
     request,
     env,
-    ["/api/v1/device/pair", "/api/v1/fleet/claim"].includes(url.pathname)
+    (["/api/v1/device/pair", "/api/v1/fleet/claim"].includes(url.pathname) ||
+      url.pathname === "/api/v1/fleet/builds" && request.method === "POST")
       ? await clientKey(request, env) : null,
   );
   const result = await response.json();

--- a/cloudflare/custom-build-worker/test/configurator.test.mjs
+++ b/cloudflare/custom-build-worker/test/configurator.test.mjs
@@ -314,6 +314,56 @@ test("fleet assignment uses only the explicit scale selection", async () => {
   assert.ok(source.includes("{device_ids: [...selectedDeviceIds]}"));
 });
 
+test("ready builds save without paired scales and require durable recovery access", async () => {
+  const source = await readFile(new URL("../../../docs/custom-build/fleet.js", import.meta.url), "utf8");
+  const handler = source.slice(source.indexOf('addBuild.addEventListener("click"'), source.indexOf('selectAll.addEventListener("change"'));
+  assert.ok(source.includes("addBuild.disabled = !readyHash || savingBuild"));
+  assert.equal(source.includes("Link a scale first"), false);
+  for (const mode of ["new", "existing", "storage-blocked", "request-failed", "not-ready"]) {
+    const requests = [];
+    const errors = [];
+    const context = {
+      fleetKey: mode === "existing" ? "existing-key" : "",
+      scales: [], builds: [], savingBuild: false,
+      getReadyHash: () => mode === "not-ready" ? "" : "a".repeat(64),
+      crypto: {getRandomValues: value => value.fill(1)},
+      encodeBase32: () => "new-key",
+      activateKey: key => {
+        if (mode === "storage-blocked") return false;
+        context.fleetKey = key;
+        return true;
+      },
+      addBuild: {addEventListener: (event, listener) => { context.click = listener; }},
+      api: async (path, options) => {
+        requests.push({path, key: context.fleetKey, body: JSON.parse(options.body)});
+        if (mode === "request-failed") throw new Error("offline");
+      },
+      renderControls: () => {}, showToast: () => {}, showApiError: error => errors.push(error),
+      loadFleet: async () => true,
+      buildSelect: {focus: () => {}},
+      document: {querySelector: () => ({scrollIntoView: () => {}})},
+      matchMedia: () => ({matches: true}),
+    };
+    runInNewContext(handler, context);
+    await context.click();
+    assert.equal(context.savingBuild, false);
+    assert.equal(requests.length, ["storage-blocked", "not-ready"].includes(mode) ? 0 : 1);
+    if (requests.length) {
+      assert.equal(requests[0].path, "/api/v1/fleet/builds");
+      assert.equal(requests[0].key, mode === "existing" ? "existing-key" : "new-key");
+      assert.equal(requests[0].body.combination_hash, "a".repeat(64));
+    }
+    assert.equal(errors.length, mode === "request-failed" ? 1 : 0);
+  }
+  const activate = source.slice(source.indexOf("const activateKey ="), source.indexOf('document.querySelector("#start-fleet")'));
+  const context = {
+    fleetKey: "", normalizedFleetKey: key => key, fleetPattern: /^[A-Z2-7]{32}$/,
+    saveKey: () => false, showToast: () => {}, setMode: () => {}, setSettingsOpen: () => {}, loadFleet: () => {},
+  };
+  assert.equal(runInNewContext(activate + 'activateKey("A".repeat(32))', context), false);
+  assert.equal(context.fleetKey, "");
+});
+
 
 test("theme follows the system until a saved preference overrides it", async () => {
   const html = await readFile(new URL("../../../docs/custom-build/index.html", import.meta.url), "utf8");

--- a/cloudflare/custom-build-worker/test/fleet.test.mjs
+++ b/cloudflare/custom-build-worker/test/fleet.test.mjs
@@ -370,6 +370,50 @@ test("device check-in reports authoritative installed state without changing des
   assert.equal(scale.firmware_version, "3.1.15-custom");
 });
 
+test("saves builds before pairing and preserves them when the first scale is linked", async () => {
+  const {env, storage} = environment();
+  const save = authorization => request(env, "/api/v1/fleet/builds", {
+    method: "POST", body: {combination_hash: combinationHash}, authorization, browser: true,
+  });
+  assert.equal((await save("invalid")).status, 401);
+  assert.equal((await save(fleetSecret)).status, 409);
+  assert.equal([...storage.values.keys()].some(key => key.startsWith("fleet:")), false);
+  await readyBuild(env, combinationHash);
+  assert.equal((await save(fleetSecret)).status, 200);
+  assert.equal((await save(fleetSecret)).status, 200);
+  const overview = async authorization => (await request(env, "/api/v1/fleet/overview", {
+    authorization, browser: true,
+  })).json();
+  const beforePairing = await overview(fleetSecret);
+  assert.deepEqual(beforePairing.scales, []);
+  assert.equal(beforePairing.builds.length, 1);
+  assert.equal(beforePairing.builds[0].combination_hash, combinationHash);
+  assert.equal(beforePairing.builds[0].state, "ready");
+  assert.deepEqual((await overview(secondFleetSecret)).builds, []);
+  await linkScale(env, {
+    selectedDeviceId: deviceId, authorization: deviceSecret, pairCode: "A3F921-100009",
+  });
+  const afterPairing = await overview(fleetSecret);
+  assert.deepEqual(afterPairing.builds, beforePairing.builds);
+  assert.equal(afterPairing.scales.length, 1);
+  assert.equal(afterPairing.scales[0].desired_combination, null);
+});
+
+test("new build libraries share the bounded pairing creation quota", async () => {
+  const {env} = environment();
+  await readyBuild(env, combinationHash);
+  const save = authorization => request(env, "/api/v1/fleet/builds", {
+    method: "POST", body: {combination_hash: combinationHash}, authorization, browser: true,
+  });
+  for (let index = 0; index < pairCreationsPerClient; index++) {
+    assert.equal((await save("A".repeat(31) + String.fromCharCode(65 + index))).status, 200);
+  }
+  const limited = await save("Z".repeat(32));
+  assert.equal(limited.status, 429);
+  assert.ok(Number(limited.headers.get("Retry-After")) > 0);
+  assert.equal((await save(fleetSecret)).status, 200);
+});
+
 test("fleet build library stores references without owning artifacts", async () => {
   const {env, storage} = environment();
   await readyBuild(env, combinationHash);

--- a/docs/custom-build/app.js
+++ b/docs/custom-build/app.js
@@ -8,7 +8,7 @@ import {
   resolveSelection,
   selectionQuery,
 } from "./selection.mjs?v=5";
-import {initFleet} from "./fleet.js?v=13";
+import {initFleet} from "./fleet.js?v=14";
 import {buildEstimate} from "./build-estimate.mjs?v=1";
 import {initBuildProgress} from "./build-progress.mjs?v=1";
 

--- a/docs/custom-build/fleet.js
+++ b/docs/custom-build/fleet.js
@@ -180,9 +180,8 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
     const readyHash = getReadyHash();
     const alreadyAdded = builds.some(build => build.combination_hash === readyHash);
     addBuild.hidden = !readyHash;
-    addBuild.disabled = !scales.length || !readyHash || savingBuild;
+    addBuild.disabled = !readyHash || savingBuild;
     addBuild.textContent = savingBuild ? "Saving..." : alreadyAdded ? "My scales" : "Save build";
-    addBuild.title = !scales.length ? "Link a scale first" : "";
   };
 
   const editingFleet = () => Boolean(consoleRoot.querySelector("input:not([type=checkbox]):focus, select:focus")) ||
@@ -382,15 +381,16 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   };
 
   const activateKey = key => {
-    fleetKey = normalizedFleetKey(key);
-    if (!fleetPattern.test(fleetKey)) {
+    const candidateKey = normalizedFleetKey(key);
+    if (!fleetPattern.test(candidateKey)) {
       showToast("Enter a valid recovery key");
       return false;
     }
-    if (!saveKey(fleetKey)) {
+    if (!saveKey(candidateKey)) {
       showToast("Scale access could not be saved. Allow browser storage and try again.");
       return false;
     }
+    fleetKey = candidateKey;
     setMode(true);
     setSettingsOpen(false);
     loadFleet();
@@ -451,7 +451,8 @@ export function initFleet({apiBase, getReadyHash, showToast}) {
   });
   addBuild.addEventListener("click", async () => {
     const combinationHash = getReadyHash();
-    if (!combinationHash || !scales.length || savingBuild) return;
+    if (!combinationHash || savingBuild) return;
+    if (!fleetKey && !activateKey(encodeBase32(crypto.getRandomValues(new Uint8Array(20))))) return;
     const showScales = () => {
       buildSelect.value = combinationHash;
       document.querySelector(".fleet-scales-section").scrollIntoView({

--- a/docs/custom-build/index.html
+++ b/docs/custom-build/index.html
@@ -309,7 +309,7 @@
     </form>
   </dialog>
 
-  <script type="module" src="app.js?v=30"></script>
+  <script type="module" src="app.js?v=31"></script>
   <script type="module" src="wizard.js?v=2"></script>
 </body>
 </html>

--- a/docs/custom-build/operations.md
+++ b/docs/custom-build/operations.md
@@ -22,9 +22,9 @@ The Worker stores SHA-256 hashes of fleet and device secrets, never their raw va
 recovery key as a bearer credential. A scale's `device_secret` stays in the `ota_custom` NVS
 namespace and must never be displayed or logged.
 
-The browser keeps the fleet recovery key only in tab-scoped session storage. It removes the legacy
-persistent copy when the configurator next opens. Move the configurator to a dedicated origin before
-making recovery keys persistent again.
+The browser keeps the fleet recovery key in local storage and migrates older session-only keys
+after persistence succeeds. Treat scripts on the shared origin as trusted with this credential.
+Saving a first build stops if the browser cannot persist the newly generated key.
 
 ## Fleet Data Model
 
@@ -33,6 +33,9 @@ contains device IDs and immutable build references. Each build reference contain
 `combination_hash`, a user-editable label, firmware version, feature and plugin identifiers, and the
 time it was added. The binaries remain in R2 under `v1/<combination-hash>/`; adding or removing a
 fleet reference never copies or deletes those objects.
+
+A ready build can create the library before any scale is paired. New libraries share the bounded
+pairing-creation quota. Pairing later preserves saved builds and does not automatically assign one.
 
 Device records distinguish these fields:
 

--- a/tools/test_plugin_catalog.py
+++ b/tools/test_plugin_catalog.py
@@ -254,7 +254,7 @@ def main():
     indexPage = (pageRoot / "index.html").read_text(encoding="utf-8")
     appScript = (pageRoot / "app.js").read_text(encoding="utf-8")
     fleetScript = (pageRoot / "fleet.js").read_text(encoding="utf-8")
-    assert 'type="module" src="app.js?v=30"' in indexPage
+    assert 'type="module" src="app.js?v=31"' in indexPage
     assert 'href="styles.css?v=18"' in indexPage
     assert 'href="fleet.css?v=7"' in indexPage
     assert 'id="request-build"' in indexPage
@@ -271,7 +271,7 @@ def main():
     assert "firmwareRefLabel(ref)" in appScript
     assert "firmwareRefLabel(selected.firmware_ref)" in appScript
     assert 'selection.mjs?v=5' in appScript
-    assert 'fleet.js?v=13' in appScript
+    assert 'fleet.js?v=14' in appScript
     assert 'fleetPanel.hidden = installMethod !== "wifi"' in appScript
     assert "sessionStorage.setItem(storageKey" not in fleetScript
     assert "localStorage.setItem(storageKey" in fleetScript


### PR DESCRIPTION
## Summary

- Allow the wizard's Save build action before pairing a scale. Generate and persist a recovery key on first save, then use the normal fleet library API.
- Create the library transactionally only for a verified ready build. Preserve saved builds when the first scale is paired; never assign or install automatically.
- Reuse the existing bounded pairing-creation quota for new libraries and forward the edge-derived client key. Keep existing-library saves independent of the creation quota.
- Do not activate a new recovery key if local persistence fails; update browser cache versions and the operations notes.

## Validation

- All 46 Node configurator, fleet, Worker, polling, and retention tests passed.
- New browser-handler coverage: no scales, new/existing key, blocked storage, failed request, and build not ready.
- New API coverage: save before pairing, duplicate save, fleet isolation, preservation after pairing, no automatic assignment, missing-build rejection, and creation rate limiting.
- Plugin catalog and AI documentation contracts passed; JavaScript syntax and git diff --check passed.

Deploy the Worker before the new browser assets. This change does not modify firmware or release assets.